### PR TITLE
Improve DF manager quality signals

### DIFF
--- a/.github/skills/df-manager/SKILL.md
+++ b/.github/skills/df-manager/SKILL.md
@@ -63,6 +63,23 @@ Always collect all three layers:
 3. **GitHub Actions**: active runs, failed runs, run titles, branches, workflow
    names, URLs, failed job logs.
 
+## Quality signals
+
+Watch for repeat patterns that usually mean the automation is learning the wrong
+lesson:
+
+- Same ticket key processed multiple times by the same workflow without a status
+  change.
+- Failed runs that keep coming back after a `none` / no-op decision.
+- One ticket monopolizing the queue while newer tickets stay untouched.
+- PRs that are clean but never merge, or that keep bouncing between review and
+  rework.
+- Labels that disappear while the ticket is still in the source state.
+
+When you see one of these patterns, prefer fixing the shared agent logic first.
+Keep TrackState-specific labels, status names, and queue rules in project
+instructions under `.dmtools/`.
+
 Useful Jira query:
 
 ```jql

--- a/js/dfManager.js
+++ b/js/dfManager.js
@@ -400,6 +400,56 @@ function detectDuplicateRuns(context) {
     });
 }
 
+function detectRepeatedFailureLoops(context) {
+    var grouped = {};
+
+    context.failedRuns.forEach(function(run) {
+        var key = extractTicketKey(runText(run));
+        if (!key) return;
+        if (!grouped[key]) {
+            grouped[key] = {
+                total: 0,
+                workflows: {},
+                urls: []
+            };
+        }
+
+        var bucket = grouped[key];
+        var workflow = run.workflowName || run.name || 'unknown-workflow';
+        bucket.total += 1;
+        bucket.workflows[workflow] = (bucket.workflows[workflow] || 0) + 1;
+        var url = runUrl(run);
+        if (url) bucket.urls.push(url);
+    });
+
+    Object.keys(grouped).forEach(function(key) {
+        var bucket = grouped[key];
+        if (bucket.total < 3) return;
+
+        var ticket = context.ticketByKey[key];
+        var status = ticketStatus(ticket);
+        var labelCount = ticketLabels(ticket).filter(function(label) {
+            return context.smLabelSet[label] === true;
+        }).length;
+        var workflows = Object.keys(bucket.workflows).map(function(name) {
+            return name + '×' + bucket.workflows[name];
+        }).join(', ');
+
+        appendAnomaly(context.anomalies, {
+            type: 'repeated-failure-loop',
+            severity: (status === 'Failed' || labelCount > 0 || bucket.total >= 5) ? 'blocking' : 'warning',
+            ticketKey: key,
+            workflowRuns: bucket.total,
+            workflows: bucket.workflows,
+            runUrls: uniq(bucket.urls),
+            status: status,
+            message: 'Ticket has ' + bucket.total + ' failed workflow runs' +
+                (workflows ? ' (' + workflows + ')' : '') +
+                (status ? ' while still in ' + status + '.' : '.')
+        });
+    });
+}
+
 function triggerSmWorkflow(context, reason) {
     if (context.recoveryState.smTriggered) return;
     context.scm.triggerWorkflow(
@@ -507,6 +557,7 @@ function action(params) {
     detectPrMergeGaps(context);
     detectFailedRuns(context);
     detectDuplicateRuns(context);
+    detectRepeatedFailureLoops(context);
     applySafeRecovery(context);
 
     var report = {

--- a/js/unit-tests/test_dfManager.js
+++ b/js/unit-tests/test_dfManager.js
@@ -131,6 +131,65 @@ suite('dfManager', function() {
         assert.ok(df.written.length > 0, 'report should be written');
     });
 
+    test('flags repeated failure loops on the same ticket', function() {
+        var df = makeDfManager({
+            tickets: [
+                {
+                    key: 'TS-909',
+                    fields: {
+                        status: { name: 'Failed' },
+                        labels: ['sm_bug_creation_triggered'],
+                        updated: '2026-05-09T16:59:00.000Z'
+                    }
+                }
+            ],
+            runsByStatus: {
+                completed: [
+                    {
+                        status: 'completed',
+                        conclusion: 'failure',
+                        workflowName: 'bug_creation',
+                        display_title: 'agents/bug_creation.json : TS-909'
+                    },
+                    {
+                        status: 'completed',
+                        conclusion: 'failure',
+                        workflowName: 'bug_creation',
+                        display_title: 'agents/bug_creation.json : TS-909'
+                    },
+                    {
+                        status: 'completed',
+                        conclusion: 'failure',
+                        workflowName: 'bug_creation',
+                        display_title: 'agents/bug_creation.json : TS-909'
+                    }
+                ]
+            }
+        });
+
+        var report = df.action({
+            jobParams: {
+                customParams: {
+                    nowMs: Date.parse('2026-05-09T17:00:00.000Z'),
+                    staleMinutes: 45
+                }
+            }
+        });
+
+        var repeated = null;
+        for (var i = 0; i < report.anomalies.length; i++) {
+            if (report.anomalies[i].type === 'repeated-failure-loop') {
+                repeated = report.anomalies[i];
+                break;
+            }
+        }
+
+        assert.ok(repeated, 'should report repeated failure loop');
+        assert.equal(repeated.ticketKey, 'TS-909');
+        assert.equal(repeated.workflowRuns, 3);
+        assert.equal(repeated.severity, 'blocking');
+    });
+
     test('does not report stale labels while matching run is active', function() {
         var df = makeDfManager({
             tickets: [


### PR DESCRIPTION
## What changed

- Added shared DF manager guidance for repeat-failure loops, queue starvation, and stale labels.
- Extended `dfManager.js` to flag tickets with 3+ failed runs as a `repeated-failure-loop` anomaly.
- Added a regression unit test covering the repeated-failure-loop signal.

## Why

This helps surface automation quality regressions earlier:
- the same ticket being processed repeatedly without status change
- one ticket monopolizing the queue
- failure churn that should be fixed in shared logic rather than patched ticket-by-ticket

## Scope

Shared logic only; no TrackState-specific labels or status names are hardcoded here.