### PR TITLE
Treat To Do as backlog in SM rules

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -36,15 +36,15 @@
           "addLabel": "sm_po_refinement_triggered"
         },
         {
-          "description": "Backlog Stories → ask clarification questions",
-          "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('Backlog')",
+          "description": "Backlog / To Do Stories → ask clarification questions",
+          "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('Backlog', 'To Do')",
           "configFile": "agents/story_questions.json",
           "skipIfLabel": "sm_story_questions_triggered",
           "addLabel": "sm_story_questions_triggered"
         },
         {
-          "description": "Backlog Tasks (children of parent ticket) → run intake agent",
-          "jql": "project = {jiraProject} AND issuetype in ('Task') AND status in ('Backlog') AND parent = {parentTicket}",
+          "description": "Backlog / To Do Tasks (children of parent ticket) → run intake agent",
+          "jql": "project = {jiraProject} AND issuetype in ('Task') AND status in ('Backlog', 'To Do') AND parent = {parentTicket}",
           "targetStatus": "In Development",
           "configFile": "agents/intake.json",
           "skipIfLabel": "sm_task_intake_triggered",
@@ -58,8 +58,8 @@
           "addLabel": "sm_story_development_triggered"
         },
         {
-          "description": "Backlog / Ready For Development Bugs → trigger bug_development",
-          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'Ready For Development')",
+          "description": "Backlog / To Do / Ready For Development Bugs → trigger bug_development",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development')",
           "configFile": "agents/bug_development.json",
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",
@@ -141,8 +141,8 @@
           "localExecution": true
         },
         {
-          "description": "Backlog Test Cases → In Development + automate",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Backlog')",
+          "description": "Backlog / To Do Test Cases → In Development + automate",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Backlog', 'To Do')",
           "targetStatus": "In Development",
           "configFile": "agents/test_case_automation.json",
           "skipIfLabel": "sm_test_automation_triggered",


### PR DESCRIPTION
## Summary
- include `To Do` alongside `Backlog` in SM startup rules
- cover story questions, intake tasks, bug development, and test case automation
- update rule descriptions to match the broader status matching

## Test plan
- parsed agents/sm.json as JSON
- inspected updated Backlog/To Do JQL rules