### PR TITLE
Recover failed test cases with linked bugs

### DIFF
--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -61,12 +61,8 @@ function linkBugToTC(ticketKey, bugKey) {
 }
 
 function moveFailedTcToRework(ticketKey) {
-    try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
-        console.log('🔧 Moved', ticketKey, 'to', STATUSES.IN_REWORK || 'In Rework');
-    } catch (e) {
-        console.warn('Failed to move to In Rework:', e);
-    }
+    jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
+    console.log('🔧 Moved', ticketKey, 'to', STATUSES.IN_REWORK || 'In Rework');
     try {
         jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
         console.log('✅ Removed sm_test_automation_triggered');

--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -112,12 +112,8 @@ function removeProcessingLabels(tcKey, labels) {
 }
 
 function moveFailedTcToRework(tcKey) {
-    try {
-        jira_move_to_status({ key: tcKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
-        console.log('  🔧 Moved to ' + (STATUSES.IN_REWORK || 'In Rework') + ':', tcKey);
-    } catch (e) {
-        console.warn('  ⚠️ Could not move to In Rework:', tcKey, e);
-    }
+    jira_move_to_status({ key: tcKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
+    console.log('  🔧 Moved to ' + (STATUSES.IN_REWORK || 'In Rework') + ':', tcKey);
     try {
         jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
     } catch (e) {}

--- a/js/recoverFailedTCBugStatus.js
+++ b/js/recoverFailedTCBugStatus.js
@@ -1,0 +1,76 @@
+/**
+ * Recover Failed Test Cases after bug triage.
+ *
+ * If a Failed TC already has linked Bugs, it must not stay in Failed waiting
+ * for bug_creation again. Move it to Bug To Fix while any linked bug is open,
+ * or Backlog if all linked bugs are already Done.
+ */
+
+const { STATUSES } = require('./config.js');
+
+function removeLabel(ticketKey, label) {
+    if (!ticketKey || !label) return;
+    try {
+        jira_remove_label({ key: ticketKey, label: label });
+        console.log('Removed label:', label);
+    } catch (e) {}
+}
+
+function action(params) {
+    var ticketKey = params.ticket && params.ticket.key;
+    if (!ticketKey) {
+        throw new Error('params.ticket.key is missing');
+    }
+
+    console.log('=== Failed TC bug status recovery for', ticketKey, '===');
+
+    var linkedBugs = jira_search_by_jql({
+        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug',
+        maxResults: 50
+    }) || [];
+
+    if (linkedBugs.length === 0) {
+        console.log('No linked Bugs found for', ticketKey);
+        // The old single bug_creation rule is disabled, but its trigger label
+        // can remain on Failed TCs and exclude them from bulk_bugs_creation JQL.
+        // Clear only that stale single-run label so the active bulk path can
+        // pick the TC up on the next SM pass.
+        removeLabel(ticketKey, 'sm_bug_creation_triggered');
+        return { success: true, action: 'released_for_bulk_bug_creation', ticketKey: ticketKey };
+    }
+
+    var openBugs = jira_search_by_jql({
+        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status != "Done"',
+        maxResults: 1
+    }) || [];
+
+    var targetStatus = openBugs.length > 0 ? STATUSES.BUG_TO_FIX : STATUSES.BACKLOG;
+    jira_move_to_status({ key: ticketKey, statusName: targetStatus });
+    console.log('Moved', ticketKey, 'to', targetStatus);
+
+    removeLabel(ticketKey, 'sm_bug_creation_triggered');
+    removeLabel(ticketKey, 'sm_bulk_bugs_creation_triggered');
+    removeLabel(ticketKey, 'sm_test_automation_triggered');
+
+    jira_post_comment({
+        key: ticketKey,
+        comment: openBugs.length > 0
+            ? 'h3. 🐛 Linked Bug Found — Moved to Bug To Fix\n\n' +
+                'This failed test case already has linked Bug issue(s), so it was moved to *' +
+                STATUSES.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
+            : 'h3. 🔄 Linked Bug Already Done — Ready for Re-automation\n\n' +
+                'All linked Bug issue(s) are already *Done*, so this test case was moved to *' +
+                STATUSES.BACKLOG + '* for re-automation.'
+    });
+
+    return {
+        success: true,
+        action: openBugs.length > 0 ? 'moved_to_bug_to_fix' : 'moved_to_backlog',
+        ticketKey: ticketKey,
+        linkedBugs: linkedBugs.length
+    };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -18,6 +18,7 @@
         "js/unit-tests/test_dfManager.js",
         "js/unit-tests/test_retryMergePR.js",
         "js/unit-tests/test_recoverMergedPRTicket.js",
+        "js/unit-tests/test_recoverFailedTCBugStatus.js",
         "js/unit-tests/test_feedbackLoop.js",
         "js/unit-tests/test_fetchParentContextToInput.js",
         "js/unit-tests/test_testsGeneratedGuard.js",

--- a/js/unit-tests/test_recoverFailedTCBugStatus.js
+++ b/js/unit-tests/test_recoverFailedTCBugStatus.js
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for js/recoverFailedTCBugStatus.js.
+ */
+
+function loadRecoverFailedTCBugStatus(mocks) {
+    var calls = {
+        searches: [],
+        statusMoves: [],
+        removedLabels: [],
+        comments: []
+    };
+
+    var defaults = {
+        jira_search_by_jql: function(args) {
+            calls.searches.push(args);
+            return [];
+        },
+        jira_move_to_status: function(args) { calls.statusMoves.push(args); },
+        jira_remove_label: function(args) { calls.removedLabels.push(args); },
+        jira_post_comment: function(args) { calls.comments.push(args); }
+    };
+
+    var mod = loadModule(
+        'js/recoverFailedTCBugStatus.js',
+        makeRequire({ './config.js': configModule }),
+        Object.assign({}, defaults, mocks || {})
+    );
+
+    return { mod: mod, calls: calls };
+}
+
+suite('recoverFailedTCBugStatus', function() {
+
+    test('moves Failed TC with linked open Bug to Bug To Fix', function() {
+        var loaded = loadRecoverFailedTCBugStatus({
+            jira_search_by_jql: function(args) {
+                loaded.calls.searches.push(args);
+                if (args.jql.indexOf('status != "Done"') !== -1) {
+                    return [{ key: 'TS-1289' }];
+                }
+                return [{ key: 'TS-1289' }];
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-222' } });
+
+        assert.equal(result.action, 'moved_to_bug_to_fix');
+        assert.deepEqual(loaded.calls.statusMoves, [
+            { key: 'TS-222', statusName: 'Bug To Fix' }
+        ]);
+        assert.deepEqual(loaded.calls.removedLabels, [
+            { key: 'TS-222', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-222', label: 'sm_bulk_bugs_creation_triggered' },
+            { key: 'TS-222', label: 'sm_test_automation_triggered' }
+        ]);
+        assert.contains(loaded.calls.comments[0].comment, 'Moved to Bug To Fix');
+    });
+
+    test('moves Failed TC with only Done linked Bugs to Backlog', function() {
+        var loaded = loadRecoverFailedTCBugStatus({
+            jira_search_by_jql: function(args) {
+                loaded.calls.searches.push(args);
+                if (args.jql.indexOf('status != "Done"') !== -1) {
+                    return [];
+                }
+                return [{ key: 'TS-1289' }];
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-333' } });
+
+        assert.equal(result.action, 'moved_to_backlog');
+        assert.deepEqual(loaded.calls.statusMoves, [
+            { key: 'TS-333', statusName: 'Backlog' }
+        ]);
+    });
+
+    test('releases Failed TC without linked Bugs for bulk bug creation', function() {
+        var loaded = loadRecoverFailedTCBugStatus();
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-444' } });
+
+        assert.equal(result.action, 'released_for_bulk_bug_creation');
+        assert.deepEqual(loaded.calls.statusMoves, []);
+        assert.deepEqual(loaded.calls.comments, []);
+        assert.deepEqual(loaded.calls.removedLabels, [
+            { key: 'TS-444', label: 'sm_bug_creation_triggered' }
+        ]);
+    });
+
+});

--- a/recover_failed_tc_bug_status.json
+++ b/recover_failed_tc_bug_status.json
@@ -1,0 +1,6 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "postJSAction": "agents/js/recoverFailedTCBugStatus.js"
+  }
+}

--- a/sm.json
+++ b/sm.json
@@ -178,6 +178,12 @@
           "addLabel": "sm_test_automation_triggered"
         },
         {
+          "description": "Failed Test Cases with linked Bugs → recover Bug To Fix",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') ORDER BY updated ASC",
+          "configFile": "agents/recover_failed_tc_bug_status.json",
+          "localExecution": true
+        },
+        {
           "description": "Failed Test Cases → create or link bug (single, disabled by default — use bulk_bugs_creation instead)",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed')",
           "configFile": "agents/bug_creation.json",


### PR DESCRIPTION
## Summary
- add a local SM recovery action for Failed Test Cases that already have linked Bugs
- move Failed TCs with open linked Bugs to Bug To Fix, or Backlog when all linked Bugs are Done
- clear stale SM trigger labels so active bulk bug creation and re-automation paths can continue
- fail loudly when post bug creation cannot move test-code issues to In Rework

## Verification
- JIRA_BASE_PATH=https://example.invalid JIRA_EMAIL=unit@example.invalid JIRA_API_TOKEN=dummy dmtools run js/unit-tests/run_all.json
- 302 passed, 0 failed

## Jira cleanup
- confirmed TS Failed Test Case count is now 0 after recovering 24 stuck TCs with Done linked Bugs to Backlog