### PR TITLE
Rebase managed submodules before publishing

### DIFF
--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -65,18 +65,25 @@ function quoteCommitMessage(message) {
 }
 
 function prepareSubmoduleBranch(run, cleanOutput, path, branch, hasDirtyChanges, hasLocalCommits) {
+    var stashed = false;
     if (hasDirtyChanges) {
         run('git -C ' + path + ' stash push -u -m ' + quoteCommitMessage('dmtools managed submodule changes'));
+        stashed = true;
     }
 
-    run('git -C ' + path + ' checkout -B ' + branch + ' HEAD');
+    try {
+        run('git -C ' + path + ' checkout -B ' + branch + ' HEAD');
 
-    if (hasDirtyChanges || hasLocalCommits) {
-        run('git -C ' + path + ' rebase origin/' + branch);
+        if (hasDirtyChanges || hasLocalCommits) {
+            run('git -C ' + path + ' rebase origin/' + branch);
+        }
+    } finally {
+        if (stashed) {
+            run('git -C ' + path + ' stash pop');
+        }
     }
 
     if (hasDirtyChanges) {
-        run('git -C ' + path + ' stash pop');
         return cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
     }
 
@@ -131,7 +138,7 @@ function pushManagedSubmodules(options) {
         }
 
         console.log('Publishing managed submodule changes:', path, '-> origin/' + branch);
-        status = prepareSubmoduleBranch(run, cleanOutput, path, branch, status.trim(), aheadCount > 0) || status;
+        status = prepareSubmoduleBranch(run, cleanOutput, path, branch, status.trim(), aheadCount > 0);
 
         if (config.git && config.git.authorName) {
             run('git -C ' + path + ' config user.name ' + quoteCommitMessage(config.git.authorName));

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -64,6 +64,25 @@ function quoteCommitMessage(message) {
         .trim() + '"';
 }
 
+function prepareSubmoduleBranch(run, cleanOutput, path, branch, hasDirtyChanges, hasLocalCommits) {
+    if (hasDirtyChanges) {
+        run('git -C ' + path + ' stash push -u -m ' + quoteCommitMessage('dmtools managed submodule changes'));
+    }
+
+    run('git -C ' + path + ' checkout -B ' + branch + ' HEAD');
+
+    if (hasDirtyChanges || hasLocalCommits) {
+        run('git -C ' + path + ' rebase origin/' + branch);
+    }
+
+    if (hasDirtyChanges) {
+        run('git -C ' + path + ' stash pop');
+        return cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
+    }
+
+    return '';
+}
+
 function pushManagedSubmodules(options) {
     var run = options.run;
     var cleanOutput = options.cleanOutput || function(output) { return output || ''; };
@@ -112,6 +131,8 @@ function pushManagedSubmodules(options) {
         }
 
         console.log('Publishing managed submodule changes:', path, '-> origin/' + branch);
+        status = prepareSubmoduleBranch(run, cleanOutput, path, branch, status.trim(), aheadCount > 0) || status;
+
         if (config.git && config.git.authorName) {
             run('git -C ' + path + ' config user.name ' + quoteCommitMessage(config.git.authorName));
         }

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -105,6 +105,73 @@ suite('submodule helper', function() {
         assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') !== -1, 'ahead submodule should be pushed');
     });
 
+    test('does not reuse stale dirty status after stash pop leaves tree clean', function() {
+        var helper = loadSubmoduleHelper();
+        var commands = [];
+        var statusCalls = 0;
+        helper.pushManagedSubmodules({
+            customParams: {
+                managedSubmodules: [{ path: 'trackstate-setup', branch: 'main' }]
+            },
+            ticketKey: 'TS-23',
+            cleanOutput: function(output) { return output || ''; },
+            run: function(command) {
+                commands.push(command);
+                if (command.indexOf('git config --file .gitmodules --get-regexp') === 0) {
+                    return 'submodule.trackstate-setup.path trackstate-setup';
+                }
+                if (command === 'git -C trackstate-setup status --porcelain') {
+                    statusCalls++;
+                    return statusCalls === 1 ? ' M README.md' : '';
+                }
+                if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
+                    return '0';
+                }
+                return '';
+            }
+        });
+
+        assert.ok(commands.indexOf('git -C trackstate-setup add .') === -1, 'clean tree after stash pop should not be staged');
+        assert.ok(commands.every(function(command) {
+            return command.indexOf('git -C trackstate-setup commit -m') === -1;
+        }), 'clean tree after stash pop should not be committed');
+        assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') !== -1, 'submodule should still be pushed');
+    });
+
+    test('restores stashed dirty changes when rebase fails', function() {
+        var helper = loadSubmoduleHelper();
+        var commands = [];
+
+        assert.throws(function() {
+            helper.pushManagedSubmodules({
+                customParams: {
+                    managedSubmodules: [{ path: 'trackstate-setup', branch: 'main' }]
+                },
+                ticketKey: 'TS-23',
+                cleanOutput: function(output) { return output || ''; },
+                run: function(command) {
+                    commands.push(command);
+                    if (command.indexOf('git config --file .gitmodules --get-regexp') === 0) {
+                        return 'submodule.trackstate-setup.path trackstate-setup';
+                    }
+                    if (command === 'git -C trackstate-setup status --porcelain') {
+                        return ' M README.md';
+                    }
+                    if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
+                        return '0';
+                    }
+                    if (command === 'git -C trackstate-setup rebase origin/main') {
+                        throw new Error('rebase failed');
+                    }
+                    return '';
+                }
+            });
+        }, 'rebase failure should be propagated');
+
+        assert.ok(commands.indexOf('git -C trackstate-setup stash push -u -m "dmtools managed submodule changes"') !== -1, 'dirty changes should be stashed before rebase');
+        assert.ok(commands.indexOf('git -C trackstate-setup stash pop') !== -1, 'dirty changes should be restored after rebase failure');
+    });
+
     test('rejects unregistered managed submodule paths', function() {
         var helper = loadSubmoduleHelper();
 

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -61,6 +61,10 @@ suite('submodule helper', function() {
             }
         });
 
+        assert.ok(commands.indexOf('git -C trackstate-setup stash push -u -m "dmtools managed submodule changes"') !== -1, 'dirty submodule changes should be stashed before branch alignment');
+        assert.ok(commands.indexOf('git -C trackstate-setup checkout -B main HEAD') !== -1, 'dirty submodule should be moved onto a local branch');
+        assert.ok(commands.indexOf('git -C trackstate-setup rebase origin/main') !== -1, 'dirty submodule should rebase onto the latest remote branch before committing');
+        assert.ok(commands.indexOf('git -C trackstate-setup stash pop') !== -1, 'dirty submodule changes should be restored after rebase');
         assert.ok(commands.indexOf('git -C trackstate-setup add .') !== -1, 'dirty submodule should be staged');
         assert.ok(commands.some(function(command) {
             return command.indexOf('git -C trackstate-setup commit -m "TS-23 Update trackstate-setup assets"') === 0;
@@ -92,6 +96,8 @@ suite('submodule helper', function() {
             }
         });
 
+        assert.ok(commands.indexOf('git -C trackstate-setup checkout -B main HEAD') !== -1, 'clean ahead submodule should be moved onto a local branch');
+        assert.ok(commands.indexOf('git -C trackstate-setup rebase origin/main') !== -1, 'clean ahead submodule should rebase before push');
         assert.ok(commands.indexOf('git -C trackstate-setup add .') === -1, 'clean ahead submodule should not be staged');
         assert.ok(commands.every(function(command) {
             return command.indexOf('git -C trackstate-setup commit -m') === -1;


### PR DESCRIPTION
## Summary
- preserve dirty managed submodule changes with stash before aligning to the target branch
- rebase managed submodule work onto origin/<branch> before committing or pushing
- restore stashed dirty changes in a finally block if checkout/rebase fails
- keep clean-but-ahead submodules rebased before push to avoid non-fast-forward failures
- extend submodule helper tests for dirty, clean-ahead, stale-status, and failed-rebase restore behavior

## Root cause
TrackState rework for TS-23 committed trackstate-setup from the parent PR's old gitlink SHA and then pushed to trackstate-setup:main. The remote main had advanced, so Git rejected the push as non-fast-forward and pr_review auto-start never ran.

## Test plan
- node --check js/common/submodules.js
- node --check js/unit-tests/test_submodules.js
- node-based mocked assertions for dirty and clean-ahead managed submodule publishing
- node-based mocked assertions for clean tree after stash pop and stash restoration on rebase failure