### PR TITLE
Make PR branch checkout idempotent

### DIFF
--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -104,15 +104,16 @@ function checkoutPRBranch(branchName, workingDir) {
     var cmdOpts = workingDir ? { workingDirectory: workingDir } : {};
 
     var cmd = function(command) { return cli_execute_command(Object.assign({}, cmdOpts, { command: command })); };
+    var localBranchExists = function() {
+        return cleanCommandOutput(cmd('git branch --list "' + branchName + '"') || '').trim() !== '';
+    };
 
     cmd('git config user.name "' + GIT_CONFIG.AUTHOR_NAME + '"');
     cmd('git config user.email "' + GIT_CONFIG.AUTHOR_EMAIL + '"');
     // Update remote refs; blobless repos already have the commit graph
     cmd(prHelper.buildOriginFetchCommand('--prune'));
 
-    const localBranch = cleanCommandOutput(cmd('git branch --list "' + branchName + '"') || '');
-
-    if (localBranch.trim()) {
+    if (localBranchExists()) {
         cmd('git checkout ' + branchName);
         cmd('git pull origin ' + branchName);
     } else {
@@ -120,10 +121,21 @@ function checkoutPRBranch(branchName, workingDir) {
         if (remoteBranch.trim()) {
             try {
                 cmd(prHelper.buildOriginFetchCommand(branchName + ':' + branchName));
-                cmd('git checkout ' + branchName);
             } catch (e) {
                 cmd(prHelper.buildOriginFetchCommand(branchName));
-                cmd('git checkout -b ' + branchName + ' origin/' + branchName);
+            }
+
+            if (localBranchExists()) {
+                cmd('git checkout ' + branchName);
+            } else {
+                try {
+                    cmd('git checkout -b ' + branchName + ' origin/' + branchName);
+                } catch (e) {
+                    if (!localBranchExists()) {
+                        throw e;
+                    }
+                    cmd('git checkout ' + branchName);
+                }
             }
         } else {
             throw new Error('Branch not found locally or remotely: ' + branchName);

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -122,6 +122,34 @@ suite('github repo remote parsing', function() {
     });
 });
 
+suite('githubHelpers.checkoutPRBranch', function() {
+    test('falls back to existing local branch when fetch creates it before failing', function() {
+        var commands = [];
+        var branchExists = false;
+        var gh = loadGithubHelpers({
+            cli_execute_command: function(args) {
+                commands.push(args.command);
+                if (args.command === 'git branch --list "ai/TS-1268"') {
+                    return branchExists ? '  ai/TS-1268\nCOMMAND_EXIT_CODE=0' : '\nCOMMAND_EXIT_CODE=0';
+                }
+                if (args.command === 'git ls-remote --heads origin ai/TS-1268') {
+                    return 'abc123\trefs/heads/ai/TS-1268\nCOMMAND_EXIT_CODE=0';
+                }
+                if (args.command === 'git -c fetch.recurseSubmodules=no fetch origin ai/TS-1268:ai/TS-1268') {
+                    branchExists = true;
+                    throw new Error('fatal: refusing to fetch into branch checked out');
+                }
+                return 'COMMAND_EXIT_CODE=0';
+            }
+        });
+
+        gh.checkoutPRBranch('ai/TS-1268');
+
+        assert.ok(commands.indexOf('git checkout ai/TS-1268') !== -1, 'existing local branch should be checked out');
+        assert.equal(commands.indexOf('git checkout -b ai/TS-1268 origin/ai/TS-1268'), -1, 'must not recreate an existing branch');
+    });
+});
+
 suite('githubHelpers.fetchDiscussionsAndRawData — resolved thread detection', function() {
 
     test('thread resolved=true via GraphQL isResolved is excluded from markdown', function() {


### PR DESCRIPTION
## Summary
- make shared PR branch checkout recover when a fetch creates the local branch before failing
- avoid retrying `git checkout -b` when the branch already exists
- add regression coverage for the duplicate-branch checkout path

## Validation
- `node --check js/common/githubHelpers.js js/unit-tests/test_githubHelpers.js`
- checkoutPRBranch regression script passes

Note: `dmtools run js/unit-tests/run_githubHelpers.json` is blocked locally because tracker credentials are unavailable in this shell.