### PR TITLE
Recover stale failed TC bug creation triggers

### DIFF
--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -105,11 +105,18 @@ function removeTriggerLabel(ticketKey, label) {
     }
 }
 
+function removeProcessingLabels(tcKey, labels) {
+    labels.forEach(function(label) {
+        removeTriggerLabel(tcKey, label);
+    });
+}
+
 function action(params) {
     try {
         var actualParams = params.jobParams || params;
         var customParams = actualParams.customParams || {};
         var triggerLabel = customParams.removeLabel || 'sm_bug_creation_triggered';
+        var smTriggerLabel = customParams.smTriggerLabel || 'sm_bulk_bugs_creation_triggered';
 
         console.log('=== Processing bulk bug creation decisions ===');
 
@@ -119,7 +126,6 @@ function action(params) {
 
             // Remove SM trigger label so SM can re-dispatch on next run
             var triggerTicketKey = (actualParams.ticket && actualParams.ticket.key) || null;
-            var smTriggerLabel = customParams.smTriggerLabel || 'sm_bulk_bugs_creation_triggered';
             removeTriggerLabel(triggerTicketKey, smTriggerLabel);
 
             // Try feedback loop resume — tell agent to produce the output file
@@ -212,6 +218,7 @@ function action(params) {
                     linkBugToTC(tcKey, bugKey);
                     moveToBugToFix(tcKey);
                     addTriggerLabel(tcKey, triggerLabel);
+                    removeTriggerLabel(tcKey, smTriggerLabel);
                     postComment(tcKey,
                         'h3. 🐛 New Bug Created (Batch)\n\n' +
                         'Created: *' + bugKey + '*\n' +
@@ -244,6 +251,7 @@ function action(params) {
                 linkBugToTC(tcKey, bugKey);
                 moveToBugToFix(tcKey);
                 addTriggerLabel(tcKey, triggerLabel);
+                removeTriggerLabel(tcKey, smTriggerLabel);
                 postComment(tcKey,
                     'h3. 🔗 Existing Bug Linked (Batch)\n\n' +
                     'Linked to existing bug: *' + bugKey + '*'
@@ -284,9 +292,7 @@ function action(params) {
                     jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
                 } catch (e) {}
                 // Remove bug creation trigger label
-                try {
-                    jira_remove_label({ key: tcKey, label: triggerLabel });
-                } catch (e) {}
+                removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 postComment(tcKey,
                     'h3. 🔄 Bug Already Fixed — Ready for Re-automation\n\n' +
                     (bugKey ? 'Matching bug *' + bugKey + '* is already in *Done* status.\n\n' : '') +
@@ -313,8 +319,8 @@ function action(params) {
             // REMOVE trigger label so SM can retry on next cycle
             // (prevents permanent deadlock in Failed status)
             try {
-                jira_remove_label({ key: tcKey, label: triggerLabel });
-                console.log('  🏷️ Removed trigger label from', tcKey, '— eligible for next cycle');
+                removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
+                console.log('  🏷️ Removed trigger labels from', tcKey, '— eligible for next cycle');
             } catch (e) {}
             postComment(tcKey,
                 'h3. ℹ️ No Bug Created (Batch) — Test Code Issue\n\n' +

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -34,6 +34,8 @@
  *   skipIfLabels   (optional) — skip ticket if it already has any of these labels
  *   addLabel       (optional) — add this label after triggering (idempotency marker)
  *   addLabels      (optional) — add these labels after triggering
+ *   recoverStaleTriggerLabel (optional) — if true, remove skip labels when no matching
+ *                               active workflow exists and continue processing
  *   enabled        (optional) — set to false to disable the rule entirely (default: true)
  *   limit          (optional) — max number of tickets to process per run (default: 50)
  *   localExecution (optional) — if true, run postJSAction directly (no runner, no AI/CLI)
@@ -300,6 +302,16 @@ function addRuleLabels(ticketKey, rule) {
     });
 }
 
+function removeRuleLabel(ticketKey, label) {
+    if (!ticketKey || !label) return;
+    try {
+        jira_remove_label({ key: ticketKey, label: label });
+        console.log('  🏷️  Removed stale trigger label "' + label + '" from ' + ticketKey);
+    } catch (e) {
+        console.warn('  ⚠️  Could not remove stale trigger label "' + label + '" from ' + ticketKey + ': ' + (e.message || e));
+    }
+}
+
 function normalizePositiveInt(value) {
     if (typeof value !== 'number' || !isFinite(value)) return null;
     var normalized = Math.floor(value);
@@ -511,8 +523,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
     }
 
     if (effectiveLimit !== null && tickets.length > effectiveLimit) {
-        console.log('  Limiting from ' + tickets.length + ' to ' + effectiveLimit + ' ticket(s)');
-        tickets = tickets.slice(0, effectiveLimit);
+        console.log('  Will trigger up to ' + effectiveLimit + ' ticket(s) after skipping active/stale labels');
     }
 
     if (tickets.length === 0) {
@@ -529,14 +540,29 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         if (workflowBudget && workflowBudget.remaining <= 0) {
             break;
         }
+        if (effectiveLimit !== null && processedKeys.length >= effectiveLimit) {
+            break;
+        }
         var ticket = tickets[idx];
         var key = ticket.key;
 
         var skipLabel = firstMatchingLabel(ticket, normalizeLabels(rule.skipIfLabel, rule.skipIfLabels));
         if (skipLabel) {
-            console.log('  ⏭️  ' + key + ' skipped (label: ' + skipLabel + ')');
-            skippedKeys.push(key);
-            continue;
+            if (rule.recoverStaleTriggerLabel) {
+                var workflowFile = rule.workflowFile || 'ai-teammate.yml';
+                var resolvedCf = resolveConfigFile(rule, effectiveConfig);
+                var scm = scmModule.createScm(effectiveConfig);
+                if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, key)) {
+                    skippedKeys.push(key);
+                    continue;
+                }
+                console.log('  ♻️  ' + key + ' has ' + skipLabel + ' but no active workflow — recovering stale trigger label');
+                removeRuleLabel(key, skipLabel);
+            } else {
+                console.log('  ⏭️  ' + key + ' skipped (label: ' + skipLabel + ')');
+                skippedKeys.push(key);
+                continue;
+            }
         }
 
         if (rule.targetStatus) {

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -583,6 +583,31 @@ suite('smAgent: skipIfLabel', function() {
         assert.equal(sm.capturedLabels.length, 0, 'no label added for skipped ticket');
     });
 
+    test('recovers stale trigger label when configured and no active workflow exists', function() {
+        var sm = makeSmAgent({
+            fileMap: {},
+            tickets: [
+                { key: 'T-1', fields: { labels: ['sm_triggered'] } }
+            ],
+            workflowRuns: {
+                queued: [],
+                in_progress: []
+            }
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = X", {
+                skipIfLabel: 'sm_triggered',
+                addLabel: 'sm_triggered',
+                recoverStaleTriggerLabel: true
+            })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 1, 'stale label should not deadlock ticket');
+        var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
+        assert.contains(inputs.encoded_config, 'T-1', 'T-1 was retriggered');
+    });
+
     test('skips ticket that has any skipIfLabels entry', function() {
         var sm = makeSmAgent({
             fileMap: {},
@@ -673,6 +698,24 @@ suite('smAgent: rule enabled flag', function() {
         ]));
 
         assert.equal(sm.capturedTriggers.length, 2, 'only 2 tickets processed (limit: 2)');
+    });
+
+    test('limit applies after skipped tickets so stale labels do not starve later tickets', function() {
+        var sm = makeSmAgent({
+            fileMap: {},
+            tickets: [
+                { key: 'T-skipped', fields: { labels: ['sm_triggered'] } },
+                { key: 'T-open', fields: { labels: [] } }
+            ]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = X", { skipIfLabel: 'sm_triggered', limit: 1 })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 1, 'one non-skipped ticket should be triggered');
+        var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
+        assert.contains(inputs.encoded_config, 'T-open', 'limit should not be consumed by skipped ticket');
     });
 
 });

--- a/prompts/codegraph_tools.md
+++ b/prompts/codegraph_tools.md
@@ -14,6 +14,16 @@ CodeGraph builds a semantic knowledge graph of the codebase and makes it availab
 | Read a single symbol's source | `codegraph node "<ClassName>"` |
 | Browse project file structure | `codegraph files` |
 
+## Mandatory usage rule
+
+For any task that requires understanding, modifying, or reviewing source code, your first code-navigation command MUST be a CodeGraph command before using `grep`, `find`, `cat`, `sed`, or opening files directly.
+
+Use `codegraph context "<task description>"` by default. Use `codegraph query "<symbol>"` only when you already know the symbol name.
+
+After editing code, run `codegraph sync` before any further CodeGraph query.
+
+Only skip CodeGraph when the task does not involve source-code navigation (for example, a pure Jira/status update or a known single-file text edit). If you skip it, state the reason in the final response.
+
 **Prefer CodeGraph over `grep` or `cat` for code understanding** — it uses the pre-built semantic index and returns only relevant, structured results.
 
 ## Key commands

--- a/sm.json
+++ b/sm.json
@@ -186,6 +186,7 @@
           "configFile": "agents/bulk_bugs_creation.json",
           "skipIfLabel": "sm_bulk_bugs_creation_triggered",
           "addLabel": "sm_bulk_bugs_creation_triggered",
+          "recoverStaleTriggerLabel": true,
           "limit": 1,
           "enabled": true
         },


### PR DESCRIPTION
## Summary
- make CodeGraph usage mandatory for source-code navigation in agent prompt
- recover stale SM trigger labels when no matching active workflow exists
- apply SM rule limits after skipped tickets so stale labels cannot starve later tickets
- clean bulk bug creation labels after processing so Failed TCs do not deadlock

## Validation
- `node --check js/smAgent.js js/postBulkBugsCreation.js js/unit-tests/test_smAgent.js`

Note: `dmtools run js/unit-tests/run_smAgent.json` is blocked locally because this shell has no tracker credentials.