### PR TITLE
Force CodeGraph usage in test review agents

### DIFF
--- a/pr_test_automation_review.json
+++ b/pr_test_automation_review.json
@@ -32,7 +32,8 @@
     },
     "inputJql": "key = JD-111",
     "cliPrompts": [
-      "./agents/prompts/bash_tools.md"
+      "./agents/prompts/bash_tools.md",
+      "./agents/prompts/codegraph_tools.md"
     ]
   }
 }

--- a/pr_test_automation_rework.json
+++ b/pr_test_automation_rework.json
@@ -33,7 +33,8 @@
     },
     "inputJql": "project = JD AND issuetype = 'Test Case' AND status = 'In Rework'",
     "cliPrompts": [
-      "./agents/prompts/bash_tools.md"
+      "./agents/prompts/bash_tools.md",
+      "./agents/prompts/codegraph_tools.md"
     ]
   }
 }

--- a/prompts/pr_test_automation_review_prompt.md
+++ b/prompts/pr_test_automation_review_prompt.md
@@ -1,5 +1,16 @@
 User request is in the 'input' folder. Read all files there.
 
+Before reviewing any source/test code, run CodeGraph once to orient yourself in
+the repository. Use a command such as:
+
+```bash
+codegraph context "test automation review architecture and relevant testing patterns"
+```
+
+Reading files from `input/` is allowed first because they are generated task
+context, but your first repository code-navigation command must be CodeGraph.
+Do not finish the review without a recorded CodeGraph invocation.
+
 **IMPORTANT**: Read in order:
 1. `request.md` *(if present)* — full ticket details
 2. `comments.md` *(if present)* — ticket comment history; recent comments contain previous test run results

--- a/prompts/pr_test_automation_rework_prompt.md
+++ b/prompts/pr_test_automation_rework_prompt.md
@@ -1,5 +1,16 @@
 User request is in the 'input' folder. Read all files there.
 
+Before modifying or reviewing any source/test code, run CodeGraph once to orient
+yourself in the repository. Use a command such as:
+
+```bash
+codegraph context "test automation rework architecture and relevant testing patterns"
+```
+
+Reading files from `input/` is allowed first because they are generated task
+context, but your first repository code-navigation command must be CodeGraph.
+Do not finish rework without a recorded CodeGraph invocation.
+
 **IMPORTANT**: Read in order:
 1. `request.md` *(if present)* — full ticket details
 2. `comments.md` *(if present)* — ticket comment history; recent comments contain previous test run results and review feedback


### PR DESCRIPTION
## Summary
- add CodeGraph tools prompt directly to test automation review/rework agent configs
- require a CodeGraph context call before reviewing or modifying repository test code

## Validation
- jq empty pr_test_automation_review.json pr_test_automation_rework.json
- JIRA_BASE_PATH=https://example.invalid JIRA_EMAIL=unit@example.invalid JIRA_API_TOKEN=dummy dmtools run js/unit-tests/run_all.json (302 passed, 0 failed)