### PR TITLE
Clarify acceptance criteria formatting guidelines

### DIFF
--- a/instructions/story/enhanced_story_jira_formatting.md
+++ b/instructions/story/enhanced_story_jira_formatting.md
@@ -52,6 +52,7 @@ AC 3 - [Category Name]
 - Do not omit any top-level section. If there is no confirmed content for a mandatory section, write a concise explicit fallback such as `- Not identified from available context.`.
 - Omit placeholder-only bullets only after replacing the section with real content or an explicit `Not identified from available context.` bullet.
 - Keep AC numbering sequential: `AC 1`, `AC 2`, `AC 3`.
+- Never write AC identifiers in the form `AC-1`, `AC-2`, etc. (uppercase letters, hyphen, digits with no trailing colon). Jira's Smart Link engine matches `[A-Z]+-[0-9]+` and, because `AC` is a real project key, every such token is auto-rendered as an inline ticket card inside the Acceptance Criteria section. Always use the space-separated form `AC 1`, `AC 2`, `AC 3` instead.
 - Use plain bullets under each AC category.
 - Do not add an introduction, conclusion, ticket key heading, or "Acceptance Criteria for ..." prefix.
 - If critical information is missing, put the blocker at the top and keep any useful existing context below it.


### PR DESCRIPTION
## Problem

When the story agent generates Acceptance Criteria, AC section headers sometimes appear in Jira as inline ticket cards (icon, title, status badge) instead of plain text.

Jira's Smart Link engine scans rich-text fields for tokens matching `[A-Z]+-[0-9]+`. If the LLM generates `AC-1`, `AC-2`, etc. (hyphen between letters and digits, no trailing colon), those tokens match exactly — and since `AC` is a real Jira project key, each one gets resolved into a full inline ticket card.

## Fix

Added an explicit warning to the formatting rules in `enhanced_story_jira_formatting.md`, directly after the sequential numbering line, instructing the LLM to never use the hyphen form `AC-1` and to always use the space-separated form `AC 1`, `AC 2`, `AC 3`.