### PR TITLE
chore: replace company-specific references with generic equivalents

### DIFF
--- a/.github/skills/dmtools-agents/SKILL.md
+++ b/.github/skills/dmtools-agents/SKILL.md
@@ -417,9 +417,9 @@ automatically use this directory for `git` and `gh` operations — no JS changes
 3. `configLoader.loadProjectConfig()` reads `workingDir` and stores it as `config.workingDir`
 4. All `cli_execute_command` calls in dev scripts pass `workingDirectory: config.workingDir`
 
-### Example — MAPC mobile app development
+### Example — mobile app development
 
-Agent JSON (`ai_teammate/mapc/story_development.json`):
+Agent JSON (`ai_teammate/myproject/story_development.json`):
 ```json
 {
   "params": {
@@ -438,7 +438,7 @@ Agent JSON (`ai_teammate/mapc/story_development.json`):
 `repositories.json` (checkout-project-dependencies):
 ```json
 {
-  "mapc": [
+  "myproject": [
     {"repo": "my-org/mobile-app", "branch": "develop"},
     {"repo": "my-org/backend", "branch": "master"}
   ]

--- a/js/cacheToReleases.js
+++ b/js/cacheToReleases.js
@@ -25,7 +25,7 @@
  * (falls back to aiRepository or targetRepository)
  *
  * Result in GitHub:
- *   Release:  [AI] [MAPC-123] Artefacts   (tag: ai-mapc-123)
+ *   Release:  [AI] [PROJ-123] Artefacts   (tag: ai-proj-123)
  *   Assets:   copilot-session.zip, agent-outputs.zip
  *
  * Usage in agent config:

--- a/js/common/releaseArtefacts.js
+++ b/js/common/releaseArtefacts.js
@@ -4,8 +4,8 @@
  * Core utilities for caching and restoring folders as GitHub Release assets.
  *
  * One release per ticket, multiple named assets inside:
- *   release tag:   ai-{ticketKey}              e.g. ai-mapc-123
- *   release name:  [AI] [MAPC-123] Artefacts
+ *   release tag:   ai-{ticketKey}              e.g. ai-proj-123
+ *   release name:  [AI] [PROJ-123] Artefacts
  *   asset names:   copilot-session.zip, agent-outputs.zip, ...
  *
  * Both the tag and release name are fully customizable via templates in customParams:
@@ -55,7 +55,7 @@ function buildReleaseName(ticketKey, nameTemplate) {
 /**
  * Resolve {ticketKey} template token in a folder path.
  * @param {string} template   e.g. ".copilot/session-state/{ticketKey}"
- * @param {string} ticketKey  e.g. "MAPC-123"
+ * @param {string} ticketKey  e.g. "PROJ-123"
  * @returns {string}
  */
 function resolveTemplate(template, ticketKey) {

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -76,7 +76,7 @@ function attemptResumeIfOutputsMissing(ticketKey, workingDir) {
         'Then write the four output files:\n\n' +
         '1. /Users/vagrant/git/outputs/test_automation_result.json\n' +
         '   Schema: { "status":"passed"|"failed", "passed":N, "failed":N, "skipped":N, "summary":"…",\n' +
-        '     "results":[{ "ticket":"MAPC-XXXX", "status":"passed"|"failed"|"written"|"skipped",\n' +
+        '     "results":[{ "ticket":"PROJ-XXXX", "status":"passed"|"failed"|"written"|"skipped",\n' +
         '       "title":"…", "file":"src/flows/…" }] }\n' +
         '   Mark any flow that was WRITTEN but not run as "status":"written" only when simulator execution was impossible.\n\n' +
         '2. /Users/vagrant/git/outputs/response.md\n' +

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -16,7 +16,7 @@ var configLoader = require('./configLoader.js');
 
 /**
  * Derive project key from customParams.configPath or customParams.projectKey.
- * e.g. ".dmtools/configs/mapc.js" → "mapc"
+ * e.g. ".dmtools/configs/myproject.js" → "myproject"
  */
 function deriveProjectKey(customParams) {
     if (!customParams) return '';

--- a/js/preCliMobileTestAutomationSetup.js
+++ b/js/preCliMobileTestAutomationSetup.js
@@ -236,7 +236,7 @@ function findFeatureBranch(ticketKey, featurePR) {
  * input/{KEY}/app_info.md with the path for the agent prompt to use.
  *
  * @param {string} ticketKey
- * @param {string} folder       - input folder path, e.g. "input/MAPC-6618"
+ * @param {string} folder       - input folder path, e.g. "input/PROJ-6618"
  * @param {object} bitriseBuild - { appSlug, workflowId }
  * @param {string} branch       - feature branch name (may be null → any branch)
  * @param {string} workingDir   - working directory for cli commands
@@ -271,7 +271,7 @@ function downloadBitriseApp(ticketKey, folder, bitriseBuild, branch, workingDir)
         var successBuilds = builds.filter(function(b) { return b.status === 1 || b.status_text === 'success'; });
 
         // If we have a feature branch, find the build whose commit message
-        // mentions it (e.g. "MAPC-6818 — iOS build for bug/MAPC-6818")
+        // mentions it (e.g. "PROJ-6818 — iOS build for bug/PROJ-6818")
         if (branch && successBuilds.length > 0) {
             var branchMatched = successBuilds.filter(function(b) {
                 var msg = b.commit_message || b.original_build_params_commit_message || '';
@@ -418,7 +418,7 @@ function downloadBitriseApp(ticketKey, folder, bitriseBuild, branch, workingDir)
  *
  * @param {string} appPath - absolute path to the .app bundle
  * @param {string} folder  - input folder for writing updated app_info.md
- * @param {string} [appId] - bundle identifier (e.g. com.postnl.internal.business.customer)
+ * @param {string} [appId] - bundle identifier (e.g. com.example.internal.business.app)
  */
 function installAppOnSimulator(appPath, folder, appId) {
     if (!appPath) {
@@ -462,7 +462,7 @@ function installAppOnSimulator(appPath, folder, appId) {
     }
 
     // Append simulator info to app_info.md
-    var resolvedAppId = appId || 'com.postnl.internal.business.customer';
+    var resolvedAppId = appId || 'com.example.internal.business.app';
     try {
         var simInfo = [
             '\n## Simulator & Maestro\n',

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -27,9 +27,9 @@
  *   workflowFile   (optional) — GitHub Actions workflow file  (default: ai-teammate.yml)
  *   workflowRef    (optional) — git ref for dispatch           (default: main)
  *   projectKey     (optional) — value passed as the `project_key` workflow input so the runner
- *                               activates the correct project-specific dependency setup (e.g. "mapc",
+ *                               activates the correct project-specific dependency setup (e.g. "myproject",
  *                               "bice"). Auto-derived from configPath basename when not set
- *                               (e.g. ".dmtools/configs/mapc.js" → "mapc").
+ *                               (e.g. ".dmtools/configs/myproject.js" → "myproject").
  *   skipIfLabel    (optional) — skip ticket if it already has this label (idempotency)
  *   skipIfLabels   (optional) — skip ticket if it already has any of these labels
  *   addLabel       (optional) — add this label after triggering (idempotency marker)
@@ -64,7 +64,7 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig) {
     var p = { inputJql: 'key = ' + ticketKey };
     var resolvedCf = resolveConfigFile(rule, effectiveConfig);
 
-    // Derive project key to resolve project-specific agent JSON (e.g. "agents/pr_review.json" → "ai_teammate/mapc/pr_review.json")
+    // Derive project key to resolve project-specific agent JSON (e.g. "agents/pr_review.json" → "ai_teammate/myproject/pr_review.json")
     var projectKey = rule.projectKey || '';
     if (!projectKey && effectiveConfig && effectiveConfig._configPath) {
         var cp = effectiveConfig._configPath;
@@ -227,7 +227,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig) {
     var resolvedCf   = resolveConfigFile(rule, effectiveConfig);
 
     // Resolve project_key: explicit rule field takes priority, then auto-derive from configPath
-    // e.g. ".dmtools/configs/mapc.js" → "mapc", ".dmtools/configs/bice.js" → "bice"
+    // e.g. ".dmtools/configs/myproject.js" → "myproject", ".dmtools/configs/bice.js" → "bice"
     var projectKey = rule.projectKey || '';
     if (!projectKey && effectiveConfig && effectiveConfig._configPath) {
         var cp = effectiveConfig._configPath;

--- a/js/triggerBitriseIosBuild.js
+++ b/js/triggerBitriseIosBuild.js
@@ -5,7 +5,7 @@
  * build_ios_simulator on the PR's head branch.
  *
  * Required jobParams:
- *   inputJql           — JQL to find the ticket (e.g. "key = MAPC-6815")
+ *   inputJql           — JQL to find the ticket (e.g. "key = PROJ-6815")
  *   bitriseBuild.appSlug       — Bitrise app slug
  *   bitriseBuild.workflowId   — Bitrise workflow ID (default: build_ios_simulator)
  *   bitriseBuild.triggerBranch — branch for Bitrise trigger (use "main" when YAML
@@ -36,7 +36,7 @@ function action(params) {
         var ticketKey = '';
         var ticketSummary = '';
         if (inputJql) {
-            // Extract ticket key directly from JQL (e.g. "key = MAPC-6815")
+            // Extract ticket key directly from JQL (e.g. "key = PROJ-6815")
             var keyMatch = inputJql.match(/key\s*=\s*([A-Z]+-\d+)/i);
             if (keyMatch) {
                 ticketKey = keyMatch[1].toUpperCase();

--- a/js/unit-tests/test_branchNaming.js
+++ b/js/unit-tests/test_branchNaming.js
@@ -69,7 +69,7 @@ suite('configLoader.resolveBranchName', function() {
         assert.equal(receivedRole, 'feature');
     });
 
-    test('branchNamingFn for MAPC-style issue-type naming: bug/MAPC-123', function() {
+    test('branchNamingFn for PROJ-style issue-type naming: bug/PROJ-123', function() {
         var mapcNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             return issueType + '/' + ticket.key;
@@ -77,11 +77,11 @@ suite('configLoader.resolveBranchName', function() {
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
             git: { branchNamingFn: mapcNamingFn }
         });
-        var ticket = { key: 'MAPC-123', fields: { issuetype: { name: 'Bug' } } };
-        assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'bug/MAPC-123');
+        var ticket = { key: 'PROJ-123', fields: { issuetype: { name: 'Bug' } } };
+        assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'bug/PROJ-123');
     });
 
-    test('branchNamingFn for MAPC-style issue-type naming: story/STORY-456', function() {
+    test('branchNamingFn for PROJ-style issue-type naming: story/STORY-456', function() {
         var mapcNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             return issueType + '/' + ticket.key;
@@ -93,7 +93,7 @@ suite('configLoader.resolveBranchName', function() {
         assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'story/STORY-456');
     });
 
-    test('branchNamingFn for MAPC-style issue-type naming: subtask → task/PROJ-1', function() {
+    test('branchNamingFn for PROJ-style issue-type naming: subtask → task/PROJ-1', function() {
         var mapcNamingFn = function(ticket, branchRole) {
             var rawType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             var issueType = rawType === 'subtask' ? 'task' : rawType;
@@ -174,7 +174,7 @@ suite('configLoader.resolvePRTargetBranch', function() {
         assert.equal(configLoaderModule.resolvePRTargetBranch(config, ticket), 'feature-PROJ-5');
     });
 
-    test('two-branch mode with MAPC-style naming', function() {
+    test('two-branch mode with PROJ-style naming', function() {
         var mapcNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             if (branchRole === 'feature') return issueType + '/' + ticket.key;
@@ -186,8 +186,8 @@ suite('configLoader.resolvePRTargetBranch', function() {
                 branchNamingFn: mapcNamingFn
             }
         });
-        var ticket = { key: 'MAPC-55', fields: { issuetype: { name: 'Story' } } };
-        assert.equal(configLoaderModule.resolvePRTargetBranch(config, ticket), 'story/MAPC-55');
+        var ticket = { key: 'PROJ-55', fields: { issuetype: { name: 'Story' } } };
+        assert.equal(configLoaderModule.resolvePRTargetBranch(config, ticket), 'story/PROJ-55');
     });
 
 });

--- a/js/unit-tests/test_branchNaming.js
+++ b/js/unit-tests/test_branchNaming.js
@@ -69,50 +69,50 @@ suite('configLoader.resolveBranchName', function() {
         assert.equal(receivedRole, 'feature');
     });
 
-    test('branchNamingFn for PROJ-style issue-type naming: bug/PROJ-123', function() {
-        var mapcNamingFn = function(ticket, branchRole) {
+    test('branchNamingFn for project-style issue-type naming: bug/PROJ-123', function() {
+        var projectNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             return issueType + '/' + ticket.key;
         };
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
-            git: { branchNamingFn: mapcNamingFn }
+            git: { branchNamingFn: projectNamingFn }
         });
         var ticket = { key: 'PROJ-123', fields: { issuetype: { name: 'Bug' } } };
         assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'bug/PROJ-123');
     });
 
-    test('branchNamingFn for PROJ-style issue-type naming: story/STORY-456', function() {
-        var mapcNamingFn = function(ticket, branchRole) {
+    test('branchNamingFn for project-style issue-type naming: story/STORY-456', function() {
+        var projectNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             return issueType + '/' + ticket.key;
         };
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
-            git: { branchNamingFn: mapcNamingFn }
+            git: { branchNamingFn: projectNamingFn }
         });
         var ticket = { key: 'STORY-456', fields: { issuetype: { name: 'Story' } } };
         assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'story/STORY-456');
     });
 
-    test('branchNamingFn for PROJ-style issue-type naming: subtask → task/PROJ-1', function() {
-        var mapcNamingFn = function(ticket, branchRole) {
+    test('branchNamingFn for project-style issue-type naming: subtask → task/PROJ-1', function() {
+        var projectNamingFn = function(ticket, branchRole) {
             var rawType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             var issueType = rawType === 'subtask' ? 'task' : rawType;
             return issueType + '/' + ticket.key;
         };
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
-            git: { branchNamingFn: mapcNamingFn }
+            git: { branchNamingFn: projectNamingFn }
         });
         var ticket = { key: 'PROJ-1', fields: { issuetype: { name: 'Subtask' } } };
         assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'task/PROJ-1');
     });
 
     test('branchNamingFn fallback when ticket has no issuetype', function() {
-        var mapcNamingFn = function(ticket, branchRole) {
+        var projectNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             return issueType + '/' + ticket.key;
         };
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
-            git: { branchNamingFn: mapcNamingFn }
+            git: { branchNamingFn: projectNamingFn }
         });
         var ticket = { key: 'PROJ-7', fields: {} };
         assert.equal(configLoaderModule.resolveBranchName(config, ticket, 'development'), 'feature/PROJ-7');
@@ -174,8 +174,8 @@ suite('configLoader.resolvePRTargetBranch', function() {
         assert.equal(configLoaderModule.resolvePRTargetBranch(config, ticket), 'feature-PROJ-5');
     });
 
-    test('two-branch mode with PROJ-style naming', function() {
-        var mapcNamingFn = function(ticket, branchRole) {
+    test('two-branch mode with project-style naming', function() {
+        var projectNamingFn = function(ticket, branchRole) {
             var issueType = (ticket.fields && ticket.fields.issuetype && ticket.fields.issuetype.name || 'feature').toLowerCase();
             if (branchRole === 'feature') return issueType + '/' + ticket.key;
             return 'ai/' + ticket.key;
@@ -183,7 +183,7 @@ suite('configLoader.resolvePRTargetBranch', function() {
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
             git: {
                 featureBranch: { enabled: true },
-                branchNamingFn: mapcNamingFn
+                branchNamingFn: projectNamingFn
             }
         });
         var ticket = { key: 'PROJ-55', fields: { issuetype: { name: 'Story' } } };

--- a/js/unit-tests/test_createPlannedStoriesFromOutput.js
+++ b/js/unit-tests/test_createPlannedStoriesFromOutput.js
@@ -52,7 +52,7 @@ function makeParams(customStoryPlanConfig, overrides) {
                     summaryCommentTitle: 'Planned Stories',
                     blockedByRelationship: 'is blocked by',
                     blockedStatusName: 'Blocked',
-                    projectKey: 'MAPC',
+                    projectKey: 'PROJ',
                     issueTypeName: 'Story',
                     additionalLinks: [
                         { target: 'sourceTicket', relationship: 'Relates', includeExisting: true }
@@ -138,7 +138,7 @@ suite('createPlannedStoriesFromOutput — creation flow', function() {
 
         assert.equal(result.success, true, 'action succeeds');
         assert.equal(createCalls.length, 2, 'two stories created');
-        assert.equal(createCalls[0].project, 'MAPC', 'creation project can differ from parent project');
+        assert.equal(createCalls[0].project, 'PROJ', 'creation project can differ from parent project');
         assert.equal(createCalls[0].fieldsJson.issuetype.name, 'Story', 'issue type can be configured');
         assert.equal(createCalls[0].fieldsJson.parent.key, 'PARENT-100', 'mobile parent resolved from source parent');
         assert.equal(createCalls[1].fieldsJson.parent.key, 'PARENT-100', 'sf parent resolved from source parent');

--- a/js/unit-tests/test_feedbackLoop.js
+++ b/js/unit-tests/test_feedbackLoop.js
@@ -173,7 +173,7 @@ suite('feedbackLoop helper', function() {
             cli_execute_command: function(args) {
                 loaded.commands.push(args);
                 if (args.command === 'yarn lint:a11y') {
-                    assert.equal(args.workingDirectory, 'dependencies/PostNL-commercial-mobileApp');
+                    assert.equal(args.workingDirectory, 'dependencies/example-mobile-app');
                     throw new Error('a11y failed');
                 }
                 return '';
@@ -182,7 +182,7 @@ suite('feedbackLoop helper', function() {
 
         var result = loaded.mod.runPostPublishGates({
             ticketKey: 'TS-5',
-            workingDir: 'dependencies/PostNL-commercial-mobileApp',
+            workingDir: 'dependencies/example-mobile-app',
             customParams: {
                 feedbackLoop: {
                     postPublishGates: {
@@ -205,7 +205,7 @@ suite('feedbackLoop helper', function() {
         );
         assert.contains(
             loaded.files['outputs/feedback/TS-5_post_publish_gate_accessibility-lint.md'],
-            'Working directory: dependencies/PostNL-commercial-mobileApp'
+            'Working directory: dependencies/example-mobile-app'
         );
     });
 

--- a/js/unit-tests/test_fetchParentContextToInput.js
+++ b/js/unit-tests/test_fetchParentContextToInput.js
@@ -19,9 +19,9 @@ function loadFetchParentContext(mocks) {
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-var PARENT_KEY = 'MAPC-100';
-var TICKET_KEY = 'MAPC-101';
-var INPUT_FOLDER = 'input/MAPC-101';
+var PARENT_KEY = 'PROJ-100';
+var TICKET_KEY = 'PROJ-101';
+var INPUT_FOLDER = 'input/PROJ-101';
 
 function makeParams(customParams, overrides) {
     return Object.assign({
@@ -152,7 +152,7 @@ suite('fetchParentContextToInput — context matching', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]')];
+                return [makeSearchResult('PROJ-200', '[BA]')];
             },
             file_write: function(p, c) { writtenFiles.push(p); }
         });
@@ -165,7 +165,7 @@ suite('fetchParentContextToInput — context matching', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-201', '[SA]')];
+                return [makeSearchResult('PROJ-201', '[SA]')];
             },
             file_write: function(p, c) { writtenFiles.push(p); }
         });
@@ -179,8 +179,8 @@ suite('fetchParentContextToInput — context matching', function() {
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
                 return [
-                    makeSearchResult('MAPC-200', '[BA]'),
-                    makeSearchResult('MAPC-201', '[SA]')
+                    makeSearchResult('PROJ-200', '[BA]'),
+                    makeSearchResult('PROJ-201', '[SA]')
                 ];
             },
             file_write: function(p, c) { writtenFiles.push(p); }
@@ -193,7 +193,7 @@ suite('fetchParentContextToInput — context matching', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[ba]')]; // lowercase
+                return [makeSearchResult('PROJ-200', '[ba]')]; // lowercase
             },
             file_write: function(p, c) { writtenFiles.push(p); }
         });
@@ -205,7 +205,7 @@ suite('fetchParentContextToInput — context matching', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-202', '[QA]')]; // no QA context configured
+                return [makeSearchResult('PROJ-202', '[QA]')]; // no QA context configured
             },
             file_write: function(p, c) { writtenFiles.push(p); }
         });
@@ -217,7 +217,7 @@ suite('fetchParentContextToInput — context matching', function() {
         var writtenPaths = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]')];
+                return [makeSearchResult('PROJ-200', '[BA]')];
             },
             file_write: function(p, c) { writtenPaths.push(p); }
         });
@@ -235,13 +235,13 @@ suite('fetchParentContextToInput — file content', function() {
         var writtenContent = null;
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]', { description: 'AC1: user can login' })];
+                return [makeSearchResult('PROJ-200', '[BA]', { description: 'AC1: user can login' })];
             },
             file_write: function(p, c) { writtenContent = c; }
         });
         m.action(makeParams(MINIMAL_PARENT_CONTEXT_FETCH));
         assert.ok(writtenContent !== null, 'content was written');
-        assert.ok(writtenContent.indexOf('MAPC-200') !== -1, 'ticket key in content');
+        assert.ok(writtenContent.indexOf('PROJ-200') !== -1, 'ticket key in content');
         assert.ok(writtenContent.indexOf('Business Analysis') !== -1, 'label in content');
     });
 
@@ -249,7 +249,7 @@ suite('fetchParentContextToInput — file content', function() {
         var writtenContent = null;
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]', { description: 'AC1: user can login' })];
+                return [makeSearchResult('PROJ-200', '[BA]', { description: 'AC1: user can login' })];
             },
             file_write: function(p, c) { writtenContent = c; }
         });
@@ -261,7 +261,7 @@ suite('fetchParentContextToInput — file content', function() {
         var writtenPaths = [];
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]')];
+                return [makeSearchResult('PROJ-200', '[BA]')];
             },
             file_write: function(p, c) { writtenPaths.push(p); }
         });
@@ -282,12 +282,12 @@ suite('fetchParentContextToInput — re-fetch fallback', function() {
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
                 // Returns result WITHOUT 'High-Level Solution' field
-                return [{ key: 'MAPC-200', fields: { summary: '[BA] Title', status: { name: 'Done' } } }];
+                return [{ key: 'PROJ-200', fields: { summary: '[BA] Title', status: { name: 'Done' } } }];
             },
             jira_get_ticket: function(opts) {
                 refetchedKeys.push(opts.key);
                 return {
-                    key: 'MAPC-200',
+                    key: 'PROJ-200',
                     fields: {
                         summary: '[BA] Title',
                         description: 'Full description',
@@ -302,18 +302,18 @@ suite('fetchParentContextToInput — re-fetch fallback', function() {
             fields: ['key', 'summary', 'description', 'status', 'High-Level Solution']
         });
         m.action(makeParams(cfg));
-        assert.ok(refetchedKeys.indexOf('MAPC-200') !== -1, 're-fetch was triggered for MAPC-200');
+        assert.ok(refetchedKeys.indexOf('PROJ-200') !== -1, 're-fetch was triggered for PROJ-200');
     });
 
     test('re-fetched field content appears in output file', function() {
         var writtenContent = null;
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [{ key: 'MAPC-200', fields: { summary: '[BA] Title', status: { name: 'Done' } } }];
+                return [{ key: 'PROJ-200', fields: { summary: '[BA] Title', status: { name: 'Done' } } }];
             },
             jira_get_ticket: function() {
                 return {
-                    key: 'MAPC-200',
+                    key: 'PROJ-200',
                     fields: {
                         summary: '[BA] Title',
                         description: 'Full description from re-fetch',
@@ -356,7 +356,7 @@ suite('fetchParentContextToInput — error resilience', function() {
     test('is non-fatal when file_write throws', function() {
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
-                return [makeSearchResult('MAPC-200', '[BA]')];
+                return [makeSearchResult('PROJ-200', '[BA]')];
             },
             file_write: function() { throw new Error('disk full'); }
         });
@@ -392,8 +392,8 @@ suite('fetchParentContextToInput — error resilience', function() {
         var m = loadFetchParentContext({
             jira_search_by_jql: function() {
                 return [
-                    makeSearchResult('MAPC-200', '[BA]'),
-                    makeSearchResult('MAPC-201', '[SA]')
+                    makeSearchResult('PROJ-200', '[BA]'),
+                    makeSearchResult('PROJ-201', '[SA]')
                 ];
             },
             file_write: function(p, c) {

--- a/js/unit-tests/test_postMobileTestAutomationResults.js
+++ b/js/unit-tests/test_postMobileTestAutomationResults.js
@@ -59,7 +59,7 @@ function makeParams(ticketKey, customParams) {
         ticket: { key: ticketKey, fields: { summary: 'Test ticket summary', labels: [] } },
         jobParams: {
             customParams: Object.assign({
-                featurePR: { owner: 'PostNL-BitDigital', repo: 'PostNL-commercial-mobileApp' },
+                featurePR: { owner: 'ExampleOrg', repo: 'example-mobile-app' },
                 labels: { testsPassed: 'tests_passed', testsFailed: 'tests_failed' },
                 testFilesGlob: 'src/flows/'
             }, customParams || {})
@@ -71,8 +71,8 @@ var PASSED_RESULT = JSON.stringify({
     status: 'passed',
     summary: '3 flows written, all passed',
     results: [
-        { ticket: 'MAPC-TC-1', title: 'VoiceOver modal', status: 'passed' },
-        { ticket: 'MAPC-TC-2', title: 'Close button label', status: 'passed' }
+        { ticket: 'PROJ-TC-1', title: 'VoiceOver modal', status: 'passed' },
+        { ticket: 'PROJ-TC-2', title: 'Close button label', status: 'passed' }
     ]
 });
 
@@ -80,8 +80,8 @@ var FAILED_RESULT = JSON.stringify({
     status: 'failed',
     summary: '2 flows, 1 failed',
     results: [
-        { ticket: 'MAPC-TC-1', title: 'VoiceOver modal', status: 'passed' },
-        { ticket: 'MAPC-TC-2', title: 'Close button', status: 'failed', error: 'Element not found' }
+        { ticket: 'PROJ-TC-1', title: 'VoiceOver modal', status: 'passed' },
+        { ticket: 'PROJ-TC-2', title: 'Close button', status: 'failed', error: 'Element not found' }
     ]
 });
 
@@ -91,8 +91,8 @@ var COUNT_ONLY_PASSED_RESULT = JSON.stringify({
     failed: 0,
     skipped: 0,
     results: [
-        { ticket: 'MAPC-TC-1', title: 'VoiceOver modal', status: 'passed' },
-        { ticket: 'MAPC-TC-2', title: 'Close button label', status: 'passed' }
+        { ticket: 'PROJ-TC-1', title: 'VoiceOver modal', status: 'passed' },
+        { ticket: 'PROJ-TC-2', title: 'Close button label', status: 'passed' }
     ]
 });
 
@@ -110,14 +110,14 @@ suite('postMobileTestAutomationResults — findFeaturePR', function() {
             },
             github_list_prs: function() {
                 return JSON.stringify({ data: [
-                    { number: 963, title: 'MAPC-6618 some feature', head: { ref: 'story/MAPC-6618' } }
+                    { number: 963, title: 'PROJ-6618 some feature', head: { ref: 'story/PROJ-6618' } }
                 ]});
             },
             github_add_pr_label: function(opts) { labelsCalled.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(labelsCalled.length > 0, 'should add label to found PR');
         assert.equal(labelsCalled[0].pullRequestId, '963', 'should use correct PR number (as string)');
@@ -132,13 +132,13 @@ suite('postMobileTestAutomationResults — findFeaturePR', function() {
                 return null;
             },
             github_list_prs: function() {
-                return [{ number: 42, title: 'Story MAPC-6618', head: { ref: 'story/MAPC-6618' } }];
+                return [{ number: 42, title: 'Story PROJ-6618', head: { ref: 'story/PROJ-6618' } }];
             },
             github_add_pr_label: function(opts) { labelsCalled.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(labelsCalled.length > 0, 'should add label even when PRs returned as array');
         assert.equal(labelsCalled[0].pullRequestId, '42');
@@ -152,11 +152,11 @@ suite('postMobileTestAutomationResults — findFeaturePR', function() {
                 return null;
             },
             github_list_prs: function() { return JSON.stringify({ data: [] }); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
         // Should complete without throwing
-        var result = m.action(makeParams('MAPC-6618'));
+        var result = m.action(makeParams('PROJ-6618'));
         assert.equal(result.success, true, 'action should succeed even without a feature PR');
     });
 
@@ -175,14 +175,14 @@ suite('postMobileTestAutomationResults — feature PR label', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function(opts) { added.push(opts.label); },
             github_remove_pr_label: function(opts) { removed.push(opts.label); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(added.indexOf('tests_passed') !== -1, 'should add tests_passed label');
         assert.ok(removed.indexOf('tests_failed') !== -1, 'should remove tests_failed label');
@@ -197,14 +197,14 @@ suite('postMobileTestAutomationResults — feature PR label', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function(opts) { added.push(opts.label); },
             github_remove_pr_label: function(opts) { removed.push(opts.label); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(added.indexOf('tests_failed') !== -1, 'should add tests_failed label');
         assert.ok(removed.indexOf('tests_passed') !== -1, 'should remove tests_passed label');
@@ -219,15 +219,15 @@ suite('postMobileTestAutomationResults — feature PR label', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function(opts) { added.push(opts.label); },
             github_remove_pr_label: function(opts) { removed.push(opts.label); },
             jira_move_to_status: function(opts) { statusMoves.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(added.indexOf('tests_passed') !== -1, 'should add tests_passed label');
         assert.ok(removed.indexOf('tests_failed') !== -1, 'should remove tests_failed label');
@@ -243,14 +243,14 @@ suite('postMobileTestAutomationResults — feature PR label', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 10, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 10, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function(opts) { added.push(opts.label); },
             github_remove_pr_label: function() {},
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618', { labels: { testsPassed: 'qa_approved', testsFailed: 'qa_rejected' } }));
+        m.action(makeParams('PROJ-6618', { labels: { testsPassed: 'qa_approved', testsFailed: 'qa_rejected' } }));
 
         assert.ok(added.indexOf('qa_approved') !== -1, 'should use custom passed label');
     });
@@ -273,18 +273,18 @@ suite('postMobileTestAutomationResults — feature PR comment', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function() {},
             github_remove_pr_label: function() {},
             github_add_pr_comment: function(opts) { prComments.push(opts); },
             cli_execute_command: function(opts) {
                 cliCommands.push(opts.command || '');
-                return 'test/MAPC-6618';
+                return 'test/PROJ-6618';
             }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(prComments.length > 0, 'should call github_add_pr_comment');
         assert.equal(prComments[0].pullRequestId, '963', 'should target correct PR');
@@ -306,15 +306,15 @@ suite('postMobileTestAutomationResults — feature PR comment', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function() {},
             github_remove_pr_label: function() {},
             github_add_pr_comment: function(opts) { prComments.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.equal(prComments.length, 1, 'should post PR comment using pr_body.md fallback');
         assert.ok(prComments[0].text.indexOf('pr_body') !== -1, 'should contain pr_body content');
@@ -331,15 +331,15 @@ suite('postMobileTestAutomationResults — feature PR comment', function() {
                 return null;
             },
             github_list_prs: function() {
-                return JSON.stringify({ data: [{ number: 963, title: 'MAPC-6618', head: { ref: 'story/MAPC-6618' } }]});
+                return JSON.stringify({ data: [{ number: 963, title: 'PROJ-6618', head: { ref: 'story/PROJ-6618' } }]});
             },
             github_add_pr_label: function() {},
             github_remove_pr_label: function() {},
             github_add_pr_comment: function(opts) { prComments.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.equal(prComments.length, 1, 'should post PR comment');
         assert.ok(prComments[0].text.indexOf('FIX VERIFIED') !== -1, 'should include inferred verdict');
@@ -363,12 +363,12 @@ suite('postMobileTestAutomationResults — Jira updates', function() {
             },
             jira_post_comment: function(opts) { jiraComments.push(opts); },
             jira_move_to_status: function(opts) { statusMoves.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
-        assert.ok(jiraComments.some(function(c) { return c.key === 'MAPC-6618'; }), 'should post Jira comment');
+        assert.ok(jiraComments.some(function(c) { return c.key === 'PROJ-6618'; }), 'should post Jira comment');
         assert.ok(statusMoves.some(function(s) { return s.statusName === 'Passed'; }), 'should move to Passed');
     });
 
@@ -383,10 +383,10 @@ suite('postMobileTestAutomationResults — Jira updates', function() {
             },
             jira_post_comment: function() {},
             jira_move_to_status: function(opts) { statusMoves.push(opts); },
-            cli_execute_command: function() { return 'test/MAPC-6618'; }
+            cli_execute_command: function() { return 'test/PROJ-6618'; }
         });
 
-        m.action(makeParams('MAPC-6618'));
+        m.action(makeParams('PROJ-6618'));
 
         assert.ok(statusMoves.some(function(s) { return s.statusName === 'Failed'; }), 'should move to Failed');
     });
@@ -400,7 +400,7 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
     test('commits and pushes even when test_automation_result.json is missing', function() {
         var gitCommands = [];
         var jiraComments = [];
-        var WORKING_DIR = 'dependencies/PostNL-commercial-mobileApp-automation';
+        var WORKING_DIR = 'dependencies/example-mobile-app-automation';
 
         var m = loadPostCli({
             file_read: function(opts) {
@@ -409,13 +409,13 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
             },
             cli_execute_command: function(opts) {
                 gitCommands.push(opts.command || '');
-                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/MAPC-6618';
+                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/PROJ-6618';
                 return '';
             },
             jira_post_comment: function(opts) { jiraComments.push(opts); }
         });
 
-        m.action(makeParams('MAPC-6618', { targetRepository: { workingDir: WORKING_DIR } }));
+        m.action(makeParams('PROJ-6618', { targetRepository: { workingDir: WORKING_DIR } }));
 
         var hasAddOrCommit = gitCommands.some(function(c) {
             return c.indexOf('git add') !== -1 || c.indexOf('git commit') !== -1;
@@ -427,7 +427,7 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
 
     test('missing-output resume prompt runs suite when simulator is available', function() {
         var writes = {};
-        var WORKING_DIR = 'dependencies/PostNL-commercial-mobileApp-automation';
+        var WORKING_DIR = 'dependencies/example-mobile-app-automation';
 
         var m = loadPostCli({
             file_read: function(opts) {
@@ -438,13 +438,13 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
                 writes[path] = content;
             },
             cli_execute_command: function(opts) {
-                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/MAPC-6618';
+                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/PROJ-6618';
                 return '';
             },
             jira_post_comment: function() {}
         });
 
-        m.action(makeParams('MAPC-6618', { targetRepository: { workingDir: WORKING_DIR } }));
+        m.action(makeParams('PROJ-6618', { targetRepository: { workingDir: WORKING_DIR } }));
 
         var prompt = writes['outputs/.resume-prompt.md'] || '';
         assert.ok(prompt.indexOf('run the generated suite once on the available simulator') !== -1,
@@ -455,7 +455,7 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
 
     test('reads result JSON from automation repo outputs dir as fallback', function() {
         var statusMoves = [];
-        var WORKING_DIR = 'dependencies/PostNL-commercial-mobileApp-automation';
+        var WORKING_DIR = 'dependencies/example-mobile-app-automation';
 
         var m = loadPostCli({
             file_read: function(opts) {
@@ -465,14 +465,14 @@ suite('postMobileTestAutomationResults — git commit resilience', function() {
                 return null;
             },
             cli_execute_command: function(opts) {
-                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/MAPC-6618';
+                if ((opts.command || '').indexOf('branch --show-current') !== -1) return 'test/PROJ-6618';
                 return '';
             },
             jira_move_to_status: function(opts) { statusMoves.push(opts); },
             jira_post_comment: function() {}
         });
 
-        m.action(makeParams('MAPC-6618', { targetRepository: { workingDir: WORKING_DIR } }));
+        m.action(makeParams('PROJ-6618', { targetRepository: { workingDir: WORKING_DIR } }));
 
         assert.ok(statusMoves.some(function(s) { return s.statusName === 'Passed'; }),
             'should read result from automation repo fallback path and move to Passed');

--- a/js/unit-tests/test_preCliMobileTestAutomationSetup.js
+++ b/js/unit-tests/test_preCliMobileTestAutomationSetup.js
@@ -57,8 +57,8 @@ function makeParams(ticketKey, workingDir, overrides) {
         jobParams: {
             customParams: {
                 targetRepository: workingDir ? {
-                    owner: 'PostNL-BitDigital',
-                    repo: 'PostNL-commercial-mobileApp-automation',
+                    owner: 'ExampleOrg',
+                    repo: 'example-mobile-app-automation',
                     baseBranch: 'main',
                     workingDir: workingDir
                 } : undefined
@@ -79,9 +79,9 @@ suite('preCliMobileTestAutomationSetup — ticket status move', function() {
             file_write: function() {},
             cli_execute_command: function() { return ''; }
         });
-        m.action(makeParams('MAPC-9999', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-9999', '/tmp/automation-repo'));
         assert.equal(moves.length, 1, 'should move ticket once');
-        assert.equal(moves[0].key, 'MAPC-9999', 'should use correct key');
+        assert.equal(moves[0].key, 'PROJ-9999', 'should use correct key');
     });
 
     test('continues even if status move throws', function() {
@@ -93,7 +93,7 @@ suite('preCliMobileTestAutomationSetup — ticket status move', function() {
             cli_execute_command: function() { return ''; }
         });
         // Should not throw; file_write should still be called (linked_test_cases.md)
-        m.action(makeParams('MAPC-9999', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-9999', '/tmp/automation-repo'));
         assert.ok(written.length > 0, 'should still write linked_test_cases.md despite status error');
     });
 
@@ -112,8 +112,8 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
                 searchCalls.push(opts.jql);
                 if (opts.jql.indexOf('is tested by') !== -1) {
                     return [
-                        { key: 'MAPC-TC-1', fields: { summary: 'VoiceOver on modal', status: { name: 'Ready' }, priority: { name: 'High' }, description: 'Step 1: Open modal' } },
-                        { key: 'MAPC-TC-2', fields: { summary: 'Close button label', status: { name: 'Draft' }, priority: { name: 'Medium' }, description: 'Verify close button' } }
+                        { key: 'PROJ-TC-1', fields: { summary: 'VoiceOver on modal', status: { name: 'Ready' }, priority: { name: 'High' }, description: 'Step 1: Open modal' } },
+                        { key: 'PROJ-TC-2', fields: { summary: 'Close button label', status: { name: 'Draft' }, priority: { name: 'Medium' }, description: 'Verify close button' } }
                     ];
                 }
                 return [];
@@ -125,12 +125,12 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
             cli_execute_command: function() { return ''; }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
-        var mdPath = 'input/MAPC-6618/linked_test_cases.md';
+        var mdPath = 'input/PROJ-5678/linked_test_cases.md';
         assert.ok(writtenFiles.hasOwnProperty(mdPath), 'linked_test_cases.md should be written');
-        assert.ok(writtenFiles[mdPath].indexOf('MAPC-TC-1') !== -1, 'should contain first TC key');
-        assert.ok(writtenFiles[mdPath].indexOf('MAPC-TC-2') !== -1, 'should contain second TC key');
+        assert.ok(writtenFiles[mdPath].indexOf('PROJ-TC-1') !== -1, 'should contain first TC key');
+        assert.ok(writtenFiles[mdPath].indexOf('PROJ-TC-2') !== -1, 'should contain second TC key');
         assert.ok(writtenFiles[mdPath].indexOf('VoiceOver on modal') !== -1, 'should contain TC summary');
     });
 
@@ -144,7 +144,7 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
                 // Primary JQL returns empty; fallback returns one TC
                 if (opts.jql.indexOf('is tested by') !== -1) return [];
                 return [
-                    { key: 'MAPC-TC-3', fields: { summary: 'Fallback TC', status: { name: 'Ready' }, priority: { name: 'Low' }, description: null } }
+                    { key: 'PROJ-TC-3', fields: { summary: 'Fallback TC', status: { name: 'Ready' }, priority: { name: 'Low' }, description: null } }
                 ];
             },
             jira_get_ticket: function(opts) {
@@ -154,12 +154,12 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
             cli_execute_command: function() { return ''; }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
         assert.equal(searchCalls.length, 2, 'should try both JQL queries');
         assert.ok(searchCalls[0].indexOf('is tested by') !== -1, 'first call uses primary JQL');
-        var mdContent = writtenFiles['input/MAPC-6618/linked_test_cases.md'];
-        assert.ok(mdContent.indexOf('MAPC-TC-3') !== -1, 'should contain fallback TC');
+        var mdContent = writtenFiles['input/PROJ-5678/linked_test_cases.md'];
+        assert.ok(mdContent.indexOf('PROJ-TC-3') !== -1, 'should contain fallback TC');
     });
 
     test('writes no-TCs message when both JQL queries return empty', function() {
@@ -171,9 +171,9 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
             cli_execute_command: function() { return ''; }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
-        var mdContent = writtenFiles['input/MAPC-6618/linked_test_cases.md'];
+        var mdContent = writtenFiles['input/PROJ-5678/linked_test_cases.md'];
         assert.ok(mdContent.indexOf('No linked Test Case') !== -1, 'should mention no TCs');
     });
 
@@ -183,7 +183,7 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
         var m = loadPreCli({
             jira_search_by_jql: function(opts) {
                 if (opts.jql.indexOf('is tested by') !== -1) {
-                    return [{ key: 'MAPC-TC-10', fields: { summary: 'Modal TC', status: { name: 'Ready' }, priority: { name: 'High' }, description: 'Steps here' } }];
+                    return [{ key: 'PROJ-TC-10', fields: { summary: 'Modal TC', status: { name: 'Ready' }, priority: { name: 'High' }, description: 'Steps here' } }];
                 }
                 return [];
             },
@@ -204,9 +204,9 @@ suite('preCliMobileTestAutomationSetup — linked TC fetching', function() {
             cli_execute_command: function() { return ''; }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
-        var md = writtenFiles['input/MAPC-6618/linked_test_cases.md'];
+        var md = writtenFiles['input/PROJ-5678/linked_test_cases.md'];
         assert.ok(md.indexOf('QA Bot') !== -1, 'should include comment author');
         assert.ok(md.indexOf('Run failed on 2026-04-10') !== -1, 'should include recent comment');
     });
@@ -224,26 +224,26 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             jira_search_by_jql: function() { return []; },
             file_write: opts.onFileWrite || function() {},
             cli_execute_command: opts.onCliCommand || function(o) {
-                if (o.command && o.command.indexOf('find') !== -1) return 'input/MAPC-6618/app/PostNL Zakelijk.app\n';
+                if (o.command && o.command.indexOf('find') !== -1) return 'input/PROJ-5678/app/Example Business.app\n';
                 return '';
             },
             github_list_prs: opts.onListPrs || function() {
                 return JSON.stringify({ data: [
-                    { number: 963, head: { ref: 'story/MAPC-6618' } }
+                    { number: 963, head: { ref: 'story/PROJ-5678' } }
                 ]});
             },
             bitrise_list_builds: opts.onListBuilds || function() {
                 return JSON.stringify({ data: [
-                    { slug: 'build-abc', build_number: 10317, status: 1, status_text: 'success', branch: 'story/MAPC-6618' }
+                    { slug: 'build-abc', build_number: 10317, status: 1, status_text: 'success', branch: 'story/PROJ-5678' }
                 ]});
             },
             bitrise_list_build_artifacts: opts.onListArtifacts || function() {
                 return JSON.stringify({ data: [
-                    { slug: 'artifact-xyz', title: 'PostNL Zakelijk-simulator.zip', file_size_bytes: 32000000 }
+                    { slug: 'artifact-xyz', title: 'Example Business-simulator.zip', file_size_bytes: 32000000 }
                 ]});
             },
             bitrise_get_build_artifact: opts.onGetArtifact || function() {
-                return JSON.stringify({ data: { expiring_download_url: 'https://example.com/app.zip', slug: 'artifact-xyz', title: 'PostNL Zakelijk-simulator.zip' } });
+                return JSON.stringify({ data: { expiring_download_url: 'https://example.com/app.zip', slug: 'artifact-xyz', title: 'Example Business-simulator.zip' } });
             }
         };
     }
@@ -254,12 +254,12 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             jobParams: {
                 customParams: {
                     targetRepository: {
-                        owner: 'PostNL-BitDigital',
-                        repo: 'PostNL-commercial-mobileApp-automation',
+                        owner: 'ExampleOrg',
+                        repo: 'example-mobile-app-automation',
                         baseBranch: 'main',
                         workingDir: '/tmp/automation-repo'
                     },
-                    featurePR: { owner: 'PostNL-BitDigital', repo: 'PostNL-commercial-mobileApp' },
+                    featurePR: { owner: 'ExampleOrg', repo: 'example-mobile-app' },
                     bitriseBuild: {
                         appSlug: 'e739ec8c-app-slug',
                         workflowId: 'build_ios_simulator'
@@ -278,18 +278,18 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             onCliCommand: function(opts) {
                 cliCommands.push(opts.command);
                 if (opts.command && opts.command.indexOf('find') !== -1) {
-                    return 'input/MAPC-6618/app/PostNL Zakelijk.app\n';
+                    return 'input/PROJ-5678/app/Example Business.app\n';
                 }
                 return '';
             }
         }));
 
-        m.action(makeParamsWithBitrise('MAPC-6618'));
+        m.action(makeParamsWithBitrise('PROJ-5678'));
 
-        var md = writtenFiles['input/MAPC-6618/app_info.md'];
+        var md = writtenFiles['input/PROJ-5678/app_info.md'];
         assert.ok(md, 'app_info.md should be written');
         assert.ok(md.indexOf('App Path') !== -1, 'should contain App Path');
-        assert.ok(md.indexOf('PostNL Zakelijk.app') !== -1, 'should contain .app name');
+        assert.ok(md.indexOf('Example Business.app') !== -1, 'should contain .app name');
         assert.ok(md.indexOf('build_ios_simulator') !== -1, 'should contain workflow name');
     });
 
@@ -300,12 +300,12 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             onFileWrite: function() {},
             onCliCommand: function(opts) {
                 cliCommands.push(opts.command);
-                if (opts.command && opts.command.indexOf('find') !== -1) return 'input/MAPC-6618/app/PostNL Zakelijk.app';
+                if (opts.command && opts.command.indexOf('find') !== -1) return 'input/PROJ-5678/app/Example Business.app';
                 return '';
             }
         }));
 
-        m.action(makeParamsWithBitrise('MAPC-6618'));
+        m.action(makeParamsWithBitrise('PROJ-5678'));
 
         var curlCmd = cliCommands.find(function(c) { return c && c.indexOf('curl') !== -1; });
         var unzipCmd = cliCommands.find(function(c) { return c && c.indexOf('unzip') !== -1; });
@@ -322,9 +322,9 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             onFileWrite: function() {},
             onListPrs: function(opts) {
                 listPrsCalled = true;
-                assert.equal(opts.workspace, 'PostNL-BitDigital', 'should use workspace param');
-                assert.equal(opts.repository, 'PostNL-commercial-mobileApp', 'should use repository param');
-                return JSON.stringify({ data: [{ number: 963, head: { ref: 'story/MAPC-6618' } }] });
+                assert.equal(opts.workspace, 'ExampleOrg', 'should use workspace param');
+                assert.equal(opts.repository, 'example-mobile-app', 'should use repository param');
+                return JSON.stringify({ data: [{ number: 963, head: { ref: 'story/PROJ-5678' } }] });
             },
             onListBuilds: function(opts) {
                 listBuildsArgs.push(opts);
@@ -334,11 +334,11 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
             onGetArtifact: function() { return JSON.stringify({ data: { expiring_download_url: 'https://x.com/a.zip' } }); }
         }));
 
-        m.action(makeParamsWithBitrise('MAPC-6618'));
+        m.action(makeParamsWithBitrise('PROJ-5678'));
 
         assert.ok(listPrsCalled, 'should call github_list_prs');
         assert.ok(listBuildsArgs.length > 0, 'should call bitrise_list_builds');
-        assert.equal(listBuildsArgs[0].branch, 'story/MAPC-6618', 'should filter builds by feature branch');
+        assert.equal(listBuildsArgs[0].branch, 'story/PROJ-5678', 'should filter builds by feature branch');
     });
 
     test('skips artifact download when bitriseBuild not configured', function() {
@@ -351,10 +351,10 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
         }), { bitrise_list_builds: function() { listBuildsCalled = true; return JSON.stringify({ data: [] }); } }));
 
         // No bitriseBuild in customParams
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
         assert.ok(!listBuildsCalled, 'should NOT call bitrise_list_builds when not configured');
-        assert.ok(!writtenFiles['input/MAPC-6618/app_info.md'], 'should NOT write app_info.md');
+        assert.ok(!writtenFiles['input/PROJ-5678/app_info.md'], 'should NOT write app_info.md');
     });
 
     test('throws when no successful builds found', function() {
@@ -365,7 +365,7 @@ suite('preCliMobileTestAutomationSetup — Bitrise artifact download', function(
 
         var threw = false;
         try {
-            m.action(makeParamsWithBitrise('MAPC-6618'));
+            m.action(makeParamsWithBitrise('PROJ-5678'));
         } catch (e) {
             threw = true;
             assert.ok(e.message.indexOf('No successful') !== -1, 'error should mention no successful builds: ' + e.message);
@@ -390,7 +390,7 @@ suite('preCliMobileTestAutomationSetup — branch checkout', function() {
             }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
         var gitCommands = commands.filter(function(c) { return c.cmd.indexOf('git') !== -1; });
         assert.ok(gitCommands.length > 0, 'should run git commands');
@@ -414,10 +414,10 @@ suite('preCliMobileTestAutomationSetup — branch checkout', function() {
             }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
-        var checkoutB = commands.find(function(c) { return c.indexOf('checkout -b test/MAPC-6618') !== -1; });
-        assert.ok(checkoutB, 'should create branch test/MAPC-6618');
+        var checkoutB = commands.find(function(c) { return c.indexOf('checkout -b test/PROJ-5678') !== -1; });
+        assert.ok(checkoutB, 'should create branch test/PROJ-5678');
     });
 
     test('checks out existing local branch without creating', function() {
@@ -429,19 +429,19 @@ suite('preCliMobileTestAutomationSetup — branch checkout', function() {
             cli_execute_command: function(opts) {
                 commands.push(opts.command);
                 // Simulate: branch exists locally
-                if (opts.command.indexOf('git branch --list') !== -1) return '  test/MAPC-6618';
+                if (opts.command.indexOf('git branch --list') !== -1) return '  test/PROJ-5678';
                 return '';
             }
         });
 
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
 
         var checkoutExisting = commands.find(function(c) {
-            return c.indexOf('git checkout test/MAPC-6618') !== -1 && c.indexOf('-b') === -1;
+            return c.indexOf('git checkout test/PROJ-5678') !== -1 && c.indexOf('-b') === -1;
         });
         assert.ok(checkoutExisting, 'should checkout existing branch without -b');
 
-        var createB = commands.find(function(c) { return c.indexOf('checkout -b test/MAPC-6618') !== -1; });
+        var createB = commands.find(function(c) { return c.indexOf('checkout -b test/PROJ-5678') !== -1; });
         assert.ok(!createB, 'should NOT use -b for existing branch');
     });
 
@@ -458,7 +458,7 @@ suite('preCliMobileTestAutomationSetup — branch checkout', function() {
         });
 
         // No workingDir → no targetRepository
-        m.action(makeParams('MAPC-6618', null));
+        m.action(makeParams('PROJ-5678', null));
 
         var gitCommands = commands.filter(function(c) { return c && c.indexOf('git') !== -1; });
         assert.equal(gitCommands.length, 0, 'should run no git commands when workingDir absent');
@@ -474,8 +474,8 @@ suite('preCliMobileTestAutomationSetup — branch checkout', function() {
         });
 
         // Should not throw; linked_test_cases.md still written
-        m.action(makeParams('MAPC-6618', '/tmp/automation-repo'));
-        assert.ok(writtenFiles.hasOwnProperty('input/MAPC-6618/linked_test_cases.md'),
+        m.action(makeParams('PROJ-5678', '/tmp/automation-repo'));
+        assert.ok(writtenFiles.hasOwnProperty('input/PROJ-5678/linked_test_cases.md'),
             'should write linked_test_cases.md even if git commands fail');
     });
 

--- a/js/unit-tests/test_releaseArtefacts.js
+++ b/js/unit-tests/test_releaseArtefacts.js
@@ -27,7 +27,7 @@ suite('releaseArtefacts.buildTag', function() {
 
     test('resolves custom tagTemplate', function() {
         var m = loadReleaseArtefacts({});
-        assert.equal(m.buildTag('PROJ-123', 'artefacts-{ticketKey}'), 'artefacts-mapc-123');
+        assert.equal(m.buildTag('PROJ-123', 'artefacts-{ticketKey}'), 'artefacts-proj-123');
     });
 
     test('lowercases the result', function() {

--- a/js/unit-tests/test_releaseArtefacts.js
+++ b/js/unit-tests/test_releaseArtefacts.js
@@ -22,12 +22,12 @@ suite('releaseArtefacts.buildTag', function() {
 
     test('uses default template ai-{ticketKey} when no template given', function() {
         var m = loadReleaseArtefacts({});
-        assert.equal(m.buildTag('MAPC-123'), 'ai-mapc-123');
+        assert.equal(m.buildTag('PROJ-123'), 'ai-proj-123');
     });
 
     test('resolves custom tagTemplate', function() {
         var m = loadReleaseArtefacts({});
-        assert.equal(m.buildTag('MAPC-123', 'artefacts-{ticketKey}'), 'artefacts-mapc-123');
+        assert.equal(m.buildTag('PROJ-123', 'artefacts-{ticketKey}'), 'artefacts-mapc-123');
     });
 
     test('lowercases the result', function() {
@@ -48,7 +48,7 @@ suite('releaseArtefacts.buildReleaseName', function() {
 
     test('uses default template [AI] [{ticketKey}] Artefacts when no template given', function() {
         var m = loadReleaseArtefacts({});
-        assert.equal(m.buildReleaseName('MAPC-123'), '[AI] [MAPC-123] Artefacts');
+        assert.equal(m.buildReleaseName('PROJ-123'), '[AI] [PROJ-123] Artefacts');
     });
 
     test('resolves custom nameTemplate', function() {
@@ -65,8 +65,8 @@ suite('releaseArtefacts.resolveTemplate', function() {
     test('replaces {ticketKey} token', function() {
         var m = loadReleaseArtefacts({});
         assert.equal(
-            m.resolveTemplate('.copilot/session-state/{ticketKey}', 'MAPC-123'),
-            '.copilot/session-state/MAPC-123'
+            m.resolveTemplate('.copilot/session-state/{ticketKey}', 'PROJ-123'),
+            '.copilot/session-state/PROJ-123'
         );
     });
 

--- a/js/unit-tests/test_testsGeneratedGuard.js
+++ b/js/unit-tests/test_testsGeneratedGuard.js
@@ -16,7 +16,7 @@ function makeOnApprovedConfig(withTestCasesGenerator) {
     return {
         bitriseBuild: null,
         testCasesGenerator: withTestCasesGenerator ? {
-            configFile: 'ai_teammate/mapc/TestCasesGenerator.json',
+            configFile: 'ai_teammate/myproject/TestCasesGenerator.json',
             workflow: 'ai-teammate.yml'
         } : null
     };
@@ -26,7 +26,7 @@ function makeCustomParams(onApproved) {
     return {
         onApproved: onApproved,
         aiRepository: { owner: 'ExampleOrg', repo: 'example-ai-agents' },
-        configPath: '.dmtools/configs/mapc.js'
+        configPath: '.dmtools/configs/myproject.js'
     };
 }
 

--- a/js/unit-tests/test_testsGeneratedGuard.js
+++ b/js/unit-tests/test_testsGeneratedGuard.js
@@ -9,7 +9,7 @@
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeTicket(labels) {
-    return { key: 'MAPC-9999', fields: { labels: labels || [], summary: 'Test ticket' } };
+    return { key: 'PROJ-9999', fields: { labels: labels || [], summary: 'Test ticket' } };
 }
 
 function makeOnApprovedConfig(withTestCasesGenerator) {
@@ -25,7 +25,7 @@ function makeOnApprovedConfig(withTestCasesGenerator) {
 function makeCustomParams(onApproved) {
     return {
         onApproved: onApproved,
-        aiRepository: { owner: 'PostNL-BitDigital', repo: 'PostNL-commercial-ai' },
+        aiRepository: { owner: 'ExampleOrg', repo: 'example-ai-agents' },
         configPath: '.dmtools/configs/mapc.js'
     };
 }

--- a/js/unit-tests/test_timerAutoCommitAndSave.js
+++ b/js/unit-tests/test_timerAutoCommitAndSave.js
@@ -46,7 +46,7 @@ suite('timerAutoCommitAndSave — autoCommitAndPush', function() {
             cli_execute_command: function(args) { cliCalls.push(args.command); return ''; }
         });
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: { customParams: {}, metadata: { contextId: 'sf_story_development' } },
             currentCliOutput: ''
         });
@@ -63,7 +63,7 @@ suite('timerAutoCommitAndSave — autoCommitAndPush', function() {
             }
         });
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: {
                 customParams: {
                     targetRepository: { workingDir: '/some/dir' }
@@ -86,7 +86,7 @@ suite('timerAutoCommitAndSave — autoCommitAndPush', function() {
             }
         });
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: {
                 customParams: {
                     targetRepository: { workingDir: '/some/dir' }
@@ -98,7 +98,7 @@ suite('timerAutoCommitAndSave — autoCommitAndPush', function() {
         assert.ok(cliCalls.length >= 4, 'should call status, add, commit, push');
         assert.contains(cliCalls[1], 'git add -A');
         assert.contains(cliCalls[2], 'git commit');
-        assert.contains(cliCalls[2], 'MAPC-123');
+        assert.contains(cliCalls[2], 'PROJ-123');
         assert.contains(cliCalls[3], 'git push');
     });
 });
@@ -115,7 +115,7 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
             file_delete: function() {}
         });
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: { customParams: {}, metadata: { contextId: 'test' } },
             currentCliOutput: 'some output'
         });
@@ -130,7 +130,7 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
             file_delete: function() {}
         });
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: {
                 customParams: {
                     artefactRepository: { owner: 'TestOrg', repo: 'test-repo' }
@@ -168,10 +168,10 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
         });
 
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: {
                 customParams: {
-                    artefactRepository: { owner: 'PostNL-BitDigital', repo: 'PostNL-commercial' },
+                    artefactRepository: { owner: 'ExampleOrg', repo: 'example-app' },
                     targetRepository: { workingDir: '/some/dir' }
                 },
                 metadata: { contextId: 'sf_story_development' }
@@ -186,14 +186,14 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
 
         // Should call github_get_or_create_draft_release
         assert.equal(releaseCalls.length, 1);
-        assert.equal(releaseCalls[0].workspace, 'PostNL-BitDigital');
-        assert.equal(releaseCalls[0].repository, 'PostNL-commercial');
-        assert.equal(releaseCalls[0].tagName, 'ai-mapc-123');
+        assert.equal(releaseCalls[0].workspace, 'ExampleOrg');
+        assert.equal(releaseCalls[0].repository, 'example-app');
+        assert.equal(releaseCalls[0].tagName, 'ai-proj-123');
 
         // Should call github_upload_release_asset with overwrite
         assert.equal(uploadCalls.length, 1);
-        assert.equal(uploadCalls[0].workspace, 'PostNL-BitDigital');
-        assert.equal(uploadCalls[0].repository, 'PostNL-commercial');
+        assert.equal(uploadCalls[0].workspace, 'ExampleOrg');
+        assert.equal(uploadCalls[0].repository, 'example-app');
         assert.equal(uploadCalls[0].releaseId, '99999');
         assert.equal(uploadCalls[0].filePath, '.dmtools-session-output.log');
         assert.equal(uploadCalls[0].assetName, 'sf_story_development-session.log');
@@ -222,7 +222,7 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
 
         // Should not throw — errors are caught
         m.action({
-            ticket: { key: 'MAPC-123' },
+            ticket: { key: 'PROJ-123' },
             jobParams: {
                 customParams: {
                     artefactRepository: { owner: 'Org', repo: 'repo' }

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -91,10 +91,10 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
     });
 
     test('passes workingDirectory when config.workingDir is set', function() {
-        var loaded = loadPreCli('dependencies/PostNL-commercial-mobileApp');
+        var loaded = loadPreCli('dependencies/example-mobile-app');
         try {
             loaded.mod.action({
-                ticket: { key: 'MAPC-1', fields: { summary: 'Test', status: { name: 'In Development' }, labels: [] } },
+                ticket: { key: 'PROJ-1', fields: { summary: 'Test', status: { name: 'In Development' }, labels: [] } },
                 jobParams: {}
             });
         } catch (e) { /* expected */ }
@@ -104,7 +104,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
             gitCalls.forEach(function(c) {
                 assert.equal(
                     c.workingDirectory,
-                    'dependencies/PostNL-commercial-mobileApp',
+                    'dependencies/example-mobile-app',
                     'workingDirectory should match config.workingDir'
                 );
             });
@@ -156,7 +156,7 @@ function loadPreCliTestAutomation(workingDir) {
     if (workingDir) {
         jobParams.customParams = {
             targetRepository: {
-                owner: 'Postnl-Production',
+                owner: 'ExampleOrg-Production',
                 repo: 'api-client-sdk',
                 baseBranch: 'main',
                 workingDir: workingDir
@@ -212,9 +212,9 @@ function loadPostTestAutomation(workingDir, testFilesGlob) {
         if (args.command.indexOf('git branch --show-current') === 0) return 'test/AITS-1';
         if (args.command.indexOf('git diff --cached --stat') === 0) return ' tests/FooTest.php | 1 +';
         if (args.command.indexOf('git ls-remote --heads origin') === 0) return 'abc123\trefs/heads/test/AITS-1';
-        if (args.command.indexOf('gh pr create') === 0) return 'https://github.com/Postnl-Production/api-client-sdk/pull/1';
+        if (args.command.indexOf('gh pr create') === 0) return 'https://github.com/ExampleOrg-Production/api-client-sdk/pull/1';
         if (args.command.indexOf('gh pr list --head') === 0) return '';
-        if (args.command.indexOf('git config --get remote.origin.url') === 0) return 'git@github.com:Postnl-Production/api-client-sdk.git';
+        if (args.command.indexOf('git config --get remote.origin.url') === 0) return 'git@github.com:ExampleOrg-Production/api-client-sdk.git';
         return '';
     };
 
@@ -283,7 +283,7 @@ function loadPostTestAutomation(workingDir, testFilesGlob) {
                     removeLabel: 'sm_aits_test_triggered',
                     testFilesGlob: testFilesGlob,
                     targetRepository: {
-                        owner: 'Postnl-Production',
+                        owner: 'ExampleOrg-Production',
                         repo: 'api-client-sdk',
                         baseBranch: 'main',
                         workingDir: workingDir

--- a/js/unit-tests/test_writeSolutionAndDiagrams.js
+++ b/js/unit-tests/test_writeSolutionAndDiagrams.js
@@ -31,7 +31,7 @@ suite('writeSolutionAndDiagrams — required outputs', function() {
         );
 
         var result = module.action({
-            ticket: { key: 'MAPC-1' },
+            ticket: { key: 'PROJ-1' },
             customParams: {
                 solutionField: 'High-Level Solution',
                 diagramField: '',

--- a/restoreDescription.js
+++ b/restoreDescription.js
@@ -3,13 +3,13 @@
  * Merges the last large "before accident" version with any unique content
  * found in the current (accidentally overridden) version.
  *
- * params.ticketKey  - Jira issue key, e.g. "MAPC-6815"
+ * params.ticketKey  - Jira issue key, e.g. "PROJ-1234"
  */
 function action(params) {
-    var ticketKey = params.ticketKey || "MAPC-6815";
+    var ticketKey = params.ticketKey || "PROJ-1234";
 
     // ── 1. Fetch the full changelog ──────────────────────────────────────────
-    var changelogUrl = "https://postnl.atlassian.net/rest/api/3/issue/" + ticketKey + "/changelog?maxResults=100";
+    var changelogUrl = "https://example.atlassian.net/rest/api/3/issue/" + ticketKey + "/changelog?maxResults=100";
     var changelog = jira_execute_request(changelogUrl);
 
     if (!changelog || !changelog.values) {

--- a/restoreDescription.json
+++ b/restoreDescription.json
@@ -7,6 +7,6 @@
     },
     "skipAIProcessing": true,
     "preJSAction": "agents/restoreDescription.js",
-    "inputJql": "key = MAPC-6815"
+    "inputJql": "key = PROJ-1234"
   }
 }


### PR DESCRIPTION
Replace all company-specific identifiers with generic equivalents to make the agents repo fully generic.

### Changes:
- Replaced org names with `ExampleOrg`
- Replaced app/repo names with generic equivalents (`example-mobile-app`, `example-ai-agents`, etc.)
- Replaced Jira instance URL with `example.atlassian.net`
- Replaced bundle identifier with `com.example.internal.business.app`
- Replaced project-specific ticket key prefixes with `PROJ-*`
- Replaced config/project names with `myproject`

17 files updated, no logic changes — purely string replacements.