### PR TITLE
Clarify bug development self-service deploy and merged flow

### DIFF
--- a/instructions/development/bug_implementation_instructions.md
+++ b/instructions/development/bug_implementation_instructions.md
@@ -35,6 +35,7 @@ Before claiming "already fixed" on any bug (returned or not):
    - If the test **PASSES** against current code → the bug may genuinely be fixed. Before writing `already_fixed.json`:
      - Re-read the latest comments — has QA confirmed the fix, or are they still reporting it broken?
      - Check the platform / build / environment the reporter mentioned — maybe it's only broken on one platform.
+     - If the failure is only in the deployed artifact, trigger the appropriate deploy/sync workflow yourself with `SOURCE_GITHUB_TOKEN`, rerun the linked test on the refreshed deployment, and only then decide whether `already_fixed.json` is correct.
      - Only after all of the above, if you are still confident, write `already_fixed.json`.
 
 ## Step 1 — Root Cause Analysis (RCA)

--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -16,6 +16,7 @@ User request is in 'input' folder, read all files there and do what is requested
 - `SOURCE_GITHUB_TOKEN` is available as an environment variable.
 - Use it to call GitHub API / `gh` and trigger the workflows you need yourself (deploy/sync/retest/retry automation), instead of waiting for manual human triggering.
 - Prefer existing project workflows and correct `workflow_dispatch` inputs.
+- If the codebase already contains the fix but the deployed app is stale, trigger the deploy/sync workflow yourself, rerun the linked test against the refreshed deployment, and then write `outputs/already_fixed.json` so the ticket can move to `Merged`.
 
 ## ⚠️ CRITICAL: Understand the bug BEFORE looking at code
 


### PR DESCRIPTION
Updates the bug development guidance to explicitly use SOURCE_GITHUB_TOKEN for deploy/sync workflows and to prefer already_fixed.json plus Merged when the source code already contains the fix but the deployment is stale.