### PR TITLE
Refactor generic prompt composition

### DIFF
--- a/.github/skills/agent-prompt-architecture/SKILL.md
+++ b/.github/skills/agent-prompt-architecture/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: agent-prompt-architecture
+description: >
+  Guidance for keeping dmtools-agents prompt/config architecture generic and
+  project-safe. Use when refactoring agent prompts, composing cliPrompt/cliPrompts,
+  moving project rules into target repos, adding .dmtools config fields, or changing
+  GraalJS agent code.
+---
+
+# Agent Prompt Architecture
+
+## Core rule
+
+`dmtools-agents` is a generic agents repository. It must not contain customer,
+project, repository, ticket, branch, or technology rules that belong to a target
+project.
+
+Put reusable behavior here. Put project context in the target repo.
+
+## Prompt layers
+
+Use small files and compose them explicitly:
+
+```text
+agents/
+  prompts/                         # generic entry prompts
+  instructions/
+    review/                        # review behavior
+    rework/                        # rework behavior
+    development/                   # implementation behavior
+    tracker/                       # Jira / ADO / generic work item formatting
+    scm/                           # GitHub / ADO PR formatting
+    platform/                      # reusable web/mobile/backend/database rules
+
+target-repo/
+  .dmtools/
+    config.js                      # project composition
+    prompts/                       # project role/context/focus
+    instructions/                  # project architecture/platform rules
+```
+
+### Generic files may contain
+
+- Agent role and task contract.
+- Input/output contract.
+- Provider-neutral wording: ticket/work item, SCM, PR, CI checks.
+- Generic quality rules: correctness, security, maintainability, tests.
+- Provider-specific rules only inside explicit provider folders:
+  - `instructions/tracker/*`
+  - `instructions/scm/*`
+
+### Generic files must not contain
+
+- Real project names, ticket keys, repo paths, or customer names.
+- Target repo branch names, workflow names, labels, or pipeline details.
+- Product-specific business rules.
+- Technology rules that only one project needs.
+- Links to private project documentation.
+
+## Composition model
+
+For CLI agents with `skipAIProcessing=true`, prefer direct CLI prompt surfaces:
+
+```js
+module.exports = {
+    cliPrompts: {
+        story_development: [
+            './.dmtools/prompts/project_context.md',
+            './.dmtools/prompts/development_focus.md',
+            './agents/instructions/platform/backend_architecture.md'
+        ],
+        pr_review: [
+            './.dmtools/prompts/reviewer_role.md',
+            './.dmtools/prompts/review_focus.md',
+            './agents/instructions/review/core.md',
+            './agents/instructions/scm/github_pr_review_format.md'
+        ]
+    },
+
+    cliPromptOverrides: {
+        pr_review: './.dmtools/prompts/pr_review_prompt.md'
+    },
+
+    agentParamPatches: {
+        story_development: {
+            aiRole: 'Senior Software Engineer'
+        }
+    },
+
+    additionalInstructions: {
+        story_solution: [
+            './.dmtools/instructions/product/domain_knowledge.md'
+        ]
+    }
+};
+```
+
+Use:
+
+| Field | Use |
+|---|---|
+| `cliPrompt` | Generic default entry prompt in agent JSON |
+| `cliPrompts.<agent>` | Project/provider/platform modules appended to the CLI prompt |
+| `cliPromptOverrides.<agent>` | Replace the default entry prompt for one project |
+| `agentParamPatches.<agent>` | Patch `params.agentParams` without copying full JSON |
+| `instructionOverrides.<agent>` | Replace `agentParams.instructions` |
+| `additionalInstructions.<agent>` | Non-CLI/DMtools AI context, not the main CLI prompt channel |
+
+## Path stability
+
+Do not move production JSON config paths unless the workflow/Jira/ADO entrypoints
+are being migrated in the same change.
+
+Safe refactors:
+
+- Split prompt markdown into smaller files.
+- Add `cliPrompts` in target `.dmtools/config.js`.
+- Move project rules from generic prompts to target repo prompt packs.
+- Add provider/platform modules under `agents/instructions/*`.
+
+Risky refactors:
+
+- Moving `*.json` configs used by CI.
+- Renaming workflow inputs or `config_file` values.
+- Moving target repo custom JS actions.
+
+## GraalJS constraints
+
+Production agent JS runs in dmtools GraalJS, not Node.js.
+
+Do not use Node-only APIs in runtime agent files:
+
+- `fs`, `path`, `process`, `Buffer`, `child_process`, npm packages.
+- Browser-only APIs such as `fetch`, `window`, `document`.
+- Shelling out unless the agent already uses an approved dmtools tool for it.
+
+Use GraalJS-safe patterns:
+
+- `var` declarations and plain functions.
+- Local `require('./module.js')` only for repository JS modules supported by the
+  agent runner.
+- JSON-safe data structures.
+- Existing dmtools MCP/tool globals such as `jira_*`, `ado_*`, `github_*`,
+  `file_read`, and project wrappers.
+- Explicit error returns or throws consistent with nearby agent code.
+
+Unit tests may run in Node.js and provide mocks, but runtime code must stay
+GraalJS-compatible.
+
+## Refactor checklist
+
+1. Identify whether each rule is generic, provider-specific, platform-specific,
+   or project-specific.
+2. Keep generic rules in `agents/`.
+3. Put provider-specific formatting in `instructions/tracker` or
+   `instructions/scm`.
+4. Put project rules in the target repo under `.dmtools/` or the existing
+   project config/prompt folder.
+5. Wire small prompt files through `cliPrompts`.
+6. Keep JSON config paths stable unless explicitly migrating workflows.
+7. Run JSON parse checks and existing JS unit tests.
+8. Search for accidental project leakage before opening a PR.

--- a/.github/skills/agent-prompt-architecture/SKILL.md
+++ b/.github/skills/agent-prompt-architecture/SKILL.md
@@ -106,6 +106,86 @@ Use:
 | `instructionOverrides.<agent>` | Replace `agentParams.instructions` |
 | `additionalInstructions.<agent>` | Non-CLI/DMtools AI context, not the main CLI prompt channel |
 
+## Creating a new CLI Teammate JSON
+
+Use `Teammate` configs for CLI-agent workflows where dmtools prepares context,
+the CLI agent performs the work, and post-actions publish the result.
+
+The JSON `"name"` is a dmtools job class name. Keep it exactly `"Teammate"`.
+
+Minimal pattern:
+
+```json
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": {
+      "contextId": "story_development"
+    },
+    "agentParams": {
+      "aiRole": "Senior Software Engineer",
+      "instructions": [
+        "./agents/instructions/development/implementation_instructions.md",
+        "./agents/instructions/common/bash_tools.md"
+      ],
+      "knownInfo": "",
+      "formattingRules": "",
+      "fewShots": ""
+    },
+    "cliPrompt": "./agents/prompts/story_development_prompt.md",
+    "cliPrompts": [],
+    "cliCommands": [
+      "./agents/scripts/run-agent.sh"
+    ],
+    "outputType": "none",
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "ticketContextDepth": 1,
+    "inputJql": "key = WORK-123"
+  }
+}
+```
+
+Best practices:
+
+- Keep generic JSON in `agents/`; put project-specific prompt composition in the
+  target repo's `.dmtools/config.js`.
+- Keep `agentParams` small and compatibility-focused.
+- Put role, project context, provider format, and platform focus in
+  `cliPrompts` files instead of long inline strings.
+- Use `metadata.contextId` to identify the workflow in logs and output.
+- Keep `cliCommands` stable and delegate project behavior to prompt/config files.
+- Add `preJSAction`, `preCliJSAction`, and `postJSAction` only when runtime
+  behavior is required.
+- Never copy a production JSON config only to change prompts. Prefer
+  `cliPrompts`, `cliPromptOverrides`, or `agentParamPatches`.
+- Validate JSON after every edit.
+
+## Output JSON discipline
+
+Agents often write JSON output files that are consumed by post-actions or CI.
+Treat those files as machine contracts.
+
+Rules:
+
+- Always write valid JSON when a JSON output file is required.
+- Validate generated JSON before finishing the agent run.
+- Keep JSON compact: status, counters, paths, IDs, and short summaries.
+- Do not put large markdown bodies, stack traces, logs, or generated reports
+  directly inside JSON fields.
+- If a large markdown/text body is needed, write it to a separate `.md` or `.txt`
+  file and put only the file path/reference in JSON.
+- Prefer:
+  ```json
+  {
+    "status": "failed",
+    "summary": "1 failing scenario",
+    "detailsFile": "outputs/bug_description.md"
+  }
+  ```
+  over embedding the full bug report in `"summary"` or `"details"`.
+- If JSON parsing fails, fix the JSON before any post-action consumes it.
+
 ## Path stability
 
 Do not move production JSON config paths unless the workflow/Jira/ADO entrypoints
@@ -158,5 +238,7 @@ GraalJS-compatible.
    project config/prompt folder.
 5. Wire small prompt files through `cliPrompts`.
 6. Keep JSON config paths stable unless explicitly migrating workflows.
-7. Run JSON parse checks and existing JS unit tests.
-8. Search for accidental project leakage before opening a PR.
+7. Validate changed agent JSON configs.
+8. Validate required output JSON contracts if the agent writes JSON files.
+9. Run existing JS unit tests.
+10. Search for accidental project leakage before opening a PR.

--- a/instructions/development/implementation_instructions.md
+++ b/instructions/development/implementation_instructions.md
@@ -13,14 +13,7 @@ Understand existing codebase patterns, architecture, and test structure before i
   - Encapsulation: hide internal state, expose clean interfaces
   - Prefer composition over inheritance
 
-**IMPORTANT** Use modern practices and frameworks appropriate to the language and stack:
-  - **Database access**: always use an ORM or query builder — never write raw SQL. Use the ORM already present in the codebase (e.g. GORM for Go, TypeORM/Prisma for TypeScript/Node.js, Hibernate/Spring Data for Java, SQLAlchemy for Python). If no ORM exists yet, introduce the most idiomatic one for the language.
-  - **Backend**: follow repository pattern — data access logic lives in repositories, not controllers or handlers
-  - **Frontend**: follow Clean Architecture with strict layer separation:
-      - **Domain layer**: entities, use cases, repository interfaces (no framework dependencies)
-      - **Data layer**: repository implementations, API clients, local storage adapters
-      - **Presentation layer**: UI components, view models / state management — depends only on domain use cases
-      - Components must not call APIs or databases directly
+**IMPORTANT** Use the project-approved language, framework, architecture, and tooling. If project or platform instruction files are provided, treat them as binding.
 
 Implement code changes based on ticket requirements including:
   - Source code implementation following existing patterns and architecture
@@ -29,26 +22,7 @@ Implement code changes based on ticket requirements including:
 
 **IMPORTANT**: Before finishing, you MUST run all unit tests and confirm they pass. If tests fail, fix the issues before completing. Do not finish with failing tests.
 
-**IMPORTANT**: Check whether a CI/CD workflow exists that runs unit tests automatically on pull request push or update (e.g. `.github/workflows/` for GitHub). If no such workflow exists, create one. For GitHub, create a workflow file under `.github/workflows/` that:
-  - Triggers on `pull_request` events (opened, synchronize, reopened)
-  - Installs dependencies and runs the unit test suite
-  - Fails the PR check if any tests fail
-  Match the language/build tool already used in the project (e.g. npm test, mvn test, gradle test, pytest, etc.)
-
-**IMPORTANT**: If the implementation requires new environment variables, configuration, or credentials for GitHub Actions (deployments, tests, or other workflows):
-  1. **Check what already exists first** — never overwrite without checking:
-     ```bash
-     gh secret list --repo {owner}/{repo}
-     gh variable list --repo {owner}/{repo}
-     ```
-  2. **Add non-sensitive variables** (URLs, project IDs, feature flags, region names, etc.):
-     ```bash
-     gh variable set VAR_NAME --body "value" --repo {owner}/{repo}
-     ```
-  3. **For sensitive secrets** (API keys, passwords, tokens) — you cannot set them automatically as you do not have the actual value. Instead, document them in `outputs/response.md` as:
-     > 🔑 **Human action required**: add secret `SECRET_NAME` to GitHub Actions (`gh secret set SECRET_NAME --body "..." --repo {owner}/{repo}`)
-  4. **Update `instruction.md`** — always add the new entry to the appropriate table (GitHub Secrets or GitHub Variables). Mark secrets not yet added with ⚠️.
-  5. Secrets and variables set at repo level are available to **all** workflows: `ai-teammate.yml`, `deploy-api.yml`, `deploy-pages.yml`, `unit-tests.yml` and any future workflow.
+**IMPORTANT**: If CI/CD or repository-level configuration changes are required, follow the project-specific SCM/CI instructions. Do not assume a specific provider.
 
 **IMPORTANT**: Before finishing, run `git status` to review every new and modified file. Check for any sensitive files that must NOT be committed:
 - Credential / service-account files (`gha-creds-*.json`, `*-credentials.json`, `*.pem`, `*.key`, `id_rsa`, `keystore.*`)
@@ -67,7 +41,7 @@ Write a short (no water words) development summary to outputs/response.md with t
   - Approach and design decisions made during implementation
   - List of files created or modified with brief explanation
   - Test coverage added (describe what tests were created)
-  - Whether a CI/CD unit test workflow already existed or was created
+  - Whether CI/CD or repository configuration was changed
 
 **IMPORTANT**: The outputs/response.md content will be automatically appended to the Pull Request description
 

--- a/instructions/intake/formatting_rules.md
+++ b/instructions/intake/formatting_rules.md
@@ -6,12 +6,12 @@
 - Each item must include:
   - `"summary"` — string, max 120 characters
   - `"description"` — string, relative file path (e.g. `"outputs/stories/story-1.md"`)
-  - `"parent"` — real Jira key (e.g. `"PROJECT-5"`), temp ID (e.g. `"temp-1"`), or absent/null for a new Epic
+  - `"parent"` — real tracker key (e.g. `"PROJECT-5"`), temp ID (e.g. `"temp-1"`), or absent/null for a new Epic
   - `"tempId"` — optional string, unique within this array; assign to new Epics so Stories can reference them via `"parent"`
   - `"priority"` — one of: `Highest`, `High`, `Medium`, `Low`, `Lowest`
   - `"storyPoints"` — integer, Stories only (1–2 simple, 3–5 medium, 8–13 complex); max 5 SP — split if larger; omit for Epics
-  - `"blockedBy"` — optional array of tempIds or real Jira keys this story cannot start until they are done. Creates "is blocked by" links and sets status to Blocked. Example: `["temp-1", "PROJECT-5"]`
-  - `"integrates"` — optional array of tempIds or real Jira keys of parallel stories that will be combined with this one. Creates "Relates" links. Use when two parallel streams must eventually be merged. Example: `["temp-2"]`
+  - `"blockedBy"` — optional array of tempIds or real tracker keys this story cannot start until they are done. Creates dependency links and sets status to Blocked where supported. Example: `["temp-1", "PROJECT-5"]`
+  - `"integrates"` — optional array of tempIds or real tracker keys of parallel stories that will be combined with this one. Creates relation links where supported. Use when two parallel streams must eventually be merged. Example: `["temp-2"]`
 - **Bug entries** — use when the intake describes a broken/malfunctioning existing feature (not a new feature):
   - `"type": "Bug"` — required, signals this is a bug ticket
   - No `"parent"` — bugs are top-level tickets
@@ -23,14 +23,14 @@
 
 ## outputs/comment.md
 
-- Use Jira Markdown only: `h3.`, `*bold*`, `* bullet`, `[text|url]`
+- Use the target tracker format
 - No HTML tags
 - Sections: intake summary, decomposition decisions, planned ticket list, assumptions/open questions
 
 ## outputs/stories/story-N.md and epic-N.md
 
 - Start directly with content — no introductory header or preamble
-- Use Jira Markdown
+- Use the target tracker format
 - Do NOT write Acceptance Criteria — that is handled by a separate agent
 - No filler, no water — be specific
 

--- a/instructions/intake/intake_instructions.md
+++ b/instructions/intake/intake_instructions.md
@@ -1,6 +1,6 @@
 # Intake Agent Instructions
 
-You are an experienced Product Owner and Business Analyst performing intake analysis on a raw Jira ticket.
+You are an experienced Product Owner and Business Analyst performing intake analysis on a raw tracker work item.
 
 ## Your Inputs
 
@@ -16,7 +16,7 @@ You are an experienced Product Owner and Business Analyst performing intake anal
   ```
   Use this to avoid creating duplicate stories. `parent` is the Epic key this story belongs to. `status` shows current work state.
 
-> **Need full details of a story?** Run `dmtools jira_get_ticket <KEY>` in the terminal to fetch the complete description, acceptance criteria, and all fields. You can also search: `dmtools jira_search_by_jql '{"jql":"project=<PROJECT> AND issuetype=Story AND summary~\"keyword\"","fields":["key","summary","description","status"]}'`
+> **Need full details of a story?** Use the tracker-specific DMtools command available for the configured project to fetch the complete description, acceptance criteria, and fields.
 
 ## Your Task
 
@@ -34,7 +34,7 @@ You are an experienced Product Owner and Business Analyst performing intake anal
    - `"tempId"` (optional) — assign a local temporary ID (e.g. `"temp-1"`) to a *new* Epic so Stories can reference it. Only needed if you create stories inside a new epic.
    - `"parent"`:
      - Absent or `null` → create as a new Epic
-     - `"PROJECT-X"` (real Jira key from existing_epics.json) → create as a Story under that existing Epic
+    - `"PROJECT-X"` (real tracker key from existing_epics.json) → create as a Story under that existing Epic
      - `"temp-1"` (temp ID) → create as a Story under a new Epic defined in this same array
    - `"summary"` — ticket title, max 120 characters
    - `"description"` — relative path to the .md file (e.g. `"outputs/stories/story-1.md"`)
@@ -57,7 +57,7 @@ You are an experienced Product Owner and Business Analyst performing intake anal
    ```
    In this example: s-1 runs first; s-2 and s-3 run in parallel after s-1 (both blocked by s-1); s-2 and s-3 have a "Relates" link because they will be combined; the last story is blocked by both parallel streams.
 
-5. **Write `outputs/comment.md`** — Jira Markdown intake summary including:
+5. **Write `outputs/comment.md`** — tracker-formatted intake summary including:
    - What the request is about
    - Key decisions (new vs existing epics, decomposition rationale)
    - List of planned tickets with brief descriptions
@@ -89,7 +89,7 @@ If any of the above is missing from the existing stories and not explicitly excl
 ## Rules
 
 - `outputs/stories.json` must be valid JSON. Run `dmtools file_validate_json "$(cat outputs/stories.json)"` to validate — fix and rewrite if `"valid"` is false. Do not finish until validation passes.
-- Do not reference Jira keys that are not in `existing_epics.json` or `existing_stories.json`.
+- Do not reference tracker keys that are not in `existing_epics.json` or `existing_stories.json`.
 - Check `existing_stories.json` before creating a story to avoid duplicating existing work.
 - Keep summaries concise and actionable (imperative form, e.g. "Add payment method selection").
 - Stories should represent 1–2 sprint's worth of work; split further if needed.

--- a/instructions/platform/backend_architecture.md
+++ b/instructions/platform/backend_architecture.md
@@ -1,0 +1,8 @@
+# Backend architecture rules
+
+- Keep business logic out of transport handlers and controllers.
+- Put data access behind repositories, gateways, service clients, or the equivalent project abstraction.
+- Keep validation, authorization, and error mapping explicit.
+- Preserve existing dependency-injection and layering patterns.
+- Avoid broad refactors unless the ticket requires them.
+

--- a/instructions/platform/database_access.md
+++ b/instructions/platform/database_access.md
@@ -1,0 +1,7 @@
+# Database access rules
+
+- Use the data-access abstraction already present in the codebase.
+- Prefer existing repositories, DAOs, ORM models, query builders, or service clients.
+- Do not put raw persistence queries in controllers, handlers, UI components, or test code unless the project explicitly uses that pattern.
+- Keep transactions, migrations, and schema changes aligned with existing project conventions.
+

--- a/instructions/platform/frontend_clean_architecture.md
+++ b/instructions/platform/frontend_clean_architecture.md
@@ -1,0 +1,8 @@
+# Frontend architecture rules
+
+- Keep UI components focused on rendering and user interaction.
+- Put business logic in domain/use-case/state-management layers according to project conventions.
+- Keep API/database calls out of UI components unless the project explicitly uses that pattern.
+- Reuse existing design tokens, theme helpers, routing, state, and data-fetching patterns.
+- Preserve accessibility behavior and visual consistency.
+

--- a/instructions/review/ci_failures.md
+++ b/instructions/review/ci_failures.md
@@ -1,0 +1,9 @@
+# CI failures
+
+If `ci_failures.md` exists:
+
+- Treat failed checks as BLOCKING unless clearly marked informational.
+- Summarize the failed check name, relevant log evidence, and required fix.
+- Do not invent root causes when logs are insufficient.
+- Mention CI failures in the tracker comment and PR general comment.
+

--- a/instructions/review/core.md
+++ b/instructions/review/core.md
@@ -1,0 +1,8 @@
+# PR review core
+
+- Review only. Do not edit code, create commits, or change branches.
+- Base findings on `input/`, the PR diff, and repository context.
+- Prioritize correctness, security, task alignment, tests, and maintainability.
+- Raise only actionable issues. Skip low-value style comments.
+- If the PR can be approved, keep the review short and leave no inline comments.
+

--- a/instructions/review/inline_comments.md
+++ b/instructions/review/inline_comments.md
@@ -1,0 +1,9 @@
+# Inline comments
+
+- Inline comments are for BLOCKING and IMPORTANT issues.
+- If recommendation is `APPROVE`, `inlineComments` must be empty.
+- Comment only on lines present in `pr_diff.txt`.
+- Findings outside the diff go into the general PR comment.
+- Each inline comment must explain the problem and the concrete fix.
+- Do not post "nice to have" comments unless project config allows suggestions.
+

--- a/instructions/review/input_context.md
+++ b/instructions/review/input_context.md
@@ -1,0 +1,15 @@
+# Input context
+
+Read available files from the input folder:
+
+- `ticket.md`: requirements, acceptance criteria, business context.
+- `pr_info.md`: PR title, URL, author, branch, metadata.
+- `pr_diff.txt`: source of truth for changed lines.
+- `pr_files.txt`: changed file list.
+- `ci_failures.md`: failed checks, if present.
+- `pr_discussions.md`: previous comments/threads, if present.
+- `pr_discussions_raw.json`: thread IDs for resolved threads, if present.
+- `parent_context_*.md`: extra project context, if present.
+
+Optional files may be absent. Continue without them.
+

--- a/instructions/review/output_contract.md
+++ b/instructions/review/output_contract.md
@@ -1,0 +1,39 @@
+# Output contract
+
+Create these files:
+
+1. `outputs/response.md` - tracker comment. For Jira configs, use Jira wiki markup.
+2. `outputs/pr_review.json` - structured review result.
+3. `outputs/pr_review_general.md` - general PR comment in SCM-compatible Markdown.
+
+`outputs/pr_review.json` schema:
+
+```json
+{
+  "recommendation": "APPROVE|REQUEST_CHANGES|BLOCK",
+  "summary": "One short paragraph",
+  "prNumber": null,
+  "prUrl": null,
+  "generalComment": "outputs/pr_review_general.md",
+  "resolvedThreadIds": [],
+  "inlineComments": [
+    {
+      "path": "src/file.tsx",
+      "line": 42,
+      "startLine": 40,
+      "side": "RIGHT",
+      "body": "Comment text",
+      "severity": "BLOCKING|IMPORTANT|SUGGESTION"
+    }
+  ],
+  "issueCounts": {
+    "blocking": 0,
+    "important": 0,
+    "suggestions": 0
+  }
+}
+```
+
+Use `recommendation`, not `verdict`.
+Counts must match reported issues.
+

--- a/instructions/review/pr_review_instructions.md
+++ b/instructions/review/pr_review_instructions.md
@@ -47,10 +47,8 @@ Scan for OWASP Top 10 and common vulnerabilities:
   - Separation of concerns
   - Cohesion and coupling
   - Naming conventions and code readability
-  - **ORM usage**: flag any raw SQL queries — database access must go through an ORM or query builder (GORM, TypeORM, Prisma, Hibernate, SQLAlchemy, etc.)
-  - **Modern frameworks**: flag use of outdated or non-idiomatic libraries when a standard modern alternative exists in the project stack
-  - **Repository pattern**: flag business logic or SQL inside controllers, handlers, or UI components — data access belongs in repositories
-  - **Frontend Clean Architecture**: flag violations of layer boundaries — UI components must not call APIs or databases directly; domain logic must not depend on UI frameworks; dependency must only flow inward (Presentation → Domain ← Data)
+  - Project architecture: flag violations of project-approved layering, data access, dependency direction, and framework conventions
+  - Modern framework usage: flag outdated or non-idiomatic libraries only when the project stack clearly has an approved alternative
 
 ## ✅ Task Alignment
   - Verify implementation matches ticket requirements

--- a/instructions/review/repeated_review.md
+++ b/instructions/review/repeated_review.md
@@ -1,0 +1,9 @@
+# Repeated review
+
+If `pr_discussions.md` exists:
+
+- Read previous comments before adding new findings.
+- For each previous issue, state: resolved, still present, partially addressed, or not verifiable.
+- Do not re-raise fully fixed issues.
+- Add a thread ID to `resolvedThreadIds` only when the fix is verified.
+

--- a/instructions/review/review_priorities.md
+++ b/instructions/review/review_priorities.md
@@ -1,0 +1,14 @@
+# Review priorities
+
+Check in this order:
+
+1. The PR solves the ticket and all acceptance criteria.
+2. No security issue is introduced.
+3. The implementation is correct for edge cases and error states.
+4. Tests cover new or changed behavior.
+5. No tests which are testing nothing and difficult to support in future.
+6. Code follows existing architecture and project patterns.
+7. No unnecessary or out-of-scope changes are included.
+
+When a defect pattern appears multiple times in the diff, report all instances in one pass.
+

--- a/instructions/review/review_priorities.md
+++ b/instructions/review/review_priorities.md
@@ -6,9 +6,8 @@ Check in this order:
 2. No security issue is introduced.
 3. The implementation is correct for edge cases and error states.
 4. Tests cover new or changed behavior.
-5. No tests which are testing nothing and difficult to support in future.
+5. Avoid tests that do not assert meaningful behavior or are difficult to maintain.
 6. Code follows existing architecture and project patterns.
 7. No unnecessary or out-of-scope changes are included.
 
 When a defect pattern appears multiple times in the diff, report all instances in one pass.
-

--- a/instructions/rework/rework_instructions.md
+++ b/instructions/rework/rework_instructions.md
@@ -41,7 +41,7 @@ After all fixes:
 
 ### 1. `outputs/response.md` — Human-readable fix summary (posted as general PR comment)
 
-Write in clear GitHub Markdown:
+Write in clear SCM-compatible Markdown:
 
 ```markdown
 ## Rework Summary

--- a/instructions/scm/github_actions_ci.md
+++ b/instructions/scm/github_actions_ci.md
@@ -1,0 +1,11 @@
+# GitHub Actions CI rules
+
+Use this only for projects that use GitHub Actions.
+
+- Check whether `.github/workflows/` already contains a pull-request test workflow before adding one.
+- If no suitable workflow exists and the ticket requires CI coverage, create a workflow that runs the existing test command on `pull_request` events.
+- Match the existing language and build tool; do not introduce unrelated tooling.
+- For repository variables, inspect existing values first with `gh variable list --repo {owner}/{repo}`.
+- For secrets, inspect existing names first with `gh secret list --repo {owner}/{repo}`.
+- Never invent secret values. Document missing secret names as human action required.
+

--- a/instructions/scm/github_pr_review_format.md
+++ b/instructions/scm/github_pr_review_format.md
@@ -1,0 +1,8 @@
+# GitHub PR review format
+
+- `outputs/pr_review_general.md` uses GitHub Markdown.
+- `inlineComments[].body` uses GitHub Markdown.
+- Use `path`, `line`, optional `startLine`, and `side`.
+- Use `side: "RIGHT"` for new code unless commenting on removed code.
+- `resolvedThreadIds` contains GitHub review thread IDs from `pr_discussions_raw.json`.
+

--- a/instructions/test_automation/mobile_test_instructions.md
+++ b/instructions/test_automation/mobile_test_instructions.md
@@ -126,11 +126,11 @@ Never hardcode credentials in test files.
 - `"status"` = `"passed"` only when ALL TCs pass; `"failed"` if any TC fails; `"blocked_by_human"` if setup is missing
 - `"results"` array: one entry per TC
 
-### `outputs/response.md` — Jira Markdown summary (posted as comment on trigger ticket)
+### `outputs/response.md` — tracker-formatted summary
 
-### `outputs/pr_body.md` — GitHub Markdown summary (automation repo PR description)
+### `outputs/pr_body.md` — SCM-formatted automation PR description
 
-### `outputs/pr_feature_update.md` — GitHub Markdown appended to the feature PR description
+### `outputs/pr_feature_update.md` — SCM-formatted update appended to the feature PR description
 
 Include: TC key | Title | Status table.
 

--- a/instructions/test_automation/test_automation_instructions.md
+++ b/instructions/test_automation/test_automation_instructions.md
@@ -2,7 +2,7 @@
 
 ## Your Role
 
-You are a Senior QA Automation Engineer. Your task is to automate a single Jira Test Case ticket.
+You are a Senior QA Automation Engineer. Your task is to automate a single test case work item.
 
 The feature code is **already implemented and deployed** on the main branch. You do NOT write feature code — you write automated tests that verify the feature works as described in the Test Case.
 
@@ -51,48 +51,9 @@ The `README.md` inside the ticket folder is mandatory. It must include:
 
 ## Available CI Credentials
 
-Before writing a test, check what is already available in GitHub Actions. **You do NOT need to request these — they are already configured.**
+Before writing a test, read project-specific CI, credential, and environment instructions if they are provided.
 
-### GCP (Google Cloud)
-- **Authentication**: `GCP_SA_KEY` secret → sets up ADC via `google-github-actions/auth@v2` → `GOOGLE_APPLICATION_CREDENTIALS` is available automatically
-- `GCP_PROJECT_ID` = `ai-native-478811`
-- `GCP_REGION` = `us-central1`
-- `GCP_DB_USER_SECRET`, `GCP_DB_PASSWORD_SECRET` — Secret Manager secret names
-- `CLOUD_SQL_CONNECTION_NAME` — Cloud SQL instance connection name
-
-### Firebase
-- `FIREBASE_PROJECT_ID` = `ai-native-478811`
-- `FIREBASE_API_KEY` — Firebase web API key (public)
-- `FIREBASE_AUTH_DOMAIN` = `ai-native-478811.firebaseapp.com`
-- `FIREBASE_APP_ID`, `FIREBASE_STORAGE_BUCKET`, `FIREBASE_MESSAGING_SENDER_ID`
-
-### Database
-- `DB_USER`, `DB_PASSWORD`, `DB_NAME`
-
-### Web App
-- Frontend: `{FRONTEND_URL}` (default — no env var needed)
-- API: `{API_URL}`
-
-### Also available
-- `RAW_OBJECT_PATH` = `test-videos/test_video.mp4` — relative path within `{GCS_BUCKET}/` to a real test video for transcoder tests
-- `FIREBASE_TEST_EMAIL` = `{TEST_EMAIL}` (variable) — CI test user, fake domain, no real Gmail
-- `FIREBASE_TEST_UID` = `ci-test-user-001` (variable)
-- `FIREBASE_TEST_PASSWORD` (secret) — password for the CI test user
-- `FIREBASE_TEST_TOKEN` — **generate at CI runtime** (token expires in 1h, never store as secret):
-  ```yaml
-  - name: Get Firebase test token
-    run: |
-      RESP=$(curl -s -X POST \
-        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${{ vars.FIREBASE_API_KEY }}" \
-        -H "Content-Type: application/json" \
-        -d "{\"email\":\"${{ vars.FIREBASE_TEST_EMAIL }}\",\"password\":\"${{ secrets.FIREBASE_TEST_PASSWORD }}\",\"returnSecureToken\":true}")
-      echo "FIREBASE_TEST_TOKEN=$(echo $RESP | jq -r .idToken)" >> $GITHUB_ENV
-      echo "FIREBASE_TEST_UID=${{ vars.FIREBASE_TEST_UID }}" >> $GITHUB_ENV
-      echo "FIREBASE_TEST_EMAIL=${{ vars.FIREBASE_TEST_EMAIL }}" >> $GITHUB_ENV
-  ```
-
-### Not yet available (require human setup)
-_All credentials are now provisioned. No blockers remain for Firebase or GCP tests._
+Do not assume a CI provider, cloud provider, project ID, secret name, or test account. If required credentials or test data are missing, report the exact missing item in `outputs/test_automation_result.json`.
 
 ---
 
@@ -143,13 +104,12 @@ curl -L -o /tmp/test_video.mp4 "https://www.w3schools.com/html/mov_bbb.mp4"
 
 Always verify the download succeeded (`curl` exit code 0, file size > 0) before using the file.
 
-### Step 3 — Upload to GCS if the test needs a GCS path
+### Step 3 — Upload to object storage if the test needs a stored file path
 
-If the test requires a file already in `{GCS_BUCKET}/`, upload the generated/downloaded file:
+If the test requires a file already in object storage, upload the generated/downloaded file using the project-approved storage tooling and bucket/container:
 
 ```bash
-gcloud storage cp /tmp/test_video.mp4 {GCS_BUCKET}/test-data/{TICKET-KEY}/test_video.mp4 \
-  --project=ai-native-478811
+<storage-cli> cp /tmp/test_video.mp4 <bucket-or-container>/test-data/{TICKET-KEY}/test_video.mp4
 ```
 
 Then use `test-data/{TICKET-KEY}/test_video.mp4` as `RAW_OBJECT_PATH` in the test.
@@ -170,7 +130,7 @@ If a test **cannot run automatically** because required credentials or test data
 
 ### When to use `blocked_by_human`
 - Required env var or secret does not exist (see "Not yet available" list above)
-- Test needs a real Firebase ID token and `FIREBASE_TEST_EMAIL`/`FIREBASE_TEST_PASSWORD` are not set
+- Test needs a real authenticated user token and the required test-account credentials are not set
 - Test requires pre-existing data in the DB (e.g. a specific user or record not guaranteed to exist)
 - Test requires an external file that could not be generated or downloaded following the **Test Data — Self-Sufficient Strategy** above
 
@@ -201,7 +161,7 @@ After writing the test:
 Always write two output files:
 
 ### 1. `outputs/response.md`
-Jira-formatted summary of what was tested and the result.
+Tracker-formatted summary of what was tested and the result.
 
 ### 2. `outputs/test_automation_result.json`
 Structured result JSON — see `agents/instructions/test_automation/test_automation_json_output.md` for exact format.
@@ -209,4 +169,4 @@ Structured result JSON — see `agents/instructions/test_automation/test_automat
 If the test **failed**, also write:
 
 ### 3. `outputs/bug_description.md`
-Detailed Jira-formatted bug description including reproduction steps, expected vs actual result, and error logs.
+Detailed tracker-formatted bug description including reproduction steps, expected vs actual result, and error logs.

--- a/instructions/test_automation/test_automation_json_output.md
+++ b/instructions/test_automation/test_automation_json_output.md
@@ -31,16 +31,16 @@ After running the test, write the structured result to `outputs/test_automation_
   "blocked_reason": "One sentence explaining why the test cannot run automatically.",
   "missing": [
     {
-      "type": "github_secret",
-      "name": "FIREBASE_TEST_EMAIL",
-      "description": "Email of a dedicated Firebase test user in project ai-native-478811",
-      "how_to_add": "gh secret set FIREBASE_TEST_EMAIL --body 'test@example.com' --repo {owner}/{repo}"
+      "type": "secret",
+      "name": "TEST_USER_EMAIL",
+      "description": "Email of a dedicated automated-test user",
+      "how_to_add": "Add the value using the project's secret-management process"
     },
     {
-      "type": "github_secret",
-      "name": "FIREBASE_TEST_PASSWORD",
-      "description": "Password for the Firebase test user",
-      "how_to_add": "gh secret set FIREBASE_TEST_PASSWORD --body 'password' --repo {owner}/{repo}"
+      "type": "secret",
+      "name": "TEST_USER_PASSWORD",
+      "description": "Password for the automated-test user",
+      "how_to_add": "Add the value using the project's secret-management process"
     }
   ]
 }
@@ -55,7 +55,7 @@ After running the test, write the structured result to `outputs/test_automation_
 | `bug.description` | if failed | Path to the bug description file you must create |
 | `bug.priority` | if failed | `High`, `Medium`, or `Low` (see priority rules below) |
 | `blocked_reason` | if blocked | One sentence: what is missing and why the test cannot run |
-| `missing[].type` | if blocked | `github_secret`, `github_variable`, `test_data`, or `external_file` |
+| `missing[].type` | if blocked | `secret`, `variable`, `test_data`, or `external_file` |
 | `missing[].name` | if blocked | Name of the secret/variable or short label for the data/file needed |
 | `missing[].description` | if blocked | Human-readable explanation of what it is |
 | `missing[].how_to_add` | if blocked | Exact `gh` command or human action to resolve the block |
@@ -72,11 +72,11 @@ After running the test, write the structured result to `outputs/test_automation_
 
 Always write **both** files:
 
-### `outputs/response.md` — Jira comment (Jira Markdown format)
+### `outputs/response.md` — tracker comment
 
 **Keep it short and factual. No filler, no repetition, no "In conclusion" paragraphs.**
 
-Use Jira Markdown syntax: `h2.`, `h3.`, `h4.`, `*bold*`, `_italic_`, `{code}`, `||table||`.
+Use the tracker-specific format provided by the project or provider instructions.
 
 Include:
 - Status: `✅ PASSED` or `❌ FAILED`
@@ -85,21 +85,21 @@ Include:
 - What passed / what failed (specific, not generic)
 - Test file: `{code}testing/tests/{TICKET-KEY}/test_{ticket_key}.py{code}`
 
-### `outputs/pr_body.md` — GitHub PR body (GitHub Markdown format)
+### `outputs/pr_body.md` — SCM PR body
 
 **Keep it short and factual. No filler, no repetition, no "In conclusion" paragraphs.**
 
-Use GitHub Markdown syntax: `##`, `**bold**`, ` ```code``` `.
+Use the SCM-specific format provided by the project or provider instructions.
 
 Include:
 - Status: `✅ PASSED` or `❌ FAILED`
 - What was automated (1-2 sentences)
 - How to run: the exact command
-- Jira ticket link
+- Source test case link
 
-### `outputs/bug_description.md` — Bug description (Jira Markdown, only when FAILED)
+### `outputs/bug_description.md` — Bug description (only when FAILED)
 
-Use Jira Markdown. Include:
+Use the tracker-specific format. Include:
 - `h4. Environment`
 - `h4. Steps to Reproduce` (numbered)
 - `h4. Expected Result`

--- a/instructions/test_cases/test_case_creation_rules.md
+++ b/instructions/test_cases/test_case_creation_rules.md
@@ -11,7 +11,7 @@ Examples:
 
 ## Structure
 
-Every test case must contain the following sections in Jira Markdown:
+Every test case must contain the following sections using the target tracker format:
 
 ```
 h4. Objective
@@ -57,7 +57,7 @@ For each acceptance criterion or feature, generate:
 
 Generate test cases that cover:
 - All acceptance criteria listed in the story
-- Main integration points with external systems (Jira, GitHub, AI providers)
+- Main integration points with external systems (tracker, SCM, AI providers, or project services)
 - Error handling and failure scenarios described in the story
 - Security-relevant behaviors (permissions, token handling, unauthorized access)
 

--- a/instructions/tracker/jira_comment_format.md
+++ b/instructions/tracker/jira_comment_format.md
@@ -1,0 +1,14 @@
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+

--- a/instructions/tracker/jira_wiki_markup.md
+++ b/instructions/tracker/jira_wiki_markup.md
@@ -1,0 +1,13 @@
+# Jira wiki markup
+
+Use this only when the target tracker field/comment expects Jira wiki markup.
+
+- Headings: `h2.`, `h3.`
+- Bold: `*bold*`
+- Italic: `_italic_`
+- Bullet lists: `* item`
+- Tables: `||Header||` and `|value|`
+- Code blocks: `{code}...{code}` or `{noformat}...{noformat}`
+- Mermaid diagrams: `{code:mermaid}...{code}` if supported by the target field.
+- Do not use Markdown headings, triple backticks, or Markdown tables in Jira wiki fields.
+

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -14,7 +14,7 @@
  *   - smRules, smMergeRules: FULL REPLACEMENT when provided
  *   - repository, git, formats, confluence: DEEP MERGE
  *   - additionalInstructions, instructionOverrides, cliPrompts, cliPromptOverrides, agentParamPatches:
- *     FULL REPLACEMENT per key
+ *     FULL REPLACEMENT when provided
  */
 
 var DEFAULT_CONFIG = require('./config.js');
@@ -464,10 +464,11 @@ function resolveConfluenceUrls(items, config) {
  * @param {string} agentName - Agent config name (e.g., 'story_development')
  * @param {string[]} defaultInstructions - Default instructions from agent JSON
  * @param {Object} config - Loaded project config
- * @returns {Object} { instructions: string[], additionalInstructions: string[], cliPrompts: string[], cliPrompt: string|null, agentParamPatch: Object|null }
+ * @returns {Object} { instructions: string[], instructionsOverridden: boolean, additionalInstructions: string[], cliPrompts: string[], cliPrompt: string|null, agentParamPatch: Object|null }
  */
 function resolveInstructions(agentName, defaultInstructions, config) {
     var instructions = defaultInstructions || [];
+    var instructionsOverridden = false;
     var additional = [];
     var cliPrompts = [];
     var cliPrompt = null;
@@ -476,6 +477,7 @@ function resolveInstructions(agentName, defaultInstructions, config) {
     // Full override if instructionOverrides has this agent
     if (config.instructionOverrides && config.instructionOverrides[agentName]) {
         instructions = config.instructionOverrides[agentName];
+        instructionsOverridden = true;
     } else {
         // Resolve Confluence URLs in default instructions
         instructions = resolveConfluenceUrls(instructions, config);
@@ -500,6 +502,7 @@ function resolveInstructions(agentName, defaultInstructions, config) {
 
     return {
         instructions: instructions,
+        instructionsOverridden: instructionsOverridden,
         additionalInstructions: additional,
         cliPrompts: cliPrompts,
         cliPrompt: cliPrompt,

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -13,7 +13,8 @@
  *   - jira.statuses, jira.issueTypes, jira.questions, labels: FULL REPLACEMENT when provided
  *   - smRules, smMergeRules: FULL REPLACEMENT when provided
  *   - repository, git, formats, confluence: DEEP MERGE
- *   - additionalInstructions, instructionOverrides: FULL REPLACEMENT per key
+ *   - additionalInstructions, instructionOverrides, cliPrompts, cliPromptOverrides, agentParamPatches:
+ *     FULL REPLACEMENT per key
  */
 
 var DEFAULT_CONFIG = require('./config.js');
@@ -89,13 +90,16 @@ var DEFAULTS = {
     smRules: null,
     smMergeRules: null,
 
-    // Base directory for agent JSON configs (e.g. "ai_teammate/AITS").
+    // Base directory for agent JSON configs (e.g. "projects/alpha").
     // When set, smRules.configFile values without a "/" are resolved relative to this dir.
     // Allows config.js to own the full picture: repo, jira, rules, and agent paths.
     agentConfigsDir: null,
 
     additionalInstructions: {},
     instructionOverrides: {},
+    cliPrompts: {},
+    cliPromptOverrides: {},
+    agentParamPatches: {},
 
     scm: {
         provider: 'github'   // 'github' | 'ado' — source control provider for PR operations
@@ -180,6 +184,15 @@ function mergeProjectConfig(defaults, overrides) {
     }
     if (overrides.instructionOverrides) {
         result.instructionOverrides = overrides.instructionOverrides;
+    }
+    if (overrides.cliPrompts) {
+        result.cliPrompts = overrides.cliPrompts;
+    }
+    if (overrides.cliPromptOverrides) {
+        result.cliPromptOverrides = overrides.cliPromptOverrides;
+    }
+    if (overrides.agentParamPatches) {
+        result.agentParamPatches = overrides.agentParamPatches;
     }
 
     return result;
@@ -451,11 +464,14 @@ function resolveConfluenceUrls(items, config) {
  * @param {string} agentName - Agent config name (e.g., 'story_development')
  * @param {string[]} defaultInstructions - Default instructions from agent JSON
  * @param {Object} config - Loaded project config
- * @returns {Object} { instructions: string[], additionalInstructions: string[] }
+ * @returns {Object} { instructions: string[], additionalInstructions: string[], cliPrompts: string[], cliPrompt: string|null, agentParamPatch: Object|null }
  */
 function resolveInstructions(agentName, defaultInstructions, config) {
     var instructions = defaultInstructions || [];
     var additional = [];
+    var cliPrompts = [];
+    var cliPrompt = null;
+    var agentParamPatch = null;
 
     // Full override if instructionOverrides has this agent
     if (config.instructionOverrides && config.instructionOverrides[agentName]) {
@@ -470,9 +486,24 @@ function resolveInstructions(agentName, defaultInstructions, config) {
         additional = config.additionalInstructions[agentName];
     }
 
+    if (config.cliPrompts && config.cliPrompts[agentName]) {
+        cliPrompts = config.cliPrompts[agentName];
+    }
+
+    if (config.cliPromptOverrides && config.cliPromptOverrides[agentName]) {
+        cliPrompt = config.cliPromptOverrides[agentName];
+    }
+
+    if (config.agentParamPatches && config.agentParamPatches[agentName]) {
+        agentParamPatch = config.agentParamPatches[agentName];
+    }
+
     return {
         instructions: instructions,
-        additionalInstructions: additional
+        additionalInstructions: additional,
+        cliPrompts: cliPrompts,
+        cliPrompt: cliPrompt,
+        agentParamPatch: agentParamPatch
     };
 }
 
@@ -492,4 +523,3 @@ module.exports = {
     resolveInstructions: resolveInstructions,
     createScm: _scmModule ? _scmModule.createScm : function() { throw new Error('scm.js not available in this environment'); }
 };
-

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -99,6 +99,16 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig) {
         if (resolved.additionalInstructions && resolved.additionalInstructions.length > 0) {
             p.additionalInstructions = resolved.additionalInstructions;
         }
+        if (resolved.cliPrompts && resolved.cliPrompts.length > 0) {
+            p.cliPrompts = resolved.cliPrompts;
+        }
+        if (resolved.cliPrompt) {
+            p.cliPrompt = resolved.cliPrompt;
+        }
+        if (resolved.agentParamPatch) {
+            if (!p.agentParams) p.agentParams = {};
+            p.agentParams = configLoader.deepMerge(p.agentParams, resolved.agentParamPatch);
+        }
 
         // Inject project-specific field name overrides from jira.fields config
         var jiraFields = effectiveConfig.jira && effectiveConfig.jira.fields;
@@ -134,8 +144,8 @@ function extractAgentName(configFile) {
 /**
  * Resolve the full path to an agent config JSON.
  * If rule.configFile is a bare filename (no "/"), prefix with agentConfigsDir from config.
- * Example: "TestCasesGenerator.json" + agentConfigsDir "ai_teammate/AITS"
- *        → "ai_teammate/AITS/TestCasesGenerator.json"
+ * Example: "TestCasesGenerator.json" + agentConfigsDir "projects/alpha"
+ *        → "projects/alpha/TestCasesGenerator.json"
  */
 function resolveConfigFile(rule, effectiveConfig) {
     var cf = rule.configFile;
@@ -483,4 +493,3 @@ function action(params) {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = { action: action };
 }
-

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -92,7 +92,7 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig) {
         var agentName = extractAgentName(resolvedCf);
         var resolved = configLoader.resolveInstructions(agentName, null, effectiveConfig);
 
-        if (resolved.instructions) {
+        if (resolved.instructionsOverridden) {
             if (!p.agentParams) p.agentParams = {};
             p.agentParams.instructions = resolved.instructions;
         }

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -375,6 +375,37 @@ suite('configLoader.resolveInstructions', function() {
         assert.deepEqual(result.additionalInstructions, ['./extra.md']);
     });
 
+    test('resolves cliPrompts and cliPromptOverrides separately', function() {
+        var config = configLoaderModule.mergeProjectConfig(defaults, {
+            cliPrompts: {
+                story_development: ['./.dmtools/prompts/role.md', './.dmtools/prompts/focus.md']
+            },
+            cliPromptOverrides: {
+                story_development: './.dmtools/prompts/main.md'
+            }
+        });
+        var result = configLoaderModule.resolveInstructions('story_development', ['./base.md'], config);
+        assert.deepEqual(result.instructions, ['./base.md']);
+        assert.deepEqual(result.cliPrompts, ['./.dmtools/prompts/role.md', './.dmtools/prompts/focus.md']);
+        assert.equal(result.cliPrompt, './.dmtools/prompts/main.md');
+    });
+
+    test('resolves agentParamPatches per agent', function() {
+        var config = configLoaderModule.mergeProjectConfig(defaults, {
+            agentParamPatches: {
+                story_development: {
+                    aiRole: 'Senior Engineer',
+                    instructions: ['./custom.md']
+                }
+            }
+        });
+        var result = configLoaderModule.resolveInstructions('story_development', ['./base.md'], config);
+        assert.deepEqual(result.agentParamPatch, {
+            aiRole: 'Senior Engineer',
+            instructions: ['./custom.md']
+        });
+    });
+
     test('agent not in overrides returns default + empty additional', function() {
         var config = configLoaderModule.mergeProjectConfig(defaults, {
             instructionOverrides: { other_agent: ['./other.md'] }

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -333,6 +333,7 @@ suite('configLoader.resolveInstructions', function() {
         var defaultInstructions = ['./agents/instructions/default.md', 'some text'];
         var result = configLoaderModule.resolveInstructions('story_development', defaultInstructions, config);
         assert.deepEqual(result.instructions, defaultInstructions);
+        assert.equal(result.instructionsOverridden, false);
         assert.deepEqual(result.additionalInstructions, []);
     });
 
@@ -348,6 +349,7 @@ suite('configLoader.resolveInstructions', function() {
             config
         );
         assert.deepEqual(result.instructions, ['./custom/dev-instructions.md']);
+        assert.equal(result.instructionsOverridden, true);
     });
 
     test('applies additionalInstructions — appended separately', function() {
@@ -413,6 +415,7 @@ suite('configLoader.resolveInstructions', function() {
         var base = ['./base.md'];
         var result = configLoaderModule.resolveInstructions('story_development', base, config);
         assert.deepEqual(result.instructions, base);
+        assert.equal(result.instructionsOverridden, false);
         assert.deepEqual(result.additionalInstructions, []);
     });
 

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -538,6 +538,7 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.notOk(decoded.params.additionalInstructions, 'no additionalInstructions when not configured');
+        assert.equal(decoded.params.agentParams.instructions.length, 2, 'default agent instructions preserved');
     });
 
     test('injects cliPrompts and agent param patches from config into encoded_config', function() {

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -540,6 +540,40 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         assert.notOk(decoded.params.additionalInstructions, 'no additionalInstructions when not configured');
     });
 
+    test('injects cliPrompts and agent param patches from config into encoded_config', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js':
+                    'module.exports = {' +
+                    '  jira: { project: "P" },' +
+                    '  repository: { owner: "o", repo: "r" },' +
+                    '  cliPromptOverrides: {' +
+                    '    story_development: "./.dmtools/prompts/main.md"' +
+                    '  },' +
+                    '  cliPrompts: {' +
+                    '    story_development: ["./.dmtools/prompts/role.md", "./.dmtools/prompts/focus.md"]' +
+                    '  },' +
+                    '  agentParamPatches: {' +
+                    '    story_development: { aiRole: "Senior Engineer", customFlag: true }' +
+                    '  }' +
+                    '};'
+            },
+            tickets: [{ key: 'P-2', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", { configFile: 'agents/story_development.json' })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 1);
+        var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
+        var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
+        assert.equal(decoded.params.cliPrompt, './.dmtools/prompts/main.md');
+        assert.deepEqual(decoded.params.cliPrompts, ['./.dmtools/prompts/role.md', './.dmtools/prompts/focus.md']);
+        assert.equal(decoded.params.agentParams.aiRole, 'Senior Engineer');
+        assert.equal(decoded.params.agentParams.customFlag, true);
+    });
+
 });
 
 // ── targetStatus ──────────────────────────────────────────────────────────────

--- a/pr_review.json
+++ b/pr_review.json
@@ -16,9 +16,6 @@
       "fewShots": "./agents/instructions/review/pr_review_few_shots.md"
     },
     "cliPrompt": "./agents/prompts/pr_review_prompt.md",
-    "cliPrompts": [
-      "./cliPrompts/pr_review_mapc.md"
-    ],
     "cliCommands": [
       "./agents/scripts/run-agent.sh"
     ],

--- a/pr_rework.json
+++ b/pr_rework.json
@@ -15,9 +15,6 @@
       "fewShots": ""
     },
     "cliPrompt": "./agents/prompts/pr_rework_prompt.md",
-    "cliPrompts": [
-      "./cliPrompts/pr_rework_mapc.md"
-    ],
     "cliCommands": [
       "./agents/scripts/run-agent.sh"
     ],

--- a/prompts/bug_creation_prompt.md
+++ b/prompts/bug_creation_prompt.md
@@ -69,7 +69,7 @@ Write `outputs/bug_decision.json` with exactly one of these formats:
 }
 ```
 
-If action is `create`, also write `outputs/bug_description.md` with a clear bug **CRITICAL IMPORTANT** description in Jira Markdown format:
+If action is `create`, also write `outputs/bug_description.md` with a clear bug **CRITICAL IMPORTANT** description in the target tracker format:
 - Steps to reproduce (from the Test Case steps)
 - Expected result
 - Actual result (what the test detected)

--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -93,29 +93,3 @@ See `bug_implementation_instructions.md` for the required format (RCA summary, f
 **OUT OF SCOPE**: E2E automation is not part of this task.
 
 DO NOT create branches or push — focus only on code implementation. You must compile and run tests before finishing.
-
-## BICE Project — Maven Build Commands
-
-This is a Java/Maven project using the Cosmo test framework. **Always use `$JAVA_HOME_COSMO`** when running Maven (Java 17, pre-configured by the dependency setup).
-
-**Verify build compiles cleanly** (run this first after any code change):
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn install -DskipTests --no-transfer-progress 2>&1 | grep -E 'BUILD|ERROR'
-```
-Expected: `[INFO] BUILD SUCCESS`. If you see `[ERROR] COMPILATION ERROR`, fix compile errors before proceeding.
-
-**Run unit tests** (replace `<ModuleName>` and `<TestClassName>` with the actual values):
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn test -pl <ModuleName> -Dtest=<TestClassName> -Denforcer.skip=true \
-  --no-transfer-progress 2>&1 | tail -30
-```
-Example for `cosmo-core`: `-pl cosmo-core`
-
-**Run all unit tests in a module**:
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn test -pl cosmo-core -Denforcer.skip=true \
-  --no-transfer-progress 2>&1 | tail -30
-```

--- a/prompts/bug_rca_prompt.md
+++ b/prompts/bug_rca_prompt.md
@@ -39,7 +39,7 @@ The root cause must be a **specific code-level finding**: a wrong condition, mis
 
 > **⚠️ CRITICAL — output paths are exact. Do NOT create subdirectories.**
 > Write output to:
-> - `outputs/response.md` — RCA document (Jira wiki markup)
+> - `outputs/response.md` — RCA document in the target tracker format
 > - `outputs/diagram.md` — Mermaid diagram
 >
 > **Do NOT write to `outputs/{ticketKey}/response.md` or any subdirectory.** The post-processing pipeline reads from the root `outputs/` path. Writing to a subdirectory will cause the RCA to be silently discarded and never submitted to Jira.

--- a/prompts/intake_prompt.md
+++ b/prompts/intake_prompt.md
@@ -17,7 +17,7 @@ List ALL files in `input/` to find any non-standard files (images, PDFs, ZIPs, m
 3. Build a mental map of what pages/flows/features already exist and what entry points are already covered.
 4. Only then proceed to identify gaps and create new tickets.
 
-Analyse the request, break it into structured Jira tickets (Epics or Stories), then:
+Analyse the request, break it into structured tracker work items (for example Epics or Stories), then:
 1. Write individual description files to outputs/stories/ (story-1.md, story-2.md, ...)
 2. Write outputs/stories.json with the ticket plan
 3. Write outputs/comment.md with your intake analysis summary

--- a/prompts/pr_review_minimal.md
+++ b/prompts/pr_review_minimal.md
@@ -1,0 +1,13 @@
+# PR review
+
+Use the configured instruction files and prompt packs.
+
+Required flow:
+
+1. Read the input context.
+2. Inspect the diff and relevant surrounding code.
+3. Check previous review threads and CI failures when present.
+4. Produce the required output files.
+
+Do not edit code.
+

--- a/prompts/pr_review_prompt.md
+++ b/prompts/pr_review_prompt.md
@@ -28,7 +28,7 @@ To answer it:
 4. Look at the **surrounding code**, not just the changed lines. A fix can be technically correct in isolation but miss the real problem because of something adjacent (wrong config, missing route, different code path that's actually triggered).
 5. If the PR includes tests — check that the tests actually reproduce the user's symptom, not just a tangentially related scenario.
 
-If you conclude the changes **do not fully solve the user's problem**, raise it as a 🚨 BLOCKING issue with a clear explanation of what is missing.
+If you conclude the changes **do not fully solve the user's problem**, raise it as a 🚨 BLOCKING issue with a clear explanation of what is missing but **if you know and highlight root cause** do it.
 
 # Review Priorities
 1. ✅ **Actually solves the user's problem** (HIGHEST PRIORITY — see above)
@@ -71,10 +71,11 @@ Verify:
 
 ## 🧪 Test Automation Results Analysis (Critical)
 
-Check `pr_discussions.md` for comments from test automation bots (e.g., comments titled **🤖 Maestro Test Results** or similar). If present, perform a **deep analysis**:
+Check `pr_discussions.md` for comments from test automation bots. If present, perform a **deep analysis**:
 
 ### ⚠️ CRITICAL RULE: Never dismiss test automation warnings as "tool limitations"
 Test automation tools capture the **real runtime state** of the application — the actual accessibility tree, UI hierarchy, and behavior. If automation reports that an element is missing from the accessibility tree, screen readers will NOT see it either. **Do NOT write** that warnings are "tool limitations", "simulator limitations", or "likely work on real devices" — test automation runtime data reflects the real behavior.
+Code which is written must be accessible by automation tests executions.
 
 ### ⚠️ CRITICAL RULE: Evidence hierarchy — runtime data beats code comments
 When evaluating whether a fix works, follow this strict evidence hierarchy:
@@ -84,11 +85,13 @@ When evaluating whether a fix works, follow this strict evidence hierarchy:
 3. **Code comments / developer explanations** (what the developer INTENDED)
 
 **Never trust code comments as evidence that a fix works.** Code comments explain intent, not actual behavior. If a code comment says "this ensures accessibility traversal works" but automation shows 0 children — the comment is wrong, the fix doesn't work.
+**IMPORTANT GOAL** confirm the code works as expected and really solves issue. **NEVER TRUST DEVELOPER, CHEKC AND CONFIRM ITSELF**.
 
 ### ⚠️ CRITICAL RULE: Never trust developer rework as evidence
 When reviewing after a rework cycle, the rework agent's code changes and commit messages are NOT evidence that the issue is fixed. **Only two sources of truth exist:**
 1. **Reviewer comments** — the original reviewer who flagged the issue
 2. **Test automation data** — runtime results from the latest build
+**IMPORTANT** ALL THE COMMENTS CAN BE FROM SAME ACCOUNT!
 
 If the rework claims "Fixed: moved accessibilityViewIsModal to correct location" but test automation STILL reports 0 children — the fix FAILED. Do NOT approve based on the rework's explanation. Do NOT rationalize persistent warnings as "expected behavior" or "architecture limitation".
 
@@ -107,7 +110,7 @@ If this is a re-review after a rework cycle, check whether the rework actually f
 Running automation is expensive (CI time, simulator/emulator, real devices). PR review is cheap. The reviewer's job is to **analyze whether the current code in the PR addresses the failures reported by automation** — not to gatekeep on a fresh post-commit automation run.
 
 **Workflow**:
-1. Automation runs, posts failures (e.g., "Calendar blank, 0 a11y children on iOS").
+1. Automation runs, posts failures (e.g., "Profile blank, 0 a11y children on iOS").
 2. Developer pushes a fix.
 3. **Reviewer analyzes the diff** against the automation failure:
    - Does the new code logically address the reported root cause? (e.g., fix swaps `BottomSheetFlatList` → `RNGH FlatList + nestedScrollEnabled` to address the iOS FullWindowOverlay a11y tree issue → YES, this directly addresses the reported failure.)
@@ -212,7 +215,7 @@ This is the machine-readable result consumed by the post-action. If it is missin
       "path": "src/components/Button.tsx",
       "line": 42,
       "side": "RIGHT",
-      "body": "Write your comment text directly here in GitHub Markdown — do NOT use a file path",
+      "body": "Write your comment text directly here in the SCM review-comment format — do NOT use a file path",
       "severity": "BLOCKING|IMPORTANT|SUGGESTION"
     }
   ],

--- a/prompts/pr_review_prompt.md
+++ b/prompts/pr_review_prompt.md
@@ -28,7 +28,7 @@ To answer it:
 4. Look at the **surrounding code**, not just the changed lines. A fix can be technically correct in isolation but miss the real problem because of something adjacent (wrong config, missing route, different code path that's actually triggered).
 5. If the PR includes tests — check that the tests actually reproduce the user's symptom, not just a tangentially related scenario.
 
-If you conclude the changes **do not fully solve the user's problem**, raise it as a 🚨 BLOCKING issue with a clear explanation of what is missing but **if you know and highlight root cause** do it.
+If you conclude the changes **do not fully solve the user's problem**, raise it as a 🚨 BLOCKING issue. Explain what is missing, and when the root cause is identifiable from the context, state that root cause explicitly.
 
 # Review Priorities
 1. ✅ **Actually solves the user's problem** (HIGHEST PRIORITY — see above)
@@ -85,7 +85,7 @@ When evaluating whether a fix works, follow this strict evidence hierarchy:
 3. **Code comments / developer explanations** (what the developer INTENDED)
 
 **Never trust code comments as evidence that a fix works.** Code comments explain intent, not actual behavior. If a code comment says "this ensures accessibility traversal works" but automation shows 0 children — the comment is wrong, the fix doesn't work.
-**IMPORTANT GOAL** confirm the code works as expected and really solves issue. **NEVER TRUST DEVELOPER, CHEKC AND CONFIRM ITSELF**.
+**IMPORTANT GOAL:** confirm that the code works as expected and really solves the issue. Never rely on developer claims alone; check the evidence and verify the behavior yourself.
 
 ### ⚠️ CRITICAL RULE: Never trust developer rework as evidence
 When reviewing after a rework cycle, the rework agent's code changes and commit messages are NOT evidence that the issue is fixed. **Only two sources of truth exist:**

--- a/prompts/pr_rework_minimal.md
+++ b/prompts/pr_rework_minimal.md
@@ -1,0 +1,14 @@
+# PR rework
+
+Use the configured instruction files and prompt packs.
+
+Required flow:
+
+1. Read the input context and open review threads.
+2. Fix merge conflicts and CI failures first.
+3. Address every actionable review comment.
+4. Run relevant checks for changed files.
+5. Write required files in `outputs/`.
+
+Do not commit, push, or create branches.
+

--- a/prompts/pr_rework_prompt.md
+++ b/prompts/pr_rework_prompt.md
@@ -21,9 +21,9 @@ You are fixing code issues identified in a Pull Request review.
 Your mission is to address every issue raised in `pr_discussions.md`. This includes:
 
 1. **Human review threads** — inline code review comments with `rootCommentId` and `threadId`. These MUST be fixed and replied to in `review_replies.json`.
-2. **🤖 Maestro Test Results** — comments titled "🤖 Maestro Test Results" containing test automation results with a11y structural warnings. These have `rootCommentId: null` because they are PR comments (not review threads), but they contain **real, actionable bugs** that MUST be fixed. See the Maestro analysis section below.
+2. **Automated test results** — PR comments from test automation tools containing failures or structural warnings. These may have `rootCommentId: null` because they are PR comments (not review threads), but they can contain **real, actionable bugs** that MUST be fixed.
 
-**Ignore only**: bot ticket-link comments (e.g. "MAPC-XXXX ...link..."), previous rework summary comments, and automated code review APPROVE comments — these are informational and require no action.
+**Ignore only**: bot ticket-link comments (e.g. "TICKET-123 ...link..."), previous rework summary comments, and automated code review APPROVE comments — these are informational and require no action.
 
 ### 🛑 STALE AUTOMATION LOOP — DO NOT REPEAT YOURSELF
 
@@ -35,7 +35,7 @@ If the only "blocker" is the reviewer asking for fresh post-fix automation, and 
 
 The reviewer's job is to APPROVE based on code analysis (review is cheaper than re-running automation). If you keep posting "Rework Complete" you keep retriggering the reviewer.
 
-If `pr_discussions.md` contains NO actionable items (no human review threads AND no Maestro failures/warnings), then there is **nothing to fix** — write a short `outputs/response.md` stating "No open review comments to address" and an empty `outputs/review_replies.json` (`{ "replies": [] }`), then exit. **Do NOT post multiple acknowledgment comments.**
+If `pr_discussions.md` contains NO actionable items (no human review threads AND no automated test failures/warnings), then there is **nothing to fix** — write a short `outputs/response.md` stating "No open review comments to address" and an empty `outputs/review_replies.json` (`{ "replies": [] }`), then exit. **Do NOT post multiple acknowledgment comments.**
 
 ### Fixing human review threads
 For each thread:
@@ -49,7 +49,7 @@ For each thread:
 
 ### 🧪 Fixing Test Automation Results (CRITICAL)
 
-When `pr_discussions.md` contains test automation results (e.g., **🤖 Maestro Test Results**), you MUST analyze them in detail:
+When `pr_discussions.md` contains automated test results, you MUST analyze them in detail:
 
 1. **Failed tests (❌)** — these indicate real bugs found by running automation on the actual build from this PR branch. The failure reason tells you exactly what's wrong.
 

--- a/prompts/pr_test_automation_review_prompt.md
+++ b/prompts/pr_test_automation_review_prompt.md
@@ -21,7 +21,7 @@ This is the machine-readable result consumed by the post-action. If it is missin
 **⚠️ CRITICAL — `recommendation` field**: Use EXACTLY `"APPROVE"`, `"REQUEST_CHANGES"`, or `"BLOCK"`. Never `"APPROVED"` (with extra D). Never use `"verdict"` as the field name.
 
 ### 2. `outputs/pr_review_general.md` — REQUIRED
-GitHub-formatted general PR comment (referenced in `pr_review.json` → `generalComment`).
+SCM-formatted general PR comment (referenced in `pr_review.json` → `generalComment`).
 
 ### 3. `outputs/response.md` — REQUIRED
-Jira-formatted review summary posted as a ticket comment.
+Tracker-formatted review summary posted as a ticket comment.

--- a/prompts/pr_test_automation_rework_prompt.md
+++ b/prompts/pr_test_automation_rework_prompt.md
@@ -30,8 +30,8 @@ Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `inp
 
 Run `mkdir -p outputs` first to ensure the directory exists.
 
-- `outputs/response.md` — rework summary in **Jira Markdown** (short, factual): what was fixed + new test result
-- `outputs/pr_body.md` — same content in **GitHub Markdown** (always required — posted as GitHub PR comment; use standard MD: `##`, `**bold**`, backticks — NOT Jira syntax like `h3.`, `*bold*`, `{code}`)
+- `outputs/response.md` — tracker-formatted rework summary (short, factual): what was fixed + new test result
+- `outputs/pr_body.md` — SCM-formatted PR/comment body (always required)
 - `outputs/test_automation_result.json` — **MANDATORY — always write this file**, even if the test failed or errored. Use exactly this format:
   ```json
   { "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
@@ -42,4 +42,4 @@ Run `mkdir -p outputs` first to ensure the directory exists.
   ```
   The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
 - `outputs/review_replies.json` — replies per thread: `{ "replies": [{ "inReplyToId": 123, "threadId": "PRRT_...", "reply": "Fixed: ..." }] }`
-- `outputs/bug_description.md` — updated bug description in Jira Markdown (only if test still FAILED)
+- `outputs/bug_description.md` — updated tracker-formatted bug description (only if test still FAILED)

--- a/prompts/questions_prompt.md
+++ b/prompts/questions_prompt.md
@@ -11,16 +11,10 @@ List the input folder with `ls -la input/` and then the ticket subfolder (e.g. `
 - Text/markdown files: read with `cat`
 - Image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`): **view them using the Read tool** — they may contain UI mockups, designs, or screenshots that are essential context. If an image shows a design or UI, describe what you see and use it to avoid asking questions that are already answered by the design.
 
-**CRITICAL: Description files MUST be written in Jira wiki markup format — NOT Markdown.**
-- Use `h2.`, `h3.` for headings (NOT `##`)
-- Use `*bold*` (NOT `**bold**`)
-- Use `_italic_` (NOT `_italic_` with underscores in Markdown sense)
-- Use `* item` for bullet lists (NOT `-`)
-- Use `||col1||col2||` for table headers, `|val1|val2|` for rows
-- Do NOT use triple backticks — use `{code}...{code}` or `{noformat}...{noformat}`
+**CRITICAL: Description files must follow the tracker-specific formatting rules provided in `request.md`, formatting instructions, or provider modules.**
 
 **CRITICAL: Description files must NEVER contain a title line.**
-The `summary` field in `questions.json` becomes the Jira subtask title automatically. Writing a title inside the description file creates a duplicate heading visible in Jira.
+The `summary` field in `questions.json` becomes the generated subtask title automatically. Writing a title inside the description file creates a duplicate heading in the tracker.
 
 If a question template you are following shows a `Title:` field — that value goes into the `summary` field of `questions.json`, NOT into the description `.md` file. The `.md` file starts directly with the body content.
 
@@ -58,7 +52,7 @@ Write individual description files to outputs/questions/ and the question plan t
 ```json
 [
   {
-    "summary": "Confirm SOQL query strategy for bulk order retrieval",
+    "summary": "Confirm query strategy for bulk data retrieval",
     "priority": "Major",
     "description": "outputs/questions/question-1.md"
   },

--- a/prompts/story_description_prompt.md
+++ b/prompts/story_description_prompt.md
@@ -17,4 +17,4 @@ List the input folder with `ls -la input/*/` and read every file found:
 
 **IMPORTANT** Before writing, investigate the target codebase and dependencies to understand the current implementation, existing patterns, and any relevant code that relates to the story. Use CLI (`find`, `ls`, `cat`) to explore. Do not make assumptions that can be verified from the code.
 
-**IMPORTANT** Strictly follow the formatting rules provided in instructions or in `request.md`. If Jira Markdown is specified — you MUST write the output in Jira Markdown syntax (e.g. `*bold*`, `_italic_`, `h3.`, `||table||`, `{code}`, `#` for lists). Only use free-form text if no formatting rules are specified anywhere.
+**IMPORTANT** Strictly follow the formatting rules provided in instructions or in `request.md`. Use tracker-specific markup only when that provider format is explicitly specified. Only use free-form text if no formatting rules are specified anywhere.

--- a/prompts/story_development_prompt.md
+++ b/prompts/story_development_prompt.md
@@ -15,33 +15,7 @@ Implement the ticket requirements including code implementation and unit tests. 
 
 DO NOT create branches or push — focus only on code implementation. You must compile and run tests before finishing.
 
-## BICE Project — Maven Build Commands
-
-This is a Java/Maven project using the Cosmo test framework. **Always use `$JAVA_HOME_COSMO`** when running Maven (Java 17, pre-configured by the dependency setup).
-
-**Verify build compiles cleanly** (run this first after any code change):
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn install -DskipTests --no-transfer-progress 2>&1 | grep -E 'BUILD|ERROR'
-```
-Expected: `[INFO] BUILD SUCCESS`. If you see `[ERROR] COMPILATION ERROR`, fix compile errors before proceeding.
-
-**Run unit tests** (replace `<ModuleName>` and `<TestClassName>` with the actual values):
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn test -pl <ModuleName> -Dtest=<TestClassName> -Denforcer.skip=true \
-  --no-transfer-progress 2>&1 | tail -30
-```
-Example for `cosmo-core`: `-pl cosmo-core`
-
-**Run all unit tests in a module**:
-```bash
-cd dependencies/PostNL-commercial/tests/cosmo && \
-  JAVA_HOME=$JAVA_HOME_COSMO mvn test -pl cosmo-core -Denforcer.skip=true \
-  --no-transfer-progress 2>&1 | tail -30
-```
-
-Write `outputs/response.md` as the **PR description** (this will be published as the GitHub PR body — write technical detail here):
+Write `outputs/response.md` as the PR description:
 - Implementation approach and key decisions
 - Summary of files changed and why
 - How to verify the fix / test results

--- a/prompts/story_solution_prompt.md
+++ b/prompts/story_solution_prompt.md
@@ -14,9 +14,8 @@ List the input folder with `ls -la input/*/` and read every file found:
 **IMPORTANT** Write the solution design to outputs/response.md and the Mermaid diagram to outputs/diagram.md.
 
 **CRITICAL: OUTPUT FORMAT**
-- The output MUST be written in **Jira wiki markup** format. Check `request.md` and `formattingRules` for the exact format — use it strictly.
-- Use `h2.`, `h3.` for headings, `*bold*`, `_italic_`, `||header||` for tables, `* item` for bullet lists, `{code:mermaid}...{code}` for diagrams.
-- Do NOT use Markdown syntax (no `##`, no `**bold**`, no backtick code fences with triple backticks).
+- The output MUST follow the formatting rules provided in `request.md`, `formattingRules`, or provider-specific modules.
+- Do not assume a tracker markup dialect unless it is explicitly specified.
 
 **CRITICAL: NO CODE IN SOLUTION**
 - This is a high-level Solution Design — NOT an implementation guide.

--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -43,7 +43,7 @@ Run `mkdir -p outputs` first to ensure the directory exists.
   The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
 - `outputs/bug_description.md` — detailed tracker-formatted bug report (only if test FAILED)
 
-`response.md` and `pr_body.md` contain the same information but formatted differently — Jira MD vs GitHub MD.
+`response.md` and `pr_body.md` contain the same information but are formatted for different consumers: tracker comment vs SCM pull request body.
 
 ## ⚠️ CRITICAL: When the test FAILS — write a detailed bug report
 

--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -30,8 +30,8 @@ Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `inp
 
 Run `mkdir -p outputs` first to ensure the directory exists.
 
-- `outputs/response.md` — test result summary in **Jira Markdown** (posted as Jira ticket comment)
-- `outputs/pr_body.md` — test result summary in **GitHub Markdown** (used as PR description)
+- `outputs/response.md` — tracker-formatted test result summary
+- `outputs/pr_body.md` — SCM-formatted test result summary
 - `outputs/test_automation_result.json` — **MANDATORY — always write this file**, even if the test failed or errored. Use exactly this format:
   ```json
   { "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
@@ -41,7 +41,7 @@ Run `mkdir -p outputs` first to ensure the directory exists.
   { "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
   ```
   The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
-- `outputs/bug_description.md` — detailed bug report in Jira Markdown (only if test FAILED)
+- `outputs/bug_description.md` — detailed tracker-formatted bug report (only if test FAILED)
 
 `response.md` and `pr_body.md` contain the same information but formatted differently — Jira MD vs GitHub MD.
 


### PR DESCRIPTION
## Summary
- add agent-prompt-architecture skill with project-safe prompt layering and GraalJS constraints
- split reusable review/platform/tracker/SCM prompt modules out of project-specific composition
- add .dmtools config support for cliPrompts, cliPromptOverrides, and agentParamPatches
- remove MAPC-specific cliPrompts from generic PR review/rework configs

## Validation
- node js/unit-tests/testRunner.js js/unit-tests/run_all.json
- git diff --check
- searched changed files for project leakage terms