### PR TITLE
Fix bug_creation infinite loop: keep trigger label on non-action paths

### DIFF
--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -79,9 +79,8 @@ function action(params) {
                 comment: 'h3. ⚠️ Bug Creation Error\n\nCould not read bug_decision.json. Check workflow logs.'
             });
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
-            if (smTriggerLabel) {
-                try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
-            }
+            // KEEP sm_bug_creation_triggered label — TC stays in Failed, removing
+            // the label would cause SM to re-trigger in an infinite loop.
             return { success: false, error: 'No bug_decision.json' };
         }
 
@@ -117,9 +116,7 @@ function action(params) {
             if (!summary) {
                 jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Bug Creation Skipped\n\nNo summary provided in bug_decision.json.' });
                 try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
-                if (smTriggerLabel) {
-                    try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
-                }
+                // KEEP sm_bug_creation_triggered — TC stays Failed, prevent re-fire loop.
                 return { success: false, error: 'No bug summary' };
             }
 
@@ -170,10 +167,9 @@ function action(params) {
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
-            if (smTriggerLabel) {
-                try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
-            }
-            console.log('ℹ️ No action taken for', ticketKey, '— TC stays in Failed');
+            // KEEP sm_bug_creation_triggered label — TC stays in Failed, removing
+            // the label would cause SM to re-trigger bug_creation in an infinite loop.
+            console.log('ℹ️ No action taken for', ticketKey, '— TC stays in Failed (trigger label kept to prevent re-fire)');
             return { success: true, ticketKey: ticketKey, bugKey: null, action: 'none' };
         }
 


### PR DESCRIPTION
## Problem

When `bug_creation` agent decides `action=none` (no bug needed) or encounters an error, the test case stays in **Failed** status. The post-action was removing `sm_bug_creation_triggered` label in these cases, causing SM to re-trigger bug_creation on the **same TC every cycle**.

**Evidence**: TS-909 was processed 4 times by bug_creation in 4 hours.

## Fix

Keep `sm_bug_creation_triggered` label when TC remains in Failed:
- `action=none` → keep label (prevents re-fire)
- Error (no decision JSON) → keep label
- Error (no summary) → keep label

Only remove the trigger label on **success paths** where TC moves to a different status:
- `action=link/create` → TC moves to Bug To Fix → label removed (safe, JQL won't match)
- `action=tests_pass` → TC moves to Passed → label removed (safe)

## Impact

Stops infinite loop of wasted bug_creation runs on TCs that legitimately have no bug to create.