### PR TITLE
fix(test-automation): add STATUSES.BACKLOG + fix git staged-only diff check

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -31,7 +31,8 @@ const STATUSES = {
     IN_REVIEW_PASSED: 'In Review - Passed',          // Test ran and passed, awaiting code review
     IN_REVIEW_FAILED: 'In Review - Failed',          // Test ran and failed, awaiting code review
     IN_TESTING: 'In Testing',                        // Test cases generated, automation in progress
-    BUG_TO_FIX: 'Bug To Fix'                         // Bug linked/created for this TC, waiting for fix
+    BUG_TO_FIX: 'Bug To Fix',                        // Bug linked/created for this TC, waiting for fix
+    BACKLOG: 'Backlog'                               // Ticket waiting to be picked up
 };
 
 // Jira Priorities

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -62,30 +62,29 @@ function performGitOperations(branchName, commitMessage) {
         console.log('Staging testing/ folder...');
         cli_execute_command({ command: 'git add testing/' });
 
-        var rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
-        console.log('Raw git status length:', rawStatus.length);
-        var statusOutput = cleanCommandOutput(rawStatus);
-        console.log('Cleaned git status:', statusOutput || '(empty)');
+        // Check for STAGED changes only (git status --porcelain also includes dirty submodule etc.)
+        var stagedOutput = cleanCommandOutput(cli_execute_command({ command: 'git diff --cached --stat' }) || '');
+        console.log('Staged changes:', stagedOutput || '(none)');
 
-        if (!statusOutput || !statusOutput.trim()) {
-            console.warn('No new changes to commit in testing/ (files may already exist on main)');
-            // Check if branch exists on remote — we can still create PR from it
+        if (!stagedOutput || !stagedOutput.trim()) {
+            console.warn('No new staged changes in testing/ (files may already exist on branch)');
+            // Ensure the branch is pushed to remote so we can create/find a PR
             var remoteBranchCheck = cleanCommandOutput(
                 cli_execute_command({ command: 'git ls-remote --heads origin ' + branchName }) || ''
             );
-            if (remoteBranchCheck.trim()) {
-                console.log('Branch exists on remote, will try to create PR from existing branch');
-                return { success: true, branchName: branchName, noNewCommit: true };
+            if (!remoteBranchCheck.trim()) {
+                console.log('No remote branch found, pushing current branch state...');
+                try {
+                    cli_execute_command({ command: 'git push -u origin ' + branchName + ' --force' });
+                } catch (pushErr) {
+                    console.warn('Failed to push branch:', pushErr);
+                    return { success: false, error: 'No test files were written and could not push branch' };
+                }
+            } else {
+                console.log('Branch exists on remote — test files unchanged, will create/find PR from existing branch');
             }
-            // No remote branch either — push current branch so PR can be created
-            console.log('No remote branch found, pushing current branch state...');
-            try {
-                cli_execute_command({ command: 'git push -u origin ' + branchName + ' --force' });
-                return { success: true, branchName: branchName, noNewCommit: true };
-            } catch (pushErr) {
-                console.warn('Failed to push branch:', pushErr);
-                return { success: false, error: 'No test files were written and could not push branch' };
-            }
+            // Return with branch name; main flow will create/find the PR and go to In Review - Passed/Failed
+            return { success: true, branchName: branchName };
         }
 
         console.log('Committing...');


### PR DESCRIPTION
## Two bugs causing tickets to get stuck in 'In Development'

### Bug 1: `STATUSES.BACKLOG` undefined in `config.js` (CRITICAL)

`postTestAutomationResults.js` error recovery calls:
```js
jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
```
But `STATUSES.BACKLOG` was **not defined** in `config.js` → `statusName: undefined`  
→ DMTools throws: `Required parameter 'statusName' is missing`  
→ Ticket stays in **In Development forever**

**Fix:** Added `BACKLOG: 'Backlog'` to `STATUSES` in `config.js`

---

### Bug 2: `git status --porcelain` includes dirty agents submodule

After `git add testing/`, the code checks if there are changes to commit using `git status --porcelain`.  
But this returns ` M agents` (agents submodule has new commits, unstaged) — making the output **non-empty**.

The code fell through to `git commit` which failed:
> `no changes added to commit` (test files already existed on branch, unchanged)

The `noNewCommit` detection was completely bypassed.

**Fix:** Replace `git status --porcelain` with `git diff --cached --stat`  
(checks only **staged** changes — submodule dirt is invisible)

---

### Improvement: `noNewCommit` path now creates PR + goes through In Review

Previously when no staged changes were detected, the ticket went directly to `Passed` (skipping PR review). Now it pushes the branch (if needed) and creates a PR from the existing test code, going through `In Review - Passed` as intended.

---

## Real-world case: MYTUBE-575

1. Test branch had existing test files from previous run
2. CLI ran, found them, tested, passed — but wrote no new files
3. `git add testing/` staged nothing
4. `git status --porcelain` returned ` M agents` (non-empty → fell through)
5. `git commit` failed → error recovery triggered
6. `STATUSES.BACKLOG` undefined → jira_move_to_status failed
7. Ticket stuck in In Development

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>