### PR TITLE
Add opt-in downstream agent chaining

### DIFF
--- a/js/assignForSolutionArchitecture.js
+++ b/js/assignForSolutionArchitecture.js
@@ -6,6 +6,9 @@
 
 const { extractTicketKey } = require('./common/jiraHelpers.js');
 const { LABELS, STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
+const scmModule = require('./common/scm.js');
+const autoStart = require('./common/autoStart.js');
 
 const ACCEPTANCE_CRITERIA_TRIGGER_LABELS = [
     'sm_story_acceptance_criteria_triggered',
@@ -19,6 +22,8 @@ function action(params) {
         var wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : null;
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
 
         // Assign to initiator (skip if accountId is not available)
         if (initiatorId) {
@@ -64,6 +69,25 @@ function action(params) {
                 console.warn('Failed to remove trigger label "' + label + '":', e);
             }
         });
+
+        var autoStartSolution = customParams.autoStartSolution === true ||
+            customParams.autoStartSolution === 'true';
+        var solutionConfigFile = customParams.autoStartSolutionConfigFile;
+        if (autoStartSolution && solutionConfigFile) {
+            try {
+                autoStart.triggerConfiguredWorkflowForTicket({
+                    scm: scmModule.createScm(projectConfig),
+                    config: projectConfig,
+                    ticketKey: ticketKey,
+                    customParams: customParams,
+                    configFile: solutionConfigFile,
+                    label: 'solution',
+                    stripKeys: ['autoStartSolution', 'autoStartSolutionConfigFile']
+                });
+            } catch (e) {
+                console.warn('⚠️ autoStartSolution trigger failed:', e.message || e);
+            }
+        }
 
         return {
             success: true,

--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -1,0 +1,78 @@
+var scmModule = require('./scm.js');
+
+function deriveProjectKey(customParams) {
+    if (!customParams) return '';
+    if (customParams.projectKey) return customParams.projectKey;
+    var cp = customParams.configPath || '';
+    if (!cp) return '';
+    var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
+    return (base && base !== 'config') ? base : '';
+}
+
+function buildAutoStartEncodedConfig(ticketKey, customParams, stripKeys) {
+    var p = { inputJql: 'key = ' + ticketKey };
+
+    if (customParams) {
+        var nextCustomParams = Object.assign({}, customParams);
+        (stripKeys || []).forEach(function(key) {
+            delete nextCustomParams[key];
+        });
+        if (Object.keys(nextCustomParams).length > 0) {
+            p.customParams = nextCustomParams;
+        }
+    }
+
+    return encodeURIComponent(JSON.stringify({ params: p }));
+}
+
+function triggerConfiguredWorkflowForTicket(options) {
+    var ticketKey = options.ticketKey;
+    var customParams = options.customParams || {};
+    var config = options.config || {};
+    var configFile = options.configFile;
+    var workflowFile = options.workflowFile || 'ai-teammate.yml';
+    var ref = options.ref || 'main';
+    var label = options.label || configFile || workflowFile;
+    var stripKeys = options.stripKeys || [];
+
+    if (!ticketKey || !configFile) {
+        console.warn('autoStart: missing ticketKey or configFile — skipping');
+        return false;
+    }
+
+    var aiRepoCfg = customParams.aiRepository;
+    var aiOwner = (aiRepoCfg && aiRepoCfg.owner) || (config.repository && config.repository.owner);
+    var aiRepo = (aiRepoCfg && aiRepoCfg.repo) || (config.repository && config.repository.repo);
+
+    if (!aiOwner || !aiRepo) {
+        console.warn('autoStart: config.repository.owner/repo not set — skipping');
+        return false;
+    }
+
+    var scm = options.scm || scmModule.createScm(config);
+    var projectKey = deriveProjectKey(customParams);
+    var encodedCfg = buildAutoStartEncodedConfig(ticketKey, customParams, stripKeys);
+
+    scm.triggerWorkflow(
+        aiOwner,
+        aiRepo,
+        workflowFile,
+        JSON.stringify({
+            concurrency_key: ticketKey,
+            config_file: configFile,
+            encoded_config: encodedCfg,
+            project_key: projectKey || ''
+        }),
+        ref
+    );
+
+    console.log('✅ Auto-started ' + label + ' for ' + ticketKey +
+        ' [config=' + configFile + (projectKey ? ', project=' + projectKey : '') + ']');
+    return true;
+}
+
+module.exports = {
+    deriveProjectKey: deriveProjectKey,
+    buildAutoStartEncodedConfig: buildAutoStartEncodedConfig,
+    triggerConfiguredWorkflowForTicket: triggerConfiguredWorkflowForTicket
+};

--- a/js/createQuestionsAndAssignForReview.js
+++ b/js/createQuestionsAndAssignForReview.js
@@ -17,6 +17,8 @@
 const { extractTicketKey } = require('./common/jiraHelpers.js');
 const { buildSummary } = require('./common/aiResponseParser.js');
 const configLoader = require('./configLoader.js');
+const scmModule = require('./common/scm.js');
+const autoStart = require('./common/autoStart.js');
 
 /**
  * Ensure summary starts with [Q] prefix
@@ -131,6 +133,7 @@ function action(params) {
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
         var jiraConfig = projectConfig.jira;
         var labels = projectConfig.labels;
+        var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
 
         console.log('Processing question creation for:', ticketKey);
 
@@ -206,6 +209,31 @@ function action(params) {
                 console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
             } catch (wipError) {
                 console.warn('Failed to remove WIP label:', wipError);
+            }
+        }
+
+        // 8. Optionally auto-start question answering for each created question
+        var autoStartQuestionAnswer = customParams.autoStartQuestionAnswer === true ||
+            customParams.autoStartQuestionAnswer === 'true';
+        var questionAnswerConfigFile = customParams.autoStartQuestionAnswerConfigFile;
+        if (autoStartQuestionAnswer && questionAnswerConfigFile) {
+            try {
+                var scm = scmModule.createScm(projectConfig);
+                createdTickets
+                    .filter(function(ticket) { return ticket.success && ticket.key; })
+                    .forEach(function(ticket) {
+                        autoStart.triggerConfiguredWorkflowForTicket({
+                            scm: scm,
+                            config: projectConfig,
+                            ticketKey: ticket.key,
+                            customParams: customParams,
+                            configFile: questionAnswerConfigFile,
+                            label: 'question answer',
+                            stripKeys: ['autoStartQuestionAnswer', 'autoStartQuestionAnswerConfigFile']
+                        });
+                    });
+            } catch (e) {
+                console.warn('⚠️ autoStartQuestionAnswer trigger failed:', e.message || e);
             }
         }
 

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -15,6 +15,9 @@
  */
 
 const { LABELS, DIAGRAM_FORMAT, JIRA_FIELDS, STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
+const scmModule = require('./common/scm.js');
+const autoStart = require('./common/autoStart.js');
 
 function action(params) {
     try {
@@ -26,6 +29,7 @@ function action(params) {
 
         // Resolve field names from customParams if provided
         var customParams = (params.customParams) || (params.jobParams && params.jobParams.customParams) || {};
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
         var solutionField = customParams.solutionField || JIRA_FIELDS.SOLUTION;
         var diagramField  = (customParams.diagramField !== undefined) ? customParams.diagramField : JIRA_FIELDS.DIAGRAMS;
         var outputType    = customParams.outputType || 'replace'; // 'replace' | 'append'
@@ -146,6 +150,25 @@ function action(params) {
                 console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
             } catch (e) {
                 console.warn('Failed to remove WIP label:', e);
+            }
+        }
+
+        var autoStartDevelopment = customParams.autoStartDevelopment === true ||
+            customParams.autoStartDevelopment === 'true';
+        var developmentConfigFile = customParams.autoStartDevelopmentConfigFile;
+        if (autoStartDevelopment && developmentConfigFile) {
+            try {
+                autoStart.triggerConfiguredWorkflowForTicket({
+                    scm: scmModule.createScm(projectConfig),
+                    config: projectConfig,
+                    ticketKey: ticketKey,
+                    customParams: customParams,
+                    configFile: developmentConfigFile,
+                    label: 'development',
+                    stripKeys: ['autoStartDevelopment', 'autoStartDevelopmentConfigFile']
+                });
+            } catch (e) {
+                console.warn('⚠️ autoStartDevelopment trigger failed:', e.message || e);
             }
         }
 


### PR DESCRIPTION
## Summary
- add generic opt-in auto-start support for downstream agent chaining
- let question generation trigger question answering agents
- let acceptance criteria trigger solution, and solution trigger development

## Test plan
- syntax-checked the updated JS files with `node --check`