### PR TITLE
fix(sm): handle empty labels in JQL NOT IN queries

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -71,7 +71,7 @@
         },
         {
           "description": "In Review Stories & Bugs → trigger pr_review",
-          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review') AND labels NOT IN ('pr_approved')",
+          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review') AND (labels is EMPTY OR labels NOT IN ('pr_approved'))",
           "configFile": "agents/pr_review.json",
           "skipIfLabel": "sm_story_review_triggered",
           "addLabel": "sm_story_review_triggered"
@@ -158,7 +158,7 @@
         },
         {
           "description": "In Review Test Cases → trigger pr_test_automation_review",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Review - Passed', 'In Review - Failed') AND labels NOT IN ('pr_approved')",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Review - Passed', 'In Review - Failed') AND (labels is EMPTY OR labels NOT IN ('pr_approved'))",
           "configFile": "agents/pr_test_automation_review.json",
           "skipIfLabel": "sm_test_review_triggered",
           "addLabel": "sm_test_review_triggered"
@@ -182,7 +182,7 @@
         },
         {
           "description": "Failed Test Cases → create or link bugs in batch",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') AND labels NOT IN ('sm_bug_creation_triggered') ORDER BY created ASC",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') AND (labels is EMPTY OR labels NOT IN ('sm_bug_creation_triggered')) ORDER BY created ASC",
           "configFile": "agents/bulk_bugs_creation.json",
           "skipIfLabel": "sm_bulk_bugs_creation_triggered",
           "addLabel": "sm_bulk_bugs_creation_triggered",


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
Jira JQL `labels NOT IN ('value')` does **not** match tickets with empty/null labels. This is a known Jira JQL behavior where `NOT IN` treats empty fields as "no value" and skips them.

This caused SM Agent to silently miss tickets like **TS-1150** (Bug, status: In Review, labels: []) — the pr_review rule never found it, so no review workflow was ever dispatched.

### Fix
Replaced `labels NOT IN ('x')` with `(labels is EMPTY OR labels NOT IN ('x'))` in all 3 affected rules:

| Rule | Config |
|------|--------|
| In Review Stories & Bugs → pr_review | `agents/pr_review.json` |
| In Review Test Cases → pr_test_automation_review | `agents/pr_test_automation_review.json` |
| Failed Test Cases → bulk_bugs_creation | `agents/bulk_bugs_creation.json` |

### Verification
- Ran `dmtools --debug run agents/sm.json` **before** fix → TS-1150 not found ("No tickets found")
- Ran `dmtools --debug run agents/sm.json` **after** fix → TS-1150 found, pr_review workflow dispatched ✅
- Confirmed via `dmtools jira_search_by_jql` that the fixed JQL returns TS-1150 correctly