### PR TITLE
fix: revert openBugsJql to open-only; remove project-specific examples

### DIFF
--- a/bug_creation.json
+++ b/bug_creation.json
@@ -29,7 +29,7 @@
     "preCliJSAction": "agents/js/prepareBugCreationContext.js",
     "postJSAction": "agents/js/postBugCreation.js",
     "customParams": {
-      "openBugsJql": "project = {jiraProject} AND issuetype in (Bug) AND (status not in (Done) OR (status = Done AND updated >= -30d))",
+      "openBugsJql": "project = {jiraProject} AND issuetype in (Bug) AND status not in (Done)",
       "removeLabel": "sm_bug_creation_triggered"
     },
     "inputJql": "key = JD-111",

--- a/instructions/test_cases/test_case_creation_rules.md
+++ b/instructions/test_cases/test_case_creation_rules.md
@@ -91,6 +91,6 @@ For bug test case names use the format:
 ### Deduplication check (mandatory before creating)
 
 Before creating any test case (for bugs or stories), scan the existing test case list for semantic overlap:
-- If an existing TC verifies the same widget/component AND the same expected outcome → link it, skip creation.
-- If the existing TC summary shares the same subject + verb + component (e.g., "workspace switcher closes", "startup probe resolves") → link it, skip creation.
+- If an existing TC verifies the same component/feature AND the same expected outcome → link it, skip creation.
+- If the existing TC summary shares the same subject + verb + component → link it, skip creation.
 - When in doubt, link the closest existing TC and add a note explaining the overlap.

--- a/instructions/test_cases/test_case_relation_rules.md
+++ b/instructions/test_cases/test_case_relation_rules.md
@@ -39,12 +39,12 @@ If an existing test case covers the same scenario as a new test case being gener
 
 Treat two test cases as duplicates if ANY of the following match:
 - Their summaries share 5 or more consecutive meaningful words
-- They test the same **component** (e.g., "workspace switcher", "startup probe") AND the same **outcome** (e.g., "closes", "renders shell", "does not advance")
+- They test the same **component/feature** AND the same **outcome**
 - One is a slightly reworded version of the other with no additional scenario coverage
 
 When uncertain, always prefer linking the existing test case over creating a new one.
 
-### Bug deduplication — recently fixed
+### Bug deduplication — existing regression tests
 
 If generating test cases for a *Bug* ticket, and an existing test case in the project already tests the exact regression scenario (even if its status is Failed or Done):
 - Do *not* create a new test case for the same scenario

--- a/prompts/bug_creation_prompt.md
+++ b/prompts/bug_creation_prompt.md
@@ -13,28 +13,21 @@ Read `input/ticket.md` to understand:
 - What the expected behavior is
 - What failed (the test case is in Failed status)
 
-## Step 2 — Review existing open bugs AND recently-fixed bugs
+## Step 2 — Review existing open bugs
 
 Read every file named `Bug *.md` in the input folder.
-Each file represents an open bug OR a recently-fixed bug (Done within the last 30 days).
+Each file represents an open bug with its key, summary, and description.
 
-If `input/no_open_bugs.md` exists — there are no open or recently-fixed bugs, skip to Step 3 directly.
+If `input/no_open_bugs.md` exists — there are no open bugs, skip to Step 3 directly.
 
 ### Matching criteria — treat as duplicate if ANY of the following:
-- The bug summary describes the **same component** (e.g., "workspace switcher", "startup probe") AND the **same failure symptom** (e.g., "closes", "does not render", "stays active")
+- The bug summary describes the **same component** AND the **same failure symptom**
 - The first 60 characters of the summaries are functionally identical (ignoring minor wording differences)
 - The bug description steps overlap ≥70% with the failed Test Case steps
-
-### Recently-fixed bugs (Done status) — regression handling
-If the matching bug has `status = Done` (it was fixed), this is a **regression**. Do NOT create a new duplicate bug. Instead:
-- Use `action: "link"` and reference the existing Done bug key
-- Explain in the reason: "This appears to be a regression of [KEY] which was previously fixed. Linking to track the regression."
 
 ## Step 3 — Make a decision
 
 **Case A — Matching open bug found**: If an existing open bug clearly describes the same underlying issue as this Test Case failure, link to it. Do NOT create duplicates.
-
-**Case A2 — Matching recently-fixed (Done) bug found**: If a recently-fixed bug (Done in the last 30 days) matches this failure, this is a regression. Link to it with a regression note. Do NOT create a new duplicate bug.
 
 **Case B — No match found**: Create a new bug ticket that describes the root cause of the test failure.
 
@@ -46,7 +39,7 @@ If the matching bug has `status = Done` (it was fixed), this is a **regression**
 
 Write `outputs/bug_decision.json` with exactly one of these formats:
 
-**Link to existing bug (open or regression):**
+**Link to existing bug:**
 ```json
 {
   "action": "link",
@@ -54,7 +47,6 @@ Write `outputs/bug_decision.json` with exactly one of these formats:
   "reason": "This bug describes the same issue: <brief explanation>"
 }
 ```
-*Use the same format for regressions — set reason to explain it is a regression of a previously-fixed bug.*
 
 **Create new bug:**
 ```json


### PR DESCRIPTION
## Changes

Corrects two mistakes from PR #28:

### 1. Revert openBugsJql to open bugs only
The previous change included Done bugs (last 30d) to detect regressions. This is wrong:
- If a bug is closed (Done) and test automation still reports a failure, it means the issue genuinely still exists → create a new bug, not link to the Done one
- The original logic (only check open bugs) is correct

### 2. Remove project-specific examples from generic rules
The instructions files in `agents` repo must remain abstract and project-agnostic. Removed concrete examples like "workspace switcher closes", "startup probe resolves" from dedup rules. Generic language retained.

### What is kept from #28
- `bug_test_cases_generator.json`: `includeOtherTicketReferences: false`, `ticketContextDepth: 0` (generic config improvement)
- `test_case_creation_rules.md`: max 2 TCs per bug, mandatory dedup check (generic rules, now with generic examples)
- `test_case_relation_rules.md`: semantic overlap rules 5+ words (generic)
- `bug_creation_prompt.md`: stronger matching criteria (component + symptom, generic)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>