### PR TITLE
Push managed submodules before parent commits

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -127,7 +127,76 @@ function configureGitAuthor(config) {
     }
 }
 
-function commitAndPush(ticketKey, config) {
+function collectIgnoredDirtySubmodulePaths(config, customParams) {
+    var paths = [];
+    function addMany(value) {
+        if (!value) return;
+        if (typeof value === 'string') {
+            paths.push(value);
+        } else if (Array.isArray(value)) {
+            value.forEach(function(path) {
+                if (path) paths.push(String(path));
+            });
+        }
+    }
+
+    addMany(customParams && customParams.ignoredDirtySubmodulePaths);
+    addMany(customParams && customParams.ignoreDirtySubmodulePaths);
+    addMany(customParams && customParams.ignoredDirtyPaths);
+    addMany(config && config.git && config.git.ignoredDirtySubmodulePaths);
+    addMany(config && config.git && config.git.ignoreDirtySubmodulePaths);
+
+    return paths.filter(function(path, index) {
+        return paths.indexOf(path) === index;
+    });
+}
+
+function isSafeRelativePath(path) {
+    return path &&
+        path[0] !== '/' &&
+        path.indexOf('..') === -1 &&
+        /^[A-Za-z0-9._/-]+$/.test(path);
+}
+
+function isSafeGitConfigName(name) {
+    return name && /^[A-Za-z0-9._/-]+$/.test(name);
+}
+
+function resolveSubmoduleName(cmd, path) {
+    try {
+        var output = cleanCommandOutput(cmd("git config --file .gitmodules --get-regexp '^submodule\\..*\\.path$'") || '');
+        var lines = output.split('\n');
+        for (var i = 0; i < lines.length; i++) {
+            var parts = lines[i].trim().split(/\s+/);
+            if (parts.length >= 2 && parts[1] === path) {
+                return parts[0].replace(/^submodule\./, '').replace(/\.path$/, '');
+            }
+        }
+    } catch (e) {
+        console.warn('Could not resolve submodule name for ignored path ' + path + ':', e.message || e);
+    }
+    return path;
+}
+
+function applyIgnoredDirtySubmodules(cmd, config, customParams) {
+    collectIgnoredDirtySubmodulePaths(config, customParams).forEach(function(path) {
+        if (!isSafeRelativePath(path)) {
+            console.warn('Skipping unsafe ignored dirty submodule path:', path);
+            return;
+        }
+
+        var submoduleName = resolveSubmoduleName(cmd, path);
+        if (!isSafeGitConfigName(submoduleName)) {
+            console.warn('Skipping unsafe ignored dirty submodule name:', submoduleName);
+            return;
+        }
+
+        cmd('git config submodule.' + submoduleName + '.ignore dirty');
+        console.log('Configured dirty submodule ignore for rework commit:', path);
+    });
+}
+
+function commitAndPush(ticketKey, config, customParams) {
     var workingDir = config.workingDir || null;
     var cmdOpts = workingDir ? { workingDirectory: workingDir } : {};
     var cmd = function(command) { return cli_execute_command(Object.assign({}, cmdOpts, { command: command })); };
@@ -161,6 +230,8 @@ function commitAndPush(ticketKey, config) {
             console.warn('Could not checkout expected branch, using current:', currentBranch, e);
         }
     }
+
+    applyIgnoredDirtySubmodules(cmd, config, customParams);
 
     cmd('git add .');
 
@@ -315,7 +386,7 @@ function action(params) {
         let branchName;
         let codeChangesCommitted = false;
         try {
-            const pushResult = commitAndPush(ticketKey, config);
+            const pushResult = commitAndPush(ticketKey, config, _customParams);
             branchName = pushResult.branch;
             codeChangesCommitted = pushResult.hasChanges;
         } catch (gitError) {


### PR DESCRIPTION
## Summary
- add a shared managed submodule helper for agent post-actions
- let development and rework agents commit and push configured submodule changes before staging the parent repository
- parent commits then include the updated submodule gitlink hash instead of failing on dirty submodule content
- validate configured paths and target branches before running git commands

## Test plan
- node --check js/common/submodules.js
- node --check js/pushReworkChanges.js
- node --check js/developTicketAndCreatePR.js