### PR TITLE
Add Codex CLI agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The SM agent (`smAgent.js`) is the central orchestrator. Every 20 minutes:
 
 | Type | Description |
 |------|-------------|
-| **Teammate** | Runs a CLI agent (Cursor / GitHub Copilot / Codemie) with a markdown prompt file. `skipAI: true` means AI is driven by the CLI tool, not DMTools AI directly. |
+| **Teammate** | Runs a CLI agent (Cursor / GitHub Copilot / Codemie / Codex) with a markdown prompt file. `skipAI: true` means AI is driven by the CLI tool, not DMTools AI directly. |
 | **TestCasesGenerator** | A specialized DMTools job that reads a Jira story/bug and generates structured Test Case tickets (issue type: Test Case) in Jira. |
 | **JSRunner** | Executes a pure JavaScript file (`jsPath`) with no AI involvement. Used for orchestration (`smAgent.js`) and reporting (`workflowFailureReporter.js`). |
 
@@ -642,7 +642,7 @@ ai-teammate.yml (GitHub Actions)
 │     └─ If wip label found → abort early, release lock
 ├─ 5. Run preCliJSAction (optional, e.g., fetchQuestionsToInput.js)
 │     └─ Fetches extra context and injects into prompt variables
-├─ 6. Invoke CLI Agent (Cursor / GitHub Copilot / Codemie)
+├─ 6. Invoke CLI Agent (Cursor / GitHub Copilot / Codemie / Codex)
 │     └─ Uses cliPrompt markdown file as the task specification
 │     └─ CLI agent reads Jira ticket, writes code, runs commands
 ├─ 7. Run postJSAction (e.g., developTicketAndCreatePR.js)

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -12,6 +12,7 @@ Providers:
   cursor   - Uses cursor-agent (default)
   codemie  - Uses codemie-claude
   copilot  - Uses GitHub Copilot CLI (npx @github/copilot)
+  codex    - Uses Codex CLI
 
 Example:
   $(basename "$0") "process the input folder"
@@ -23,6 +24,8 @@ Notes:
   - For codemie: requires CODEMIE_API_KEY and CODEMIE_BASE_URL environment variables
   - For copilot: requires COPILOT_GITHUB_TOKEN or GITHUB_TOKEN environment variable
   - For cursor: optional CURSOR_MODEL env var (default: auto)
+  - For codex: optional CODEX_MODEL, CODEX_REASONING_EFFORT,
+    CODEX_SANDBOX, and CODEX_APPROVAL_POLICY env vars
   - Final response is written to outputs/response.md
 EOF
 }
@@ -168,6 +171,77 @@ elif [ "$PROVIDER" = "copilot" ]; then
     echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} -p <inline prompt>"
     echo ""
     "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}"
+  fi
+
+  exit_code=$?
+  echo ""
+  echo "=== Agent completed with exit code: $exit_code ==="
+  exit $exit_code
+
+elif [ "$PROVIDER" = "codex" ]; then
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "Error: codex not found in PATH" >&2
+    exit 127
+  fi
+
+  mkdir -p outputs
+
+  CODEX_SANDBOX_VALUE="${CODEX_SANDBOX:-danger-full-access}"
+  CODEX_APPROVAL_VALUE="${CODEX_APPROVAL_POLICY:-never}"
+  echo "Codex Configuration:"
+  echo "  Model: ${CODEX_MODEL:-default}"
+  echo "  Sandbox: ${CODEX_SANDBOX_VALUE}"
+  echo "  Approval policy: ${CODEX_APPROVAL_VALUE}"
+
+  CODEX_BASE=(codex
+    --cd "$(pwd)"
+    --sandbox "${CODEX_SANDBOX_VALUE}"
+    --ask-for-approval "${CODEX_APPROVAL_VALUE}")
+
+  if [ -n "${CODEX_MODEL:-}" ]; then
+    CODEX_BASE+=(--model "${CODEX_MODEL}")
+  fi
+
+  if [ -n "${CODEX_REASONING_EFFORT:-}" ]; then
+    CODEX_BASE+=(-c "reasoning_effort=\"${CODEX_REASONING_EFFORT}\"")
+  fi
+
+  CODEX_RESUME=false
+  CODEX_FORWARD_ARGS=()
+  if [ ${#PASS_ARGS[@]} -gt 0 ]; then
+    for arg in "${PASS_ARGS[@]}"; do
+      case "$arg" in
+        --continue|--resume)
+          CODEX_RESUME=true
+          ;;
+        *)
+          CODEX_FORWARD_ARGS+=("$arg")
+          ;;
+      esac
+    done
+  fi
+
+  if [ "$CODEX_RESUME" = true ]; then
+    CMD=("${CODEX_BASE[@]}" exec resume --last -o outputs/response.md)
+  else
+    CMD=("${CODEX_BASE[@]}" exec -o outputs/response.md)
+  fi
+
+  if [ ${#CODEX_FORWARD_ARGS[@]} -gt 0 ]; then
+    CMD+=("${CODEX_FORWARD_ARGS[@]}")
+  fi
+
+  echo "Working directory: $(pwd)"
+  echo ""
+
+  if [ -f "${PROMPT_ARG}" ]; then
+    echo "Running: ${CMD[*]} - (prompt: ${PROMPT_BYTES} bytes via stdin)"
+    echo ""
+    "${CMD[@]}" - < "${PROMPT_ARG}"
+  else
+    echo "Running: ${CMD[*]} <inline prompt>"
+    echo ""
+    "${CMD[@]}" "$PROMPT"
   fi
 
   exit_code=$?


### PR DESCRIPTION
## Summary

- add `AI_AGENT_PROVIDER=codex` support to `scripts/run-agent.sh`
- map legacy feedback-loop flags `--continue --resume` to `codex exec resume --last`
- document Codex as a Teammate CLI provider

## Validation

- `bash -n scripts/run-agent.sh`
- stubbed `codex` binary to verify normal calls use `codex exec`
- stubbed `codex` binary to verify feedback resume calls use `codex exec resume --last`

This unblocks projects that use dmtools-agents with local Codex execution and the shared feedback loop.
