### PR TITLE
Add SOURCE_GITHUB_TOKEN workflow self-service guidance

### DIFF
--- a/instructions/development/bug_implementation_instructions.md
+++ b/instructions/development/bug_implementation_instructions.md
@@ -93,6 +93,12 @@ Then write `outputs/blocked.json`:
 Write a summary to `outputs/response.md` explaining the blocker clearly.
 **STOP — do not make incomplete changes.**
 
+### GitHub workflow self-service before blocking on deployment
+
+Before declaring a deployment/workflow blocker, use `SOURCE_GITHUB_TOKEN` (available as an environment variable) to trigger the required existing GitHub workflow(s) yourself (for example deploy/sync/retest workflows), then re-verify.
+
+Only use `blocked.json` for deployment/workflow reasons if self-triggered workflow attempts fail or are not permitted by repository configuration.
+
 ## Step 4 — Reproduce the Bug with a Unit Test First
 
 **Only after confirming the bug is NOT already fixed and NOT blocked:**

--- a/instructions/test_automation/test_automation_instructions.md
+++ b/instructions/test_automation/test_automation_instructions.md
@@ -55,6 +55,12 @@ Before writing a test, read project-specific CI, credential, and environment ins
 
 Do not assume a CI provider, cloud provider, project ID, secret name, or test account. If required credentials or test data are missing, report the exact missing item in `outputs/test_automation_result.json`.
 
+### GitHub workflow access
+
+- `SOURCE_GITHUB_TOKEN` is available as an environment variable in CI jobs.
+- You may use this token to call GitHub APIs or trigger required workflows yourself when the test flow depends on deployment/sync/retry automation.
+- Prefer repository workflows that already exist (for example, dispatching the project automation workflow with the proper inputs) instead of asking a human to click-run them manually.
+
 ---
 
 ## Test Data — Self-Sufficient Strategy

--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -11,6 +11,12 @@ User request is in 'input' folder, read all files there and do what is requested
    - Before writing `already_fixed.json`, verify the linked test actually passes with the current code.
 5. `existing_questions.json` — if present, clarification answers from the PO — treat as binding requirements
 
+## GitHub token and workflow self-service
+
+- `SOURCE_GITHUB_TOKEN` is available as an environment variable.
+- Use it to call GitHub API / `gh` and trigger the workflows you need yourself (deploy/sync/retest/retry automation), instead of waiting for manual human triggering.
+- Prefer existing project workflows and correct `workflow_dispatch` inputs.
+
 ## ⚠️ CRITICAL: Understand the bug BEFORE looking at code
 
 **Always start by deeply understanding what the user actually experiences**, not what the code looks like.


### PR DESCRIPTION
Adds explicit guidance for agents to self-trigger required GitHub workflows using SOURCE_GITHUB_TOKEN instead of blocking on manual deployment actions. Updates test automation instructions, bug development prompt, and bug implementation instructions.