### PR TITLE
Fix test automation publishing synced existing branches

### DIFF
--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -120,20 +120,38 @@ function performGitOperations(branchName, commitMessage, workingDir, testFilesPa
 
         if (!stagedOutput || !stagedOutput.trim()) {
             console.warn('No new staged changes in ' + addPath + ' (files may already exist on branch)');
-            // Ensure the branch is pushed to remote so we can create/find a PR
+            // Ensure the branch is pushed to remote so we can create/find a PR.
+            // preCliTestAutomationSetup may have rebased/merged origin/main into
+            // an existing test branch without changing test files. In that case
+            // there are no staged changes here, but the branch tip still needs to
+            // be published; otherwise the remote test/<KEY> branch stays stale.
             var remoteBranchCheck = cleanCommandOutput(
                 runInRepo('git ls-remote --heads origin ' + branchName, workingDir) || ''
             );
             if (!remoteBranchCheck.trim()) {
                 console.log('No remote branch found, pushing current branch state...');
                 try {
-                    runInRepo('git push -u origin ' + branchName + ' --force', workingDir);
+                    runInRepo('git push -u origin ' + branchName, workingDir);
                 } catch (pushErr) {
                     console.warn('Failed to push branch:', pushErr);
                     return { success: false, error: 'No test files were written and could not push branch' };
                 }
             } else {
-                console.log('Branch exists on remote — test files unchanged, will create/find PR from existing branch');
+                console.log('Branch exists on remote — pushing current branch state in case setup synced it from main');
+                try {
+                    runInRepo('git push -u origin ' + branchName, workingDir);
+                } catch (pushErr) {
+                    console.log('Normal push failed, retrying with --force-with-lease for rebased test branch...');
+                    try {
+                        runInRepo('git push -u origin ' + branchName + ' --force-with-lease', workingDir);
+                    } catch (forcePushErr) {
+                        console.warn('Failed to publish synced existing branch:', forcePushErr);
+                        return {
+                            success: false,
+                            error: 'No test files were written and the synced branch could not be pushed'
+                        };
+                    }
+                }
             }
             return { success: true, branchName: branchName, noNewCommit: true };
         }

--- a/js/unit-tests/test_postTestAutomationResults.js
+++ b/js/unit-tests/test_postTestAutomationResults.js
@@ -90,7 +90,7 @@ suite('postTestAutomationResults: PR creation', function() {
         assert.notOk(commands.some(function(command) { return command === 'pwd'; }), 'pwd command not used');
     });
 
-    test('skips PR and moves directly to Passed when existing branch has no new test changes', function() {
+    test('pushes synced existing branch before moving directly to Passed when there are no new test changes', function() {
         var commands = [];
         var statuses = [];
         var comments = [];
@@ -129,6 +129,7 @@ suite('postTestAutomationResults: PR creation', function() {
         assert.equal(result.success, true);
         assert.equal(result.prUrl, null);
         assert.ok(commands.some(function(command) { return command === 'git diff --cached --stat'; }), 'checked staged diff');
+        assert.ok(commands.some(function(command) { return command === 'git push -u origin test/DMC-968'; }), 'pushed existing branch after setup sync');
         assert.notOk(commands.some(function(command) { return command.indexOf('gh pr create') === 0; }), 'PR creation skipped');
         assert.ok(statuses.indexOf('Passed') !== -1, 'moved directly to Passed');
         assert.equal(comments.length, 1);


### PR DESCRIPTION
Fixes a gap in test automation branch syncing.

preCliTestAutomationSetup already rebases or merges origin/main into an existing test ticket branch, but postTestAutomationResults skipped pushing when the test files were unchanged. That meant logs could say the branch was synced, while the remote branch stayed stale.

This change publishes the current branch state even in the no-new-test-changes path. If a normal push fails because setup rebased the branch, it retries with force-with-lease.

Verification:
- node --check agents/js/postTestAutomationResults.js
- node --check agents/js/unit-tests/test_postTestAutomationResults.js

The full dmtools JS unit runner could not be executed locally because it requires tracker/Jira environment variables.