### PR TITLE
Include In Development bugs in SM bug_development rule

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -62,8 +62,8 @@
           "addLabel": "sm_story_development_triggered"
         },
         {
-          "description": "Backlog / To Do / Ready For Development Bugs → trigger bug_development",
-          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development')",
+          "description": "Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development', 'In Development', 'In Progress')",
           "configFile": "agents/bug_development.json",
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",


### PR DESCRIPTION
## Problem

Bugs could get stuck in **In Development** with no active label/run.
The SM bug_development rule only matched statuses:
- Backlog
- To Do
- Ready For Development

So once a bug ended up in In Development without moving forward, SM stopped re-dispatching it.

## Fix

Expanded bug_development rule JQL to include:
- In Development
- In Progress

## Impact

Stalled bugs in active development statuses are now eligible for re-dispatch by SM instead of remaining orphaned in status.