### PR TITLE
Fix stale agent pipeline recovery

### DIFF
--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -7,7 +7,7 @@
  *   { "action": "none", "reason": "..." }
  *
  * For link/create: links/creates bug, moves TC to "Bug To Fix", removes trigger labels.
- * For none:        posts comment, keeps TC in Failed, keeps trigger label (prevents re-fire).
+ * For none:        posts comment, moves TC to In Rework, removes trigger labels.
  *
  * Link direction: Bug "blocks" TC (TC is blocked by the Bug until it's fixed).
  */
@@ -58,6 +58,19 @@ function linkBugToTC(ticketKey, bugKey) {
         relationship: 'Blocks'
     });
     console.log('✅ Linked:', bugKey, 'blocks', ticketKey);
+}
+
+function moveFailedTcToRework(ticketKey) {
+    try {
+        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
+        console.log('🔧 Moved', ticketKey, 'to', STATUSES.IN_REWORK || 'In Rework');
+    } catch (e) {
+        console.warn('Failed to move to In Rework:', e);
+    }
+    try {
+        jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
+        console.log('✅ Removed sm_test_automation_triggered');
+    } catch (e) {}
 }
 
 function action(params) {
@@ -163,13 +176,15 @@ function action(params) {
             // action: none — test code issue, not an app bug
             comment = 'h3. ℹ️ No Bug Created\n\n' +
                 (decision.reason || 'AI determined no bug creation or linking is required.') +
-                '\n\n_TC remains in Failed status for manual review._';
+                '\n\n_TC moved to *In Rework* so the test automation can be fixed instead of staying in *Failed*._';
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
+            moveFailedTcToRework(ticketKey);
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
-            // KEEP sm_bug_creation_triggered label — TC stays in Failed, removing
-            // the label would cause SM to re-trigger bug_creation in an infinite loop.
-            console.log('ℹ️ No action taken for', ticketKey, '— TC stays in Failed (trigger label kept to prevent re-fire)');
+            if (smTriggerLabel) {
+                try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
+            }
+            console.log('ℹ️ No product bug for', ticketKey, '— moved to In Rework for test automation fixes');
             return { success: true, ticketKey: ticketKey, bugKey: null, action: 'none' };
         }
 

--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -21,7 +21,7 @@
  *
  * For newBugs:  create bug, link all linkedTCs, move linkedTCs to "Bug To Fix"
  * For links:    link TC to existing bug, move TC to "Bug To Fix"
- * For skipped:  add sm_bug_creation_triggered label, keep TC in Failed
+ * For skipped:  move TC to In Rework so test automation can be fixed
  */
 
 const { STATUSES, LABELS } = require('./config.js');
@@ -109,6 +109,18 @@ function removeProcessingLabels(tcKey, labels) {
     labels.forEach(function(label) {
         removeTriggerLabel(tcKey, label);
     });
+}
+
+function moveFailedTcToRework(tcKey) {
+    try {
+        jira_move_to_status({ key: tcKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
+        console.log('  🔧 Moved to ' + (STATUSES.IN_REWORK || 'In Rework') + ':', tcKey);
+    } catch (e) {
+        console.warn('  ⚠️ Could not move to In Rework:', tcKey, e);
+    }
+    try {
+        jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
+    } catch (e) {}
 }
 
 function action(params) {
@@ -306,7 +318,7 @@ function action(params) {
             }
         });
 
-        // ── 4. Mark skipped TCs (keep in Failed, REMOVE trigger label for retry) ─
+        // ── 4. Test-code issues → In Rework so they leave Failed and rework runs ─
         skipped.forEach(function(skipDef) {
             var tcKey = skipDef.tcKey;
             if (!tcKey) return;
@@ -314,18 +326,16 @@ function action(params) {
                 console.warn('  ⚠️ TC', tcKey, 'not in processed list — skipping (safety guard)');
                 return;
             }
-
             console.log('  Skipping', tcKey, '—', skipDef.reason || 'no reason given');
-            // REMOVE trigger label so SM can retry on next cycle
-            // (prevents permanent deadlock in Failed status)
+            moveFailedTcToRework(tcKey);
             try {
                 removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
-                console.log('  🏷️ Removed trigger labels from', tcKey, '— eligible for next cycle');
+                console.log('  🏷️ Removed trigger labels from', tcKey, '— eligible for rework');
             } catch (e) {}
             postComment(tcKey,
                 'h3. ℹ️ No Bug Created (Batch) — Test Code Issue\n\n' +
                 '*Reason*: ' + (skipDef.reason || 'AI determined this is a test code issue, not an application bug.') +
-                '\n\n_TC remains in Failed status. Trigger label removed — will be re-evaluated on next cycle._'
+                '\n\n_TC moved to *In Rework* so the test automation can be fixed instead of staying in *Failed*._'
             );
             results.skipped.push({ tcKey: tcKey, reason: skipDef.reason });
         });
@@ -343,4 +353,8 @@ function action(params) {
         console.error('postBulkBugsCreation failed:', e);
         throw e;
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
 }

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -35,7 +35,9 @@
  *   addLabel       (optional) — add this label after triggering (idempotency marker)
  *   addLabels      (optional) — add these labels after triggering
  *   recoverStaleTriggerLabel (optional) — if true, remove skip labels when no matching
- *                               active workflow exists and continue processing
+ *                               active workflow exists and continue processing. Trigger
+ *                               labels that are also added by the same rule recover by
+ *                               default; set false to opt out.
  *   enabled        (optional) — set to false to disable the rule entirely (default: true)
  *   limit          (optional) — max number of tickets to process per run (default: 50)
  *   localExecution (optional) — if true, run postJSAction directly (no runner, no AI/CLI)
@@ -193,6 +195,25 @@ function parseWorkflowRuns(raw) {
     if (parsed && Array.isArray(parsed.workflow_runs)) return parsed.workflow_runs;
     if (parsed && Array.isArray(parsed.runs)) return parsed.runs;
     return [];
+}
+
+function labelList(value) {
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+}
+
+function isRuleTriggerLabel(rule, label) {
+    var labels = labelList(rule.addLabel).concat(labelList(rule.addLabels));
+    for (var i = 0; i < labels.length; i++) {
+        if (labels[i] === label) return true;
+    }
+    return false;
+}
+
+function shouldRecoverStaleTriggerLabel(rule, label) {
+    if (rule.recoverStaleTriggerLabel === true) return true;
+    if (rule.recoverStaleTriggerLabel === false) return false;
+    return isRuleTriggerLabel(rule, label);
 }
 
 function hasActiveTargetWorkflowRun(scm, workflowFile, configFile, ticketKey) {
@@ -548,7 +569,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
 
         var skipLabel = firstMatchingLabel(ticket, normalizeLabels(rule.skipIfLabel, rule.skipIfLabels));
         if (skipLabel) {
-            if (rule.recoverStaleTriggerLabel) {
+            if (shouldRecoverStaleTriggerLabel(rule, skipLabel)) {
                 var workflowFile = rule.workflowFile || 'ai-teammate.yml';
                 var resolvedCf = resolveConfigFile(rule, effectiveConfig);
                 var scm = scmModule.createScm(effectiveConfig);

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -21,6 +21,7 @@
         "js/unit-tests/test_fetchParentContextToInput.js",
         "js/unit-tests/test_testsGeneratedGuard.js",
         "js/unit-tests/test_postBugCreation.js",
+        "js/unit-tests/test_postBulkBugsCreation.js",
         "js/unit-tests/test_postTestAutomationResults.js",
         "js/unit-tests/test_postTestReviewComments.js",
         "js/unit-tests/test_postPRReviewComments.js",

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -13,7 +13,15 @@
 function loadGithubHelpers(mocks) {
     return loadModule(
         'js/common/githubHelpers.js',
-        makeRequire({ '../config.js': configModule, 'config': configModule, './pullRequest.js': {} }),
+        makeRequire({
+            '../config.js': configModule,
+            'config': configModule,
+            './pullRequest.js': {
+                buildOriginFetchCommand: function(refSpec) {
+                    return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                }
+            }
+        }),
         mocks || {}
     );
 }

--- a/js/unit-tests/test_postBugCreation.js
+++ b/js/unit-tests/test_postBugCreation.js
@@ -60,4 +60,48 @@ suite('postBugCreation', function() {
         ]);
     });
 
+    test('moves test-code issue decision to In Rework and clears trigger labels', function() {
+        var statusMoves = [];
+        var removedLabels = [];
+        var comments = [];
+
+        var module = loadPostBugCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bug_decision.json') {
+                    return JSON.stringify({
+                        action: 'none',
+                        reason: 'Failure is caused by stale test automation.'
+                    });
+                }
+                return null;
+            },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-222' },
+            metadata: { contextId: 'bug_creation' },
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'none');
+        assert.deepEqual(statusMoves, [
+            { key: 'TS-222', statusName: 'In Rework' }
+        ]);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-222', label: 'sm_test_automation_triggered' },
+            { key: 'TS-222', label: 'bug_creation_wip' },
+            { key: 'TS-222', label: 'sm_bug_creation_triggered' }
+        ]);
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'In Rework');
+    });
+
 });

--- a/js/unit-tests/test_postBulkBugsCreation.js
+++ b/js/unit-tests/test_postBulkBugsCreation.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for js/postBulkBugsCreation.js
+ */
+
+function loadPostBulkBugsCreation(mocks) {
+    var defaults = {
+        jira_post_comment: function() {},
+        jira_move_to_status: function() {},
+        jira_remove_label: function() {},
+        jira_add_label: function() {},
+        jira_link_issues: function() {},
+        jira_create_ticket_basic: function() { return ''; },
+        file_read: function() { return null; }
+    };
+
+    return loadModule(
+        'js/postBulkBugsCreation.js',
+        makeRequire({
+            './config.js': configModule,
+            './common/feedbackLoop.js': {
+                resumeAgent: function() {
+                    return { attempted: false, reason: 'unit test' };
+                }
+            }
+        }),
+        Object.assign({}, defaults, mocks)
+    );
+}
+
+suite('postBulkBugsCreation', function() {
+
+    test('moves skipped test-code issues to In Rework and clears trigger labels', function() {
+        var statusMoves = [];
+        var removedLabels = [];
+        var comments = [];
+
+        var module = loadPostBulkBugsCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bulk_bug_decisions.json') {
+                    return JSON.stringify({
+                        processed: ['TS-396'],
+                        newBugs: [],
+                        links: [],
+                        fixedByBug: [],
+                        skipped: [
+                            { tcKey: 'TS-396', reason: 'Failure is caused by outdated test code.' }
+                        ]
+                    });
+                }
+                return null;
+            },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered',
+                    smTriggerLabel: 'sm_bulk_bugs_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.results.skipped.length, 1);
+        assert.deepEqual(statusMoves, [
+            { key: 'TS-396', statusName: 'In Rework' }
+        ]);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-396', label: 'sm_test_automation_triggered' },
+            { key: 'TS-396', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-396', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'In Rework');
+    });
+
+});

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -567,7 +567,7 @@ suite('smAgent: skipIfLabel', function() {
         assert.equal(sm.capturedLabels[0].label, 'sm_dev_triggered');
     });
 
-    test('does not add label when ticket already had skipIfLabel', function() {
+    test('does not recover trigger label when explicitly disabled', function() {
         var sm = makeSmAgent({
             fileMap: {},
             tickets: [
@@ -576,14 +576,18 @@ suite('smAgent: skipIfLabel', function() {
         });
 
         sm.action(baseParams('o', 'r', [
-            makeRule("project = X", { skipIfLabel: 'sm_triggered', addLabel: 'sm_triggered' })
+            makeRule("project = X", {
+                skipIfLabel: 'sm_triggered',
+                addLabel: 'sm_triggered',
+                recoverStaleTriggerLabel: false
+            })
         ]));
 
         assert.equal(sm.capturedTriggers.length, 0, 'no trigger for skipped ticket');
         assert.equal(sm.capturedLabels.length, 0, 'no label added for skipped ticket');
     });
 
-    test('recovers stale trigger label when configured and no active workflow exists', function() {
+    test('recovers stale trigger label by default when no active workflow exists', function() {
         var sm = makeSmAgent({
             fileMap: {},
             tickets: [
@@ -598,8 +602,7 @@ suite('smAgent: skipIfLabel', function() {
         sm.action(baseParams('o', 'r', [
             makeRule("project = X", {
                 skipIfLabel: 'sm_triggered',
-                addLabel: 'sm_triggered',
-                recoverStaleTriggerLabel: true
+                addLabel: 'sm_triggered'
             })
         ]));
 


### PR DESCRIPTION
Fixes agent pipeline deadlocks observed in TrackState.\n\n- Recover stale SM trigger labels by default when a rule's skip label is the same trigger label it adds and no active workflow exists.\n- Move TC bug-triage decisions classified as test-code issues to In Rework instead of leaving them in Failed.\n- Cover single and bulk bug creation post-actions plus full JS unit suite.\n\nValidation: JIRA_BASE_PATH=https://example.invalid JIRA_EMAIL=unit@example.invalid JIRA_API_TOKEN=dummy dmtools run js/unit-tests/run_all.json