### PR TITLE
Recover tickets with already merged PRs

### DIFF
--- a/js/recoverMergedPRTicket.js
+++ b/js/recoverMergedPRTicket.js
@@ -1,0 +1,96 @@
+/**
+ * Recover Jira tickets whose GitHub PR was already merged while Jira stayed in
+ * a review/rework status.
+ */
+
+const { STATUSES, LABELS } = require('./config.js');
+var scmModule = require('./common/scm.js');
+var configLoader = require('./configLoader.js');
+
+function prMatchesTicket(pr, ticketKey) {
+    if (!pr || !ticketKey) return false;
+    var titleMatch = pr.title && pr.title.indexOf(ticketKey) !== -1;
+    var branchMatch = pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1;
+    var bodyMatch = pr.body && pr.body.indexOf(ticketKey) !== -1;
+    return !!(titleMatch || branchMatch || bodyMatch);
+}
+
+function isMergedPR(pr) {
+    if (!pr) return false;
+    return !!(pr.merged_at || pr.mergedAt || pr.merge_commit_sha || pr.mergeCommit) ||
+        pr.state === 'MERGED' ||
+        pr.merged === true;
+}
+
+function findMergedPRForTicket(scm, ticketKey) {
+    var closed = [];
+    try {
+        closed = scm.listPrs('closed') || [];
+    } catch (e) {
+        console.warn('Could not list closed PRs:', e.message || e);
+        return null;
+    }
+
+    for (var i = 0; i < closed.length; i++) {
+        if (prMatchesTicket(closed[i], ticketKey) && isMergedPR(closed[i])) {
+            return closed[i];
+        }
+    }
+    return null;
+}
+
+function removeLabel(ticketKey, label) {
+    if (!ticketKey || !label) return;
+    try {
+        jira_remove_label({ key: ticketKey, label: label });
+        console.log('Removed label from Jira:', label);
+    } catch (e) {}
+}
+
+function action(params) {
+    var ticketKey = params.ticket && params.ticket.key;
+    if (!ticketKey) {
+        console.error('No ticket key provided');
+        return { success: false, action: 'missing_ticket' };
+    }
+
+    var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var scm = scmModule.createScm(config);
+    var pr = findMergedPRForTicket(scm, ticketKey);
+
+    if (!pr) {
+        console.log('No merged PR found for', ticketKey);
+        return { success: true, action: 'none' };
+    }
+
+    var prNumber = pr.number || pr.id || '?';
+    var prUrl = pr.html_url || pr.url || '';
+    console.log('Recovered merged PR #' + prNumber + ' for ' + ticketKey);
+
+    try {
+        jira_move_to_status({ key: ticketKey, statusName: STATUSES.MERGED });
+        console.log('Moved', ticketKey, 'to', STATUSES.MERGED);
+    } catch (e) {
+        console.warn('Could not move ticket to Merged:', e.message || e);
+    }
+
+    removeLabel(ticketKey, LABELS.PR_APPROVED);
+    removeLabel(ticketKey, 'sm_pr_merge_triggered');
+    removeLabel(ticketKey, 'sm_story_review_triggered');
+    removeLabel(ticketKey, 'sm_story_rework_triggered');
+
+    try {
+        jira_post_comment({
+            key: ticketKey,
+            comment: 'h3. ✅ Merged PR Recovered\n\n' +
+                'Found already merged PR #' + prNumber + (prUrl ? ' — [View PR|' + prUrl + ']' : '') +
+                '. Ticket moved to *' + STATUSES.MERGED + '* so the normal post-merge pipeline can continue.'
+        });
+    } catch (e) {}
+
+    return { success: true, action: 'moved_to_merged', prNumber: prNumber };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action, findMergedPRForTicket, prMatchesTicket, isMergedPR };
+}

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -17,6 +17,7 @@
         "js/unit-tests/test_autoStart.js",
         "js/unit-tests/test_dfManager.js",
         "js/unit-tests/test_retryMergePR.js",
+        "js/unit-tests/test_recoverMergedPRTicket.js",
         "js/unit-tests/test_feedbackLoop.js",
         "js/unit-tests/test_fetchParentContextToInput.js",
         "js/unit-tests/test_testsGeneratedGuard.js",

--- a/js/unit-tests/test_recoverMergedPRTicket.js
+++ b/js/unit-tests/test_recoverMergedPRTicket.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for js/recoverMergedPRTicket.js.
+ */
+
+function loadRecoverMergedPRTicket(options) {
+    options = options || {};
+    var scm = options.scm || {
+        listPrs: function() { return []; }
+    };
+    var statusMoves = [];
+    var removedLabels = [];
+    var comments = [];
+
+    var mod = loadModule(
+        'js/recoverMergedPRTicket.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': {
+                loadProjectConfig: function() {
+                    return { repository: { owner: 'IstiN', repo: 'trackstate' } };
+                }
+            },
+            './common/scm.js': { createScm: function() { return scm; } }
+        }),
+        {
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        }
+    );
+
+    return {
+        mod: mod,
+        statusMoves: statusMoves,
+        removedLabels: removedLabels,
+        comments: comments
+    };
+}
+
+suite('recoverMergedPRTicket', function() {
+
+    test('moves ticket to Merged when a matching closed PR is already merged', function() {
+        var loaded = loadRecoverMergedPRTicket({
+            scm: {
+                listPrs: function(state) {
+                    assert.equal(state, 'closed');
+                    return [{
+                        number: 1512,
+                        title: 'TS-1268 accessibility fix',
+                        html_url: 'https://github.com/IstiN/trackstate/pull/1512',
+                        head: { ref: 'ai/TS-1268' },
+                        merged_at: '2026-05-30T18:28:34Z'
+                    }];
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-1268' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_merged');
+        assert.deepEqual(loaded.statusMoves, [
+            { key: 'TS-1268', statusName: 'Merged' }
+        ]);
+        assert.deepEqual(loaded.removedLabels, [
+            { key: 'TS-1268', label: 'pr_approved' },
+            { key: 'TS-1268', label: 'sm_pr_merge_triggered' },
+            { key: 'TS-1268', label: 'sm_story_review_triggered' },
+            { key: 'TS-1268', label: 'sm_story_rework_triggered' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Merged PR Recovered');
+    });
+
+    test('does nothing when matching PR is closed but not merged', function() {
+        var loaded = loadRecoverMergedPRTicket({
+            scm: {
+                listPrs: function() {
+                    return [{
+                        number: 9,
+                        title: 'TS-1272 attempted fix',
+                        head: { ref: 'ai/TS-1272' },
+                        state: 'CLOSED'
+                    }];
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-1272' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'none');
+        assert.deepEqual(loaded.statusMoves, []);
+        assert.deepEqual(loaded.removedLabels, []);
+    });
+
+});

--- a/recover_merged_pr.json
+++ b/recover_merged_pr.json
@@ -1,0 +1,6 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "postJSAction": "agents/js/recoverMergedPRTicket.js"
+  }
+}

--- a/sm.json
+++ b/sm.json
@@ -70,6 +70,12 @@
           "enabled": true
         },
         {
+          "description": "Review/Rework/Blocked Stories & Bugs with already merged PR → recover Merged status",
+          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review', 'In Rework', 'Blocked') ORDER BY updated ASC",
+          "configFile": "agents/recover_merged_pr.json",
+          "localExecution": true
+        },
+        {
           "description": "In Review Stories & Bugs → trigger pr_review",
           "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review') AND (labels is EMPTY OR labels NOT IN ('pr_approved'))",
           "configFile": "agents/pr_review.json",


### PR DESCRIPTION
Adds SM recovery for Story/Bug tickets stuck in In Review, In Rework, or Blocked after their matching GitHub PR has already merged.\n\n- local recovery action finds merged closed PRs by ticket key;\n- moves Jira ticket to Merged and clears stale PR/SM labels;\n- runs before normal pr_review/pr_rework rules so stuck tickets do not loop;\n- includes JS unit coverage.\n\nValidation: JIRA_BASE_PATH=https://example.invalid JIRA_EMAIL=unit@example.invalid JIRA_API_TOKEN=dummy dmtools run js/unit-tests/run_all.json