### PR TITLE
Fix test_automation_result.json undefined status causing toUpperCase crash

### DIFF
--- a/js/postTestReworkResults.js
+++ b/js/postTestReworkResults.js
@@ -252,16 +252,23 @@ function action(params) {
 
         // Step 1: Read new test result
         const result = readResultJson();
-        if (!result) {
-            jira_post_comment({
-                key: ticketKey,
-                comment: 'h3. ⚠️ Rework Error\n\nCould not read test_automation_result.json. Check logs.'
-            });
+        if (!result || !result.status) {
+            const errMsg = !result
+                ? 'Could not read outputs/test_automation_result.json — file missing or empty.'
+                : 'outputs/test_automation_result.json is missing required "status" field (got: ' + JSON.stringify(result) + '). The agent must write { "status": "passed" | "failed", ... }.';
+            console.error(errMsg);
+            try {
+                jira_post_comment({
+                    key: ticketKey,
+                    comment: 'h3. ⚠️ Rework Error\n\n' + errMsg + '\n\nCheck CI logs for the agent output.'
+                });
+            } catch (e) {}
             releaseLock();
-            return { success: false, error: 'No test result JSON found' };
+            return { success: false, error: errMsg };
         }
 
-        const passed = (result.status || '').toLowerCase() === 'passed';
+        const testStatus = result.status.toLowerCase();
+        const passed = testStatus === 'passed';
         console.log('Re-run result:', result.status);
 
         // Step 2: Configure git + commit/push testing/ only
@@ -298,7 +305,7 @@ function action(params) {
                 const statusEmoji = passed ? '✅' : '❌';
                 const prBodyContent = readFile('outputs/pr_body.md') || fixSummary;
                 const prComment = '## 🔧 Test Rework Complete — ' + ticketKey + '\n\n' +
-                    '**Re-run result**: ' + statusEmoji + ' ' + result.status.toUpperCase() + '\n\n' +
+                    '**Re-run result**: ' + statusEmoji + ' ' + testStatus.toUpperCase() + '\n\n' +
                     '---\n\n' + prBodyContent;
                 github_add_pr_comment({
                     workspace: repoInfo.owner,
@@ -328,7 +335,7 @@ function action(params) {
         try {
             const statusEmoji = passed ? '✅' : '❌';
             let comment = 'h3. 🔧 Test Rework Completed\n\n';
-            comment += '*Re-run result*: ' + statusEmoji + ' *' + result.status.toUpperCase() + '*\n';
+            comment += '*Re-run result*: ' + statusEmoji + ' *' + testStatus.toUpperCase() + '*\n';
             comment += '*Branch*: {code}' + branchName + '{code}\n';
             if (pr) comment += '*Pull Request*: ' + pr.html_url + '\n';
             comment += '\n' + fixSummary;
@@ -340,11 +347,11 @@ function action(params) {
         // Step 7 & 8: Remove WIP label + SM idempotency label
         releaseLock();
 
-        console.log('✅ Test rework complete — re-run:', result.status, '→', targetStatus);
+        console.log('✅ Test rework complete — re-run:', testStatus, '→', targetStatus);
 
         return {
             success: true,
-            testStatus: result.status,
+            testStatus: testStatus,
             jiraStatus: targetStatus,
             ticketKey: ticketKey
         };

--- a/prompts/pr_test_automation_rework_prompt.md
+++ b/prompts/pr_test_automation_rework_prompt.md
@@ -32,6 +32,14 @@ Run `mkdir -p outputs` first to ensure the directory exists.
 
 - `outputs/response.md` — rework summary in **Jira Markdown** (short, factual): what was fixed + new test result
 - `outputs/pr_body.md` — same content in **GitHub Markdown** (always required — posted as GitHub PR comment; use standard MD: `##`, `**bold**`, backticks — NOT Jira syntax like `h3.`, `*bold*`, `{code}`)
-- `outputs/test_automation_result.json` — new test result (see instructions for format)
+- `outputs/test_automation_result.json` — **MANDATORY — always write this file**, even if the test failed or errored. Use exactly this format:
+  ```json
+  { "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+  ```
+  or for failure:
+  ```json
+  { "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+  ```
+  The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
 - `outputs/review_replies.json` — replies per thread: `{ "replies": [{ "inReplyToId": 123, "threadId": "PRRT_...", "reply": "Fixed: ..." }] }`
 - `outputs/bug_description.md` — updated bug description in Jira Markdown (only if test still FAILED)

--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -32,7 +32,15 @@ Run `mkdir -p outputs` first to ensure the directory exists.
 
 - `outputs/response.md` — test result summary in **Jira Markdown** (posted as Jira ticket comment)
 - `outputs/pr_body.md` — test result summary in **GitHub Markdown** (used as PR description)
-- `outputs/test_automation_result.json` — structured result JSON (see instructions for exact format)
+- `outputs/test_automation_result.json` — **MANDATORY — always write this file**, even if the test failed or errored. Use exactly this format:
+  ```json
+  { "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+  ```
+  or for failure:
+  ```json
+  { "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+  ```
+  The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
 - `outputs/bug_description.md` — detailed bug report in Jira Markdown (only if test FAILED)
 
 `response.md` and `pr_body.md` contain the same information but formatted differently — Jira MD vs GitHub MD.


### PR DESCRIPTION
## Problem

In `postTestReworkResults.js`, when the CLI agent writes `outputs/test_automation_result.json` with a missing or wrong `status` field (e.g. `{"result": "failed"}` instead of `{"status": "failed"}`), the script crashes with:

```
TypeError: Cannot read property 'toUpperCase' of undefined
```

This caused both the PR comment and Jira comment to be silently skipped, with the ticket moved to "In Review - Failed" but no context posted.

**Root cause**: Both prompts said *"see instructions for exact format"* for `test_automation_result.json` — but the format was never actually defined anywhere. Agents were guessing.

## Changes

### Prompts (both automation and rework)
- Added explicit JSON format with example to `test_case_automation_prompt.md` and `pr_test_automation_rework_prompt.md`
- Marked as **MANDATORY — always write this file** (even on failure/error)
- Specified that `"status"` must be exactly `"passed"` or `"failed"` (lowercase)

### postTestReworkResults.js
- Guard against `result.status` being undefined — now posts a clear error to Jira with the actual JSON received
- Use normalized `testStatus` variable (lowercased once) consistently — no more `result.status.toUpperCase()` on potentially undefined value