### PR TITLE
Fix stuck bug creation trigger cleanup

### DIFF
--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -79,6 +79,9 @@ function action(params) {
                 comment: 'h3. ⚠️ Bug Creation Error\n\nCould not read bug_decision.json. Check workflow logs.'
             });
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
+            if (smTriggerLabel) {
+                try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
+            }
             return { success: false, error: 'No bug_decision.json' };
         }
 
@@ -114,6 +117,9 @@ function action(params) {
             if (!summary) {
                 jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Bug Creation Skipped\n\nNo summary provided in bug_decision.json.' });
                 try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
+                if (smTriggerLabel) {
+                    try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
+                }
                 return { success: false, error: 'No bug summary' };
             }
 

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -14,6 +14,7 @@
         "agents/js/unit-tests/test_pullRequestHelper.js",
         "agents/js/unit-tests/test_fetchParentContextToInput.js",
         "agents/js/unit-tests/test_testsGeneratedGuard.js",
+        "agents/js/unit-tests/test_postBugCreation.js",
         "agents/js/unit-tests/test_postTestAutomationResults.js",
         "agents/js/unit-tests/test_preCliMobileTestAutomationSetup.js",
         "agents/js/unit-tests/test_postMobileTestAutomationResults.js"

--- a/js/unit-tests/test_postBugCreation.js
+++ b/js/unit-tests/test_postBugCreation.js
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for agents/js/postBugCreation.js
+ */
+
+function loadPostBugCreation(mocks) {
+    var defaults = {
+        jira_post_comment: function() {},
+        jira_move_to_status: function() {},
+        jira_remove_label: function() {},
+        jira_link_issues: function() {},
+        jira_create_ticket_basic: function() { return ''; },
+        file_read: function() { return null; }
+    };
+
+    return loadModule(
+        'agents/js/postBugCreation.js',
+        makeRequire({
+            './config.js': configModule
+        }),
+        Object.assign({}, defaults, mocks)
+    );
+}
+
+suite('postBugCreation', function() {
+
+    test('removes SM trigger label when bug_decision.json is missing', function() {
+        var removedLabels = [];
+        var comments = [];
+
+        var module = loadPostBugCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bug_decision.json') return null;
+                return null;
+            },
+            jira_post_comment: function(args) {
+                comments.push(args);
+            },
+            jira_remove_label: function(args) {
+                removedLabels.push(args);
+            }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-732' },
+            metadata: { contextId: 'bug_creation' },
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, false);
+        assert.equal(result.error, 'No bug_decision.json');
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'Could not read bug_decision.json');
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-732', label: 'bug_creation_wip' },
+            { key: 'TS-732', label: 'sm_bug_creation_triggered' }
+        ]);
+    });
+
+});


### PR DESCRIPTION
## Summary
- remove the SM bug-creation trigger label when bug_creation exits before outputs/bug_decision.json is produced
- remove the same trigger label when bug_decision.json is present but missing a bug summary
- add a focused JS unit test and include it in the agents run_all suite

## Validation
- dmtools run /tmp/run_postBugCreation.json
- dmtools run agents/js/unit-tests/run_all.json (existing baseline failures remain outside this change)