### PR TITLE
improve: reduce test case explosion and fix duplicate bug detection

### DIFF
--- a/bug_creation.json
+++ b/bug_creation.json
@@ -29,7 +29,7 @@
     "preCliJSAction": "agents/js/prepareBugCreationContext.js",
     "postJSAction": "agents/js/postBugCreation.js",
     "customParams": {
-      "openBugsJql": "project = {jiraProject} AND issuetype in (Bug) AND status not in (Done)",
+      "openBugsJql": "project = {jiraProject} AND issuetype in (Bug) AND (status not in (Done) OR (status = Done AND updated >= -30d))",
       "removeLabel": "sm_bug_creation_triggered"
     },
     "inputJql": "key = JD-111",

--- a/bug_test_cases_generator.json
+++ b/bug_test_cases_generator.json
@@ -4,15 +4,15 @@
     "testCasesPriorities": "High, Medium, Low",
     "outputType": "creation",
     "testCaseIssueType": "Test Case",
-    "existingTestCasesJql": "project = {jiraProject} AND issuetype = 'Test Case'",
+    "existingTestCasesJql": "project = {jiraProject} AND issuetype = 'Test Case' ORDER BY created DESC",
     "testCaseLinkRelationship": "relates to",
     "isFindRelated": true,
     "isGenerateNew": true,
     "isConvertToJiraMarkdown": false,
     "isOverridePromptExamples": true,
-    "includeOtherTicketReferences": true,
+    "includeOtherTicketReferences": false,
     "alwaysPostComments": true,
-    "ticketContextDepth": 1,
+    "ticketContextDepth": 0,
     "confluencePages": [
       "./agents/instructions/test_cases/test_case_creation_rules.md"
     ],

--- a/instructions/test_cases/test_case_creation_rules.md
+++ b/instructions/test_cases/test_case_creation_rules.md
@@ -65,7 +65,32 @@ Generate test cases that cover:
 
 When the ticket type is *Bug*, the *Solution* field contains a structured RCA written by the development agent (Root Cause, Fix Applied, Prevention).
 
-Use the bug description and the Solution field to understand what broke and how it was fixed. Generate whatever test cases are needed to ensure this bug cannot recur undetected — covering the exact scenario that triggered it, the conditions around the root cause, and any prevention points noted in the Solution field.
+Use the bug description and the Solution field to understand what broke and how it was fixed.
+
+### Strict limits for bug-sourced test cases
+
+**Create at most 2 new test cases per bug ticket:**
+
+1. *Regression test* (mandatory) — the exact scenario that triggered the bug. This verifies the specific failure cannot silently recur.
+2. *Prevention test* (optional, only if mechanically distinct) — a test that targets the root cause fix directly and covers a scenario not already tested by the regression test.
+
+**Do NOT generate for bugs:**
+- Positive/happy-path scenarios (these belong to the original story)
+- Negative or boundary variants of the bug scenario (one regression test is sufficient)
+- Tests for related bugs found via ticket links — only test THIS bug's scenario
+- Multiple tests for different prevention points listed in the RCA — pick the most critical one
+
+**Before creating any test case for a bug:**
+1. Check the existing test cases listed in the context.
+2. If an existing test case title shares 5 or more meaningful words with your proposed title, skip creation and link the existing one instead.
+3. If the existing test case covers the same component + same failure symptom, link it — do not create a new one.
 
 For bug test case names use the format:
 *Test: [Scenario that triggered the bug] — [Expected correct behaviour]*
+
+### Deduplication check (mandatory before creating)
+
+Before creating any test case (for bugs or stories), scan the existing test case list for semantic overlap:
+- If an existing TC verifies the same widget/component AND the same expected outcome → link it, skip creation.
+- If the existing TC summary shares the same subject + verb + component (e.g., "workspace switcher closes", "startup probe resolves") → link it, skip creation.
+- When in doubt, link the closest existing TC and add a note explaining the overlap.

--- a/instructions/test_cases/test_case_relation_rules.md
+++ b/instructions/test_cases/test_case_relation_rules.md
@@ -35,6 +35,22 @@ If an existing test case covers the same scenario as a new test case being gener
 - Link the existing test case instead
 - Note in the comment that the existing test case covers this scenario
 
+### Semantic overlap rules (apply to all tickets, especially bugs)
+
+Treat two test cases as duplicates if ANY of the following match:
+- Their summaries share 5 or more consecutive meaningful words
+- They test the same **component** (e.g., "workspace switcher", "startup probe") AND the same **outcome** (e.g., "closes", "renders shell", "does not advance")
+- One is a slightly reworded version of the other with no additional scenario coverage
+
+When uncertain, always prefer linking the existing test case over creating a new one.
+
+### Bug deduplication — recently fixed
+
+If generating test cases for a *Bug* ticket, and an existing test case in the project already tests the exact regression scenario (even if its status is Failed or Done):
+- Do *not* create a new test case for the same scenario
+- Link the existing one with relationship "relates to"
+- Add a comment noting it is the canonical regression test for this bug
+
 ## Link Relationship
 
 Use relationship *"relates to"* for all linked test cases.

--- a/prompts/bug_creation_prompt.md
+++ b/prompts/bug_creation_prompt.md
@@ -13,16 +13,28 @@ Read `input/ticket.md` to understand:
 - What the expected behavior is
 - What failed (the test case is in Failed status)
 
-## Step 2 — Review existing open bugs
+## Step 2 — Review existing open bugs AND recently-fixed bugs
 
 Read every file named `Bug *.md` in the input folder.
-Each file represents an open bug with its key, summary, and description.
+Each file represents an open bug OR a recently-fixed bug (Done within the last 30 days).
 
-If `input/no_open_bugs.md` exists — there are no open bugs, skip to Step 3 directly.
+If `input/no_open_bugs.md` exists — there are no open or recently-fixed bugs, skip to Step 3 directly.
+
+### Matching criteria — treat as duplicate if ANY of the following:
+- The bug summary describes the **same component** (e.g., "workspace switcher", "startup probe") AND the **same failure symptom** (e.g., "closes", "does not render", "stays active")
+- The first 60 characters of the summaries are functionally identical (ignoring minor wording differences)
+- The bug description steps overlap ≥70% with the failed Test Case steps
+
+### Recently-fixed bugs (Done status) — regression handling
+If the matching bug has `status = Done` (it was fixed), this is a **regression**. Do NOT create a new duplicate bug. Instead:
+- Use `action: "link"` and reference the existing Done bug key
+- Explain in the reason: "This appears to be a regression of [KEY] which was previously fixed. Linking to track the regression."
 
 ## Step 3 — Make a decision
 
-**Case A — Matching bug found**: If an existing open bug clearly describes the same underlying issue as this Test Case failure, link to it. Do NOT create duplicates.
+**Case A — Matching open bug found**: If an existing open bug clearly describes the same underlying issue as this Test Case failure, link to it. Do NOT create duplicates.
+
+**Case A2 — Matching recently-fixed (Done) bug found**: If a recently-fixed bug (Done in the last 30 days) matches this failure, this is a regression. Link to it with a regression note. Do NOT create a new duplicate bug.
 
 **Case B — No match found**: Create a new bug ticket that describes the root cause of the test failure.
 
@@ -34,7 +46,7 @@ If `input/no_open_bugs.md` exists — there are no open bugs, skip to Step 3 dir
 
 Write `outputs/bug_decision.json` with exactly one of these formats:
 
-**Link to existing bug:**
+**Link to existing bug (open or regression):**
 ```json
 {
   "action": "link",
@@ -42,6 +54,7 @@ Write `outputs/bug_decision.json` with exactly one of these formats:
   "reason": "This bug describes the same issue: <brief explanation>"
 }
 ```
+*Use the same format for regressions — set reason to explain it is a regression of a previously-fixed bug.*
 
 **Create new bug:**
 ```json


### PR DESCRIPTION
## Problem

The number of test cases and bugs in the project has been growing exponentially due to 3 compounding issues:

### Issue 1: Duplicate bugs created when a fixed bug regresses
The `openBugsJql` only searched open bugs. When a bug gets fixed (Done) and the same test fails again, a new identical bug is created instead of linking to the original.

**Examples observed:**
- TS-1040 = TS-996 (identical summaries, created on different days)
- TS-1030 = TS-1011
- TS-1021 = TS-1010  
- TS-1022 = TS-1013

**Fix:** Extend `openBugsJql` to include Done bugs updated in last 30 days. Agent detects regression and links to original.

### Issue 2: Omnibus test cases linked to 10+ bugs
With `includeOtherTicketReferences: true` and `ticketContextDepth: 1`, the TC generator saw all related bugs via links and created "comprehensive" test cases covering all of them. Result: TS-990 was linked to 12 bugs, TS-1002 to 10 bugs.

**Fix:** Set `includeOtherTicketReferences: false` and `ticketContextDepth: 0` for bug TC generator — only scope to THIS bug's scenario.

### Issue 3: No limit on test cases per bug
Rules said "generate whatever test cases are needed" — AI created 5-9 TCs per bug (positive/negative/boundary variants).

**Fix:** Strict limit of max 2 TCs per bug (1 regression + 1 optional prevention), explicit rule against positive/negative/boundary variants for bug-sourced TCs, mandatory dedup check.

## Changes

- `bug_creation.json`: `openBugsJql` includes Done bugs (last 30d)
- `bug_test_cases_generator.json`: `includeOtherTicketReferences: false`, `ticketContextDepth: 0`
- `test_case_creation_rules.md`: max 2 TCs per bug, mandatory dedup, no variants
- `test_case_relation_rules.md`: semantic overlap rules (5+ words match = duplicate)
- `bug_creation_prompt.md`: Case A2 — link to recently-fixed bug as regression

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>