### PR TITLE
Push managed submodules before parent commits

### DIFF
--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -6,8 +6,18 @@ function addManySubmodules(target, value) {
         value.forEach(function(item) {
             addManySubmodules(target, item);
         });
-    } else if (value.path) {
-        target.push(value);
+    } else if (typeof value === 'object' && value.path !== undefined && value.path !== null) {
+        var module = { path: String(value.path) };
+        if (value.branch !== undefined && value.branch !== null) {
+            module.branch = String(value.branch);
+        }
+        if (value.targetBranch !== undefined && value.targetBranch !== null) {
+            module.targetBranch = String(value.targetBranch);
+        }
+        if (value.commitMessage !== undefined && value.commitMessage !== null) {
+            module.commitMessage = String(value.commitMessage);
+        }
+        target.push(module);
     }
 }
 
@@ -28,13 +38,19 @@ function collectManagedSubmodules(config, customParams) {
 
 function isSafeRelativePath(path) {
     return path &&
+        typeof path === 'string' &&
+        path !== '.' &&
         path[0] !== '/' &&
         path.indexOf('..') === -1 &&
+        path.split('/').every(function(segment) {
+            return segment && segment[0] !== '.';
+        }) &&
         /^[A-Za-z0-9._/-]+$/.test(path);
 }
 
 function isSafeRefName(ref) {
     return ref &&
+        typeof ref === 'string' &&
         ref[0] !== '-' &&
         ref.indexOf('..') === -1 &&
         /^[A-Za-z0-9._/-]+$/.test(ref);
@@ -66,13 +82,36 @@ function pushManagedSubmodules(options) {
             throw new Error('Unsafe managed submodule branch for ' + path + ': ' + branch);
         }
 
+        var registeredPath = cleanOutput(run('git config --file .gitmodules --get-regexp "^submodule\\..*\\.path$"') || '')
+            .split('\n')
+            .some(function(line) {
+                return line.trim().split(/\s+/)[1] === path;
+            });
+        if (!registeredPath) {
+            throw new Error('Managed submodule path is not registered in .gitmodules: ' + path);
+        }
+
+        try {
+            run('git -C ' + path + ' fetch origin ' + branch);
+        } catch (e) {
+            console.warn('Could not fetch managed submodule branch ' + path + ' origin/' + branch + ':', e.message || e);
+        }
+
         var status = cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
-        if (!status.trim()) {
+        var aheadCount = 0;
+        try {
+            var aheadOutput = cleanOutput(run('git -C ' + path + ' rev-list --count origin/' + branch + '..HEAD') || '');
+            aheadCount = parseInt(aheadOutput, 10) || 0;
+        } catch (e) {
+            console.warn('Could not check managed submodule commits ahead for ' + path + ':', e.message || e);
+        }
+
+        if (!status.trim() && aheadCount === 0) {
             console.log('No managed submodule changes detected in', path);
             return;
         }
 
-        console.log('Committing managed submodule changes:', path, '-> origin/' + branch);
+        console.log('Publishing managed submodule changes:', path, '-> origin/' + branch);
         if (config.git && config.git.authorName) {
             run('git -C ' + path + ' config user.name ' + quoteCommitMessage(config.git.authorName));
         }
@@ -80,15 +119,17 @@ function pushManagedSubmodules(options) {
             run('git -C ' + path + ' config user.email ' + quoteCommitMessage(config.git.authorEmail));
         }
 
-        run('git -C ' + path + ' add .');
-        var stagedStatus = cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
-        if (!stagedStatus.trim()) {
-            console.log('Managed submodule had no committable changes after staging:', path);
-            return;
+        if (status.trim()) {
+            run('git -C ' + path + ' add .');
+            var stagedStatus = cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
+            if (!stagedStatus.trim()) {
+                console.log('Managed submodule had no committable changes after staging:', path);
+            } else {
+                var commitMessage = module.commitMessage || (ticketKey + ' Update ' + path + ' assets');
+                run('git -C ' + path + ' commit -m ' + quoteCommitMessage(commitMessage));
+            }
         }
 
-        var commitMessage = module.commitMessage || (ticketKey + ' Update ' + path + ' assets');
-        run('git -C ' + path + ' commit -m ' + quoteCommitMessage(commitMessage));
         run('git -C ' + path + ' push origin HEAD:' + branch);
         console.log('Managed submodule pushed:', path, '-> origin/' + branch);
     });
@@ -96,5 +137,6 @@ function pushManagedSubmodules(options) {
 
 module.exports = {
     collectManagedSubmodules: collectManagedSubmodules,
-    pushManagedSubmodules: pushManagedSubmodules
+    pushManagedSubmodules: pushManagedSubmodules,
+    isSafeRelativePath: isSafeRelativePath
 };

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -1,0 +1,100 @@
+function addManySubmodules(target, value) {
+    if (!value) return;
+    if (typeof value === 'string') {
+        target.push({ path: value });
+    } else if (Array.isArray(value)) {
+        value.forEach(function(item) {
+            addManySubmodules(target, item);
+        });
+    } else if (value.path) {
+        target.push(value);
+    }
+}
+
+function collectManagedSubmodules(config, customParams) {
+    var modules = [];
+    addManySubmodules(modules, customParams && customParams.managedSubmodules);
+    addManySubmodules(modules, customParams && customParams.pushSubmodules);
+    addManySubmodules(modules, config && config.git && config.git.managedSubmodules);
+    addManySubmodules(modules, config && config.git && config.git.pushSubmodules);
+
+    var seen = {};
+    return modules.filter(function(module) {
+        if (!module || !module.path || seen[module.path]) return false;
+        seen[module.path] = true;
+        return true;
+    });
+}
+
+function isSafeRelativePath(path) {
+    return path &&
+        path[0] !== '/' &&
+        path.indexOf('..') === -1 &&
+        /^[A-Za-z0-9._/-]+$/.test(path);
+}
+
+function isSafeRefName(ref) {
+    return ref &&
+        ref[0] !== '-' &&
+        ref.indexOf('..') === -1 &&
+        /^[A-Za-z0-9._/-]+$/.test(ref);
+}
+
+function quoteCommitMessage(message) {
+    return '"' + String(message || '')
+        .replace(/"/g, '\\"')
+        .replace(/[><|;`$\r\n]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim() + '"';
+}
+
+function pushManagedSubmodules(options) {
+    var run = options.run;
+    var cleanOutput = options.cleanOutput || function(output) { return output || ''; };
+    var config = options.config || {};
+    var customParams = options.customParams || {};
+    var ticketKey = options.ticketKey || 'Agent';
+
+    collectManagedSubmodules(config, customParams).forEach(function(module) {
+        var path = module.path;
+        var branch = module.branch || module.targetBranch || 'main';
+
+        if (!isSafeRelativePath(path)) {
+            throw new Error('Unsafe managed submodule path: ' + path);
+        }
+        if (!isSafeRefName(branch)) {
+            throw new Error('Unsafe managed submodule branch for ' + path + ': ' + branch);
+        }
+
+        var status = cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
+        if (!status.trim()) {
+            console.log('No managed submodule changes detected in', path);
+            return;
+        }
+
+        console.log('Committing managed submodule changes:', path, '-> origin/' + branch);
+        if (config.git && config.git.authorName) {
+            run('git -C ' + path + ' config user.name ' + quoteCommitMessage(config.git.authorName));
+        }
+        if (config.git && config.git.authorEmail) {
+            run('git -C ' + path + ' config user.email ' + quoteCommitMessage(config.git.authorEmail));
+        }
+
+        run('git -C ' + path + ' add .');
+        var stagedStatus = cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
+        if (!stagedStatus.trim()) {
+            console.log('Managed submodule had no committable changes after staging:', path);
+            return;
+        }
+
+        var commitMessage = module.commitMessage || (ticketKey + ' Update ' + path + ' assets');
+        run('git -C ' + path + ' commit -m ' + quoteCommitMessage(commitMessage));
+        run('git -C ' + path + ' push origin HEAD:' + branch);
+        console.log('Managed submodule pushed:', path, '-> origin/' + branch);
+    });
+}
+
+module.exports = {
+    collectManagedSubmodules: collectManagedSubmodules,
+    pushManagedSubmodules: pushManagedSubmodules
+};

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -190,6 +190,10 @@ function performPushOnly(branchName) {
  *
  * @param {string} branchName - Current branch name (already checked out by preCliJSAction)
  * @param {string} commitMessage - Commit message
+ * @param {string} baseBranch - Base branch used to detect existing local/remote commits
+ * @param {Object} config - Resolved project config, including optional managed submodules
+ * @param {Object} customParams - Runtime custom params, including optional managed submodules
+ * @param {string} ticketKey - Ticket key used for managed submodule commit messages
  * @returns {Object} Result with success status and branch name
  */
 function performGitOperations(branchName, commitMessage, baseBranch, config, customParams, ticketKey) {

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -6,6 +6,7 @@
 // Import common helper functions
 const { extractTicketKey } = require('./common/jiraHelpers.js');
 const prHelper = require('./common/pullRequest.js');
+const submoduleHelper = require('./common/submodules.js');
 var configLoader = require('./configLoader.js');
 const { GIT_CONFIG, STATUSES, LABELS, resolveStatuses } = require('./config.js');
 
@@ -191,8 +192,18 @@ function performPushOnly(branchName) {
  * @param {string} commitMessage - Commit message
  * @returns {Object} Result with success status and branch name
  */
-function performGitOperations(branchName, commitMessage, baseBranch) {
+function performGitOperations(branchName, commitMessage, baseBranch, config, customParams, ticketKey) {
     try {
+        submoduleHelper.pushManagedSubmodules({
+            run: function(command) {
+                return runCmd({ command: command });
+            },
+            cleanOutput: cleanCommandOutput,
+            config: config,
+            customParams: customParams,
+            ticketKey: ticketKey
+        });
+
         // Stage all changes
         console.log('Staging changes...');
         runCmd({
@@ -633,7 +644,7 @@ function action(params) {
 
         // Perform git operations
         const prTarget = configLoader.resolvePRTargetBranch(config, params.ticket || actualParams.ticket);
-        const gitResult = performGitOperations(branchName, commitMessage, prTarget);
+        const gitResult = performGitOperations(branchName, commitMessage, prTarget, config, _customParams, ticketKey);
         if (!gitResult.success) {
             if (gitResult.isPushFailure) {
                 // Push was rejected — ask the agent to fix the commit, then retry

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -9,6 +9,7 @@
 
 var configLoader = require('./configLoader.js');
 var scmModule = require('./common/scm.js');
+var submoduleHelper = require('./common/submodules.js');
 const { GIT_CONFIG, STATUSES, LABELS, resolveStatuses } = require('./config.js');
 
 /**
@@ -127,75 +128,6 @@ function configureGitAuthor(config) {
     }
 }
 
-function collectIgnoredDirtySubmodulePaths(config, customParams) {
-    var paths = [];
-    function addMany(value) {
-        if (!value) return;
-        if (typeof value === 'string') {
-            paths.push(value);
-        } else if (Array.isArray(value)) {
-            value.forEach(function(path) {
-                if (path) paths.push(String(path));
-            });
-        }
-    }
-
-    addMany(customParams && customParams.ignoredDirtySubmodulePaths);
-    addMany(customParams && customParams.ignoreDirtySubmodulePaths);
-    addMany(customParams && customParams.ignoredDirtyPaths);
-    addMany(config && config.git && config.git.ignoredDirtySubmodulePaths);
-    addMany(config && config.git && config.git.ignoreDirtySubmodulePaths);
-
-    return paths.filter(function(path, index) {
-        return paths.indexOf(path) === index;
-    });
-}
-
-function isSafeRelativePath(path) {
-    return path &&
-        path[0] !== '/' &&
-        path.indexOf('..') === -1 &&
-        /^[A-Za-z0-9._/-]+$/.test(path);
-}
-
-function isSafeGitConfigName(name) {
-    return name && /^[A-Za-z0-9._/-]+$/.test(name);
-}
-
-function resolveSubmoduleName(cmd, path) {
-    try {
-        var output = cleanCommandOutput(cmd("git config --file .gitmodules --get-regexp '^submodule\\..*\\.path$'") || '');
-        var lines = output.split('\n');
-        for (var i = 0; i < lines.length; i++) {
-            var parts = lines[i].trim().split(/\s+/);
-            if (parts.length >= 2 && parts[1] === path) {
-                return parts[0].replace(/^submodule\./, '').replace(/\.path$/, '');
-            }
-        }
-    } catch (e) {
-        console.warn('Could not resolve submodule name for ignored path ' + path + ':', e.message || e);
-    }
-    return path;
-}
-
-function applyIgnoredDirtySubmodules(cmd, config, customParams) {
-    collectIgnoredDirtySubmodulePaths(config, customParams).forEach(function(path) {
-        if (!isSafeRelativePath(path)) {
-            console.warn('Skipping unsafe ignored dirty submodule path:', path);
-            return;
-        }
-
-        var submoduleName = resolveSubmoduleName(cmd, path);
-        if (!isSafeGitConfigName(submoduleName)) {
-            console.warn('Skipping unsafe ignored dirty submodule name:', submoduleName);
-            return;
-        }
-
-        cmd('git config submodule.' + submoduleName + '.ignore dirty');
-        console.log('Configured dirty submodule ignore for rework commit:', path);
-    });
-}
-
 function commitAndPush(ticketKey, config, customParams) {
     var workingDir = config.workingDir || null;
     var cmdOpts = workingDir ? { workingDirectory: workingDir } : {};
@@ -231,7 +163,13 @@ function commitAndPush(ticketKey, config, customParams) {
         }
     }
 
-    applyIgnoredDirtySubmodules(cmd, config, customParams);
+    submoduleHelper.pushManagedSubmodules({
+        run: cmd,
+        cleanOutput: cleanCommandOutput,
+        config: config,
+        customParams: customParams,
+        ticketKey: ticketKey
+    });
 
     cmd('git add .');
 

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -11,6 +11,7 @@
         "agents/js/unit-tests/test_workingDir.js",
         "agents/js/unit-tests/test_branchNaming.js",
         "agents/js/unit-tests/test_githubHelpers.js",
+        "agents/js/unit-tests/test_submodules.js",
         "agents/js/unit-tests/test_pullRequestHelper.js",
         "agents/js/unit-tests/test_fetchParentContextToInput.js",
         "agents/js/unit-tests/test_testsGeneratedGuard.js",

--- a/js/unit-tests/run_submodules.json
+++ b/js/unit-tests/run_submodules.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "agents/js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "agents/js/unit-tests/test_submodules.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for agents/js/common/submodules.js
+ */
+
+function loadSubmoduleHelper() {
+    return loadModule('agents/js/common/submodules.js');
+}
+
+suite('submodule helper', function() {
+
+    test('normalizes and deduplicates managed submodule config', function() {
+        var helper = loadSubmoduleHelper();
+        var modules = helper.collectManagedSubmodules(
+            { git: { managedSubmodules: [{ path: 123, branch: 456, commitMessage: 789 }] } },
+            { managedSubmodules: ['trackstate-setup', { path: 'trackstate-setup', branch: 'main' }] }
+        );
+
+        assert.deepEqual(modules, [
+            { path: 'trackstate-setup' },
+            { path: '123', branch: '456', commitMessage: '789' }
+        ]);
+    });
+
+    test('rejects dot and dot-prefixed managed submodule paths', function() {
+        var helper = loadSubmoduleHelper();
+
+        assert.equal(helper.isSafeRelativePath('trackstate-setup'), true);
+        assert.equal(helper.isSafeRelativePath('.'), false);
+        assert.equal(helper.isSafeRelativePath('.git'), false);
+        assert.equal(helper.isSafeRelativePath('safe/.git'), false);
+        assert.equal(helper.isSafeRelativePath('../outside'), false);
+    });
+
+    test('commits dirty submodule then pushes it', function() {
+        var helper = loadSubmoduleHelper();
+        var commands = [];
+        helper.pushManagedSubmodules({
+            config: {
+                git: {
+                    authorName: 'AI Teammate',
+                    authorEmail: 'agent@example.com'
+                }
+            },
+            customParams: {
+                managedSubmodules: [{ path: 'trackstate-setup', branch: 'main' }]
+            },
+            ticketKey: 'TS-23',
+            cleanOutput: function(output) { return output || ''; },
+            run: function(command) {
+                commands.push(command);
+                if (command.indexOf('git config --file .gitmodules --get-regexp') === 0) {
+                    return 'submodule.trackstate-setup.path trackstate-setup';
+                }
+                if (command === 'git -C trackstate-setup status --porcelain') {
+                    return ' M README.md';
+                }
+                if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
+                    return '0';
+                }
+                return '';
+            }
+        });
+
+        assert.ok(commands.indexOf('git -C trackstate-setup add .') !== -1, 'dirty submodule should be staged');
+        assert.ok(commands.some(function(command) {
+            return command.indexOf('git -C trackstate-setup commit -m "TS-23 Update trackstate-setup assets"') === 0;
+        }), 'dirty submodule should be committed');
+        assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') !== -1, 'submodule should be pushed');
+    });
+
+    test('pushes clean submodule when HEAD is ahead of remote', function() {
+        var helper = loadSubmoduleHelper();
+        var commands = [];
+        helper.pushManagedSubmodules({
+            customParams: {
+                managedSubmodules: [{ path: 'trackstate-setup', branch: 'main' }]
+            },
+            ticketKey: 'TS-23',
+            cleanOutput: function(output) { return output || ''; },
+            run: function(command) {
+                commands.push(command);
+                if (command.indexOf('git config --file .gitmodules --get-regexp') === 0) {
+                    return 'submodule.trackstate-setup.path trackstate-setup';
+                }
+                if (command === 'git -C trackstate-setup status --porcelain') {
+                    return '';
+                }
+                if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
+                    return '2';
+                }
+                return '';
+            }
+        });
+
+        assert.ok(commands.indexOf('git -C trackstate-setup add .') === -1, 'clean ahead submodule should not be staged');
+        assert.ok(commands.every(function(command) {
+            return command.indexOf('git -C trackstate-setup commit -m') === -1;
+        }), 'clean ahead submodule should not create another commit');
+        assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') !== -1, 'ahead submodule should be pushed');
+    });
+
+    test('rejects unregistered managed submodule paths', function() {
+        var helper = loadSubmoduleHelper();
+
+        assert.throws(function() {
+            helper.pushManagedSubmodules({
+                customParams: { managedSubmodules: ['not-a-submodule'] },
+                run: function(command) {
+                    if (command.indexOf('git config --file .gitmodules --get-regexp') === 0) {
+                        return 'submodule.trackstate-setup.path trackstate-setup';
+                    }
+                    return '';
+                }
+            });
+        }, 'unregistered paths should be rejected');
+    });
+
+});


### PR DESCRIPTION
## Summary
- add a shared managed submodule helper for agent post-actions
- let development and rework agents commit and push configured submodule changes before staging the parent repository
- parent commits then include the updated submodule gitlink hash instead of failing on dirty submodule content
- normalize configured submodule fields, reject unsafe/dot paths, verify paths are registered in .gitmodules, and push clean-but-ahead submodule commits
- add unit coverage for normalization, path validation, dirty submodule publish, clean-ahead publish, and unregistered path rejection

## Test plan
- node --check js/common/submodules.js
- node --check js/pushReworkChanges.js
- node --check js/developTicketAndCreatePR.js
- node --check js/unit-tests/test_submodules.js
- node-based mocked assertions for js/common/submodules.js

Note: dmtools JSRunner was not runnable in the local shell because tracker credentials are not configured there.