### PR TITLE
fix(review-pipeline): remove SM label + post Jira comment on CLI failure; capture stderr

### DIFF
--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -358,7 +358,27 @@ function action(params) {
         // Step 1: Read structured review data
         const reviewData = readReviewJson();
         if (!reviewData) {
-            console.error('Failed to read pr_review.json');
+            console.error('Failed to read pr_review.json — CLI likely failed; removing SM label so SM can retry');
+            // Remove SM idempotency label so the next SM cycle will re-trigger the review
+            const customParamsOnFail = params.jobParams && params.jobParams.customParams;
+            const removeLabelOnFail = customParamsOnFail && customParamsOnFail.removeLabel;
+            if (removeLabelOnFail) {
+                try {
+                    jira_remove_label({ key: ticketKey, label: removeLabelOnFail });
+                    console.log('✅ Removed SM label on CLI failure:', removeLabelOnFail);
+                } catch (e) {
+                    console.warn('Could not remove SM label on CLI failure:', e);
+                }
+            }
+            // Post an error comment to Jira so the failure is visible
+            try {
+                jira_add_comment({
+                    key: ticketKey,
+                    comment: 'h3. ⚠️ PR Review — CLI Failure\n\nThe AI review agent ran but produced no output ({code}pr_review.json{code} was not written). This is usually a transient Copilot API/rate-limit issue.\n\nThe SM idempotency label has been removed — the review will be retried automatically on the next SM cycle.'
+                });
+            } catch (e) {
+                console.warn('Could not post CLI failure comment:', e);
+            }
             return {
                 success: false,
                 error: 'No review data found in pr_review.json'

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -159,10 +159,18 @@ echo ""
 echo "Running: ${CMD[*]}"
 echo ""
 
-# Execute Command
-"${CMD[@]}"
-
+# Execute Command — capture stderr so failures are visible in CI logs
+STDERR_FILE="$(mktemp)"
+"${CMD[@]}" 2>"$STDERR_FILE"
 exit_code=$?
+
+if [ -s "$STDERR_FILE" ]; then
+  echo ""
+  echo "=== Agent stderr output ==="
+  cat "$STDERR_FILE"
+  echo "=== End of stderr ==="
+fi
+rm -f "$STDERR_FILE"
 
 echo ""
 echo "=== Agent completed with exit code: $exit_code ==="


### PR DESCRIPTION
## Problem
When the Copilot CLI fails (transient error, rate limit, model unavailable), `postPRReviewComments.js` returns early because `pr_review.json` is missing. The early return skips Step 10 (SM label removal), leaving `sm_story_review_triggered` on the Jira ticket — causing the SM to skip the ticket every 10 minutes **forever**.

## Changes

### `js/postPRReviewComments.js`
- When `pr_review.json` is missing, **remove the SM idempotency label** (from `customParams.removeLabel`) BEFORE returning early
- **Post a visible Jira comment** explaining the CLI failure so it's not silent
- SM will retry the review on the next cron cycle automatically

### `scripts/run-agent.sh`
- Capture CLI **stderr** to a temp file and print it to stdout at the end
- Makes the actual failure reason (auth error, rate limit, model error) visible in CI logs instead of being silently lost

## Root cause (MYTUBE-566)
The review pipeline run completed with exit code 0 (Java-level success) but the Copilot CLI failed internally after ~5 seconds — stderr was not captured, no output files were written, and the SM label was never removed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>