### PR TITLE
Avoid committing CodeGraph generated gitignore

### DIFF
--- a/setup/_common.sh
+++ b/setup/_common.sh
@@ -109,11 +109,12 @@ _codegraph_init_or_sync() {
   if [ -d "${workspace}/.codegraph" ]; then
     echo "🔄 CodeGraph index found — syncing..."
     codegraph sync "${workspace}" 2>/dev/null || true
+    rm -f "${workspace}/.codegraph/.gitignore"
     echo "✅ CodeGraph index synced"
   else
     echo "🔨 Initializing CodeGraph index..."
     codegraph init -i "${workspace}" 2>/dev/null || true
+    rm -f "${workspace}/.codegraph/.gitignore"
     echo "✅ CodeGraph index initialized"
   fi
 }
-


### PR DESCRIPTION
## Summary
- remove CodeGraph's generated .codegraph/.gitignore after init/sync
- keep the shared agents setup repository-agnostic and avoid checkout-blocking local index artifacts

## Validation
- bash -n agents/setup/_common.sh
- git diff --check