### PR TITLE
Exclude Done bugs from bug matching

### DIFF
--- a/bulk_bugs_creation.json
+++ b/bulk_bugs_creation.json
@@ -8,9 +8,9 @@
       "aiRole": "QA Engineer",
       "instructions": [
         "Read input/failed_tcs.json for the list of failed Test Cases.",
-        "Read input/open_bugs.json for all existing open bugs.",
-        "Read input/done_bugs.json for recently fixed (Done) bugs.",
-        "For each failed TC decide: link to existing open bug, create new bug, mark as fixed by Done bug, or skip (test code issue only).",
+        "Read input/open_bugs.json for all existing non-Done bugs.",
+        "Done bugs are intentionally excluded from bug matching.",
+        "For each failed TC decide: link to existing non-Done bug, create new bug, or skip (test code issue only).",
         "Group TCs with the same root cause — create ONE new bug for the group.",
         "Write outputs/bulk_bug_decisions.json as described in the prompt.",
         "For each new bug write its description to a separate file: outputs/bug_NNN_description.md (NNN = zero-padded index). Reference that file in bulk_bug_decisions.json via 'descriptionFile'.",
@@ -18,7 +18,7 @@
         "Prefer creating a bug over skipping. Only skip when you are confident the failure is purely a test code problem — and provide a detailed reason."
       ],
       "knownInfo": "",
-      "formattingRules": "outputs/bulk_bug_decisions.json must be valid JSON. 'processed' must list every TC key the AI made a decision for. newBugs[].descriptionFile must be a relative path to an existing outputs/*.md file. fixedByBug[] entries must reference a bugKey from input/done_bugs.json. skipped[].reason must be a detailed explanation of the test code issue."
+      "formattingRules": "outputs/bulk_bug_decisions.json must be valid JSON. 'processed' must list every TC key the AI made a decision for. newBugs[].descriptionFile must be a relative path to an existing outputs/*.md file. Do not output fixedByBug; Done bugs are excluded from matching. skipped[].reason must be a detailed explanation of the test code issue."
     },
     "cliPrompt": "./agents/prompts/bulk_bugs_creation_prompt.md",
     "cliCommands": [

--- a/js/fetchLinkedBugsToInput.js
+++ b/js/fetchLinkedBugsToInput.js
@@ -23,7 +23,7 @@ function action(params) {
         var linkedBugs = [];
         try {
             linkedBugs = jira_search_by_jql({
-                jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug',
+                jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in (Done)',
                 fields: ['key', 'summary', 'status', 'description', 'Solution', 'labels'],
                 maxResults: 10
             });

--- a/js/prepareBulkBugsCreationContext.js
+++ b/js/prepareBulkBugsCreationContext.js
@@ -2,11 +2,11 @@
  * Prepare Bulk Bugs Creation Context (preCliJSAction for bulk_bugs_creation agent)
  *
  * Fetches all failed Test Cases (without sm_bug_creation_triggered label) and
- * all open bugs, then writes them to input files for the AI to process in batch.
+ * all non-Done bugs, then writes them to input files for the AI to process in batch.
  *
  * Writes:
  *   input/failed_tcs.json  — array of failed TC objects
- *   input/open_bugs.json   — array of open bug objects
+ *   input/open_bugs.json   — array of non-Done bug objects
  *   input/context.md       — summary for the AI
  *
  * The SM passes one ticket as the "trigger" but this action ignores it and
@@ -75,8 +75,8 @@ function action(params) {
         file_write(inputFolder + '/failed_tcs.json', JSON.stringify(tcList, null, 2));
         console.log('Wrote input/failed_tcs.json with ' + tcList.length + ' TCs');
 
-        // Fetch open bugs
-        console.log('Fetching open bugs with JQL:', openBugsJql);
+        // Fetch non-Done bugs
+        console.log('Fetching non-Done bugs with JQL:', openBugsJql);
         var bugs = [];
         try {
             var bugResults = jira_search_by_jql({
@@ -89,7 +89,7 @@ function action(params) {
             console.error('Failed to fetch open bugs:', e);
         }
 
-        console.log('Found ' + bugs.length + ' open bug(s)');
+        console.log('Found ' + bugs.length + ' non-Done bug(s)');
 
         var bugList = bugs.map(function(bug) {
             var fields = bug.fields || {};
@@ -104,51 +104,17 @@ function action(params) {
 
         if (bugList.length === 0) {
             file_write(inputFolder + '/open_bugs.json', '[]');
-            console.log('No open bugs found — wrote empty open_bugs.json');
+            console.log('No non-Done bugs found — wrote empty open_bugs.json');
         } else {
             file_write(inputFolder + '/open_bugs.json', JSON.stringify(bugList, null, 2));
             console.log('Wrote input/open_bugs.json with ' + bugList.length + ' bugs');
         }
 
-        // Fetch recently Done bugs (for "already fixed" detection)
-        var doneBugsJql = (customParams.doneBugsJql ||
-            'project = {jiraProject} AND issuetype in (Bug) AND status in (Done) ORDER BY updated DESC')
-            .replace('{jiraProject}', projectKey);
-
-        console.log('Fetching done bugs with JQL:', doneBugsJql);
-        var doneBugs = [];
-        try {
-            var doneResults = jira_search_by_jql({
-                jql: doneBugsJql,
-                fields: ['key', 'summary', 'description', 'status', 'priority'],
-                maxResults: 100
-            });
-            doneBugs = doneResults || [];
-        } catch (e) {
-            console.error('Failed to fetch done bugs:', e);
-        }
-
-        console.log('Found ' + doneBugs.length + ' done bug(s)');
-
-        var doneBugList = doneBugs.map(function(bug) {
-            var fields = bug.fields || {};
-            return {
-                key: bug.key,
-                summary: fields.summary || '',
-                description: (fields.description || '').substring(0, 500),
-                status: fields.status ? fields.status.name : '',
-                priority: fields.priority ? fields.priority.name : ''
-            };
-        });
-
-        file_write(inputFolder + '/done_bugs.json', JSON.stringify(doneBugList, null, 2));
-        console.log('Wrote input/done_bugs.json with ' + doneBugList.length + ' bugs');
-
         // Write context summary for the AI
         var contextMd = '# Bulk Bug Creation Context\n\n' +
             '- **Project**: ' + projectKey + '\n' +
             '- **Failed TCs to process**: ' + tcList.length + '\n' +
-            '- **Open bugs for dedup check**: ' + bugList.length + '\n\n' +
+            '- **Non-Done bugs for dedup check**: ' + bugList.length + '\n\n' +
             'Read `input/failed_tcs.json` and `input/open_bugs.json`, then follow the prompt instructions.\n';
         file_write(inputFolder + '/context.md', contextMd);
         console.log('=== Context preparation complete ===');

--- a/js/recoverFailedTCBugStatus.js
+++ b/js/recoverFailedTCBugStatus.js
@@ -1,9 +1,10 @@
 /**
  * Recover Failed Test Cases after bug triage.
  *
- * If a Failed TC already has linked Bugs, it must not stay in Failed waiting
- * for bug_creation again. Move it to Bug To Fix while any linked bug is open,
- * or Backlog if all linked bugs are already Done.
+ * If a Failed TC already has linked non-Done Bugs, it must not stay in Failed
+ * waiting for bug_creation again. Move it to Bug To Fix while any linked bug is
+ * still active. Done Bugs are historical context only; they must not suppress
+ * new bug creation.
  */
 
 const { STATUSES } = require('./config.js');
@@ -25,12 +26,12 @@ function action(params) {
     console.log('=== Failed TC bug status recovery for', ticketKey, '===');
 
     var linkedBugs = jira_search_by_jql({
-        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug',
+        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in (Done)',
         maxResults: 50
     }) || [];
 
     if (linkedBugs.length === 0) {
-        console.log('No linked Bugs found for', ticketKey);
+        console.log('No linked non-Done Bugs found for', ticketKey);
         // The old single bug_creation rule is disabled, but its trigger label
         // can remain on Failed TCs and exclude them from bulk_bugs_creation JQL.
         // Clear only that stale single-run label so the active bulk path can
@@ -39,14 +40,8 @@ function action(params) {
         return { success: true, action: 'released_for_bulk_bug_creation', ticketKey: ticketKey };
     }
 
-    var openBugs = jira_search_by_jql({
-        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status != "Done"',
-        maxResults: 1
-    }) || [];
-
-    var targetStatus = openBugs.length > 0 ? STATUSES.BUG_TO_FIX : STATUSES.BACKLOG;
-    jira_move_to_status({ key: ticketKey, statusName: targetStatus });
-    console.log('Moved', ticketKey, 'to', targetStatus);
+    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BUG_TO_FIX });
+    console.log('Moved', ticketKey, 'to', STATUSES.BUG_TO_FIX);
 
     removeLabel(ticketKey, 'sm_bug_creation_triggered');
     removeLabel(ticketKey, 'sm_bulk_bugs_creation_triggered');
@@ -54,18 +49,14 @@ function action(params) {
 
     jira_post_comment({
         key: ticketKey,
-        comment: openBugs.length > 0
-            ? 'h3. 🐛 Linked Bug Found — Moved to Bug To Fix\n\n' +
-                'This failed test case already has linked Bug issue(s), so it was moved to *' +
-                STATUSES.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
-            : 'h3. 🔄 Linked Bug Already Done — Ready for Re-automation\n\n' +
-                'All linked Bug issue(s) are already *Done*, so this test case was moved to *' +
-                STATUSES.BACKLOG + '* for re-automation.'
+        comment: 'h3. 🐛 Linked Non-Done Bug Found — Moved to Bug To Fix\n\n' +
+            'This failed test case already has linked non-Done Bug issue(s), so it was moved to *' +
+            STATUSES.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
     });
 
     return {
         success: true,
-        action: openBugs.length > 0 ? 'moved_to_bug_to_fix' : 'moved_to_backlog',
+        action: 'moved_to_bug_to_fix',
         ticketKey: ticketKey,
         linkedBugs: linkedBugs.length
     };

--- a/js/unit-tests/test_recoverFailedTCBugStatus.js
+++ b/js/unit-tests/test_recoverFailedTCBugStatus.js
@@ -35,10 +35,10 @@ suite('recoverFailedTCBugStatus', function() {
         var loaded = loadRecoverFailedTCBugStatus({
             jira_search_by_jql: function(args) {
                 loaded.calls.searches.push(args);
-                if (args.jql.indexOf('status != "Done"') !== -1) {
+                if (args.jql.indexOf('status not in (Done)') !== -1) {
                     return [{ key: 'TS-1289' }];
                 }
-                return [{ key: 'TS-1289' }];
+                return [];
             }
         });
 
@@ -56,22 +56,23 @@ suite('recoverFailedTCBugStatus', function() {
         assert.contains(loaded.calls.comments[0].comment, 'Moved to Bug To Fix');
     });
 
-    test('moves Failed TC with only Done linked Bugs to Backlog', function() {
+    test('releases Failed TC with only Done linked Bugs for bulk bug creation', function() {
         var loaded = loadRecoverFailedTCBugStatus({
             jira_search_by_jql: function(args) {
                 loaded.calls.searches.push(args);
-                if (args.jql.indexOf('status != "Done"') !== -1) {
+                if (args.jql.indexOf('status not in (Done)') !== -1) {
                     return [];
                 }
-                return [{ key: 'TS-1289' }];
+                return [];
             }
         });
 
         var result = loaded.mod.action({ ticket: { key: 'TS-333' } });
 
-        assert.equal(result.action, 'moved_to_backlog');
-        assert.deepEqual(loaded.calls.statusMoves, [
-            { key: 'TS-333', statusName: 'Backlog' }
+        assert.equal(result.action, 'released_for_bulk_bug_creation');
+        assert.deepEqual(loaded.calls.statusMoves, []);
+        assert.deepEqual(loaded.calls.removedLabels, [
+            { key: 'TS-333', label: 'sm_bug_creation_triggered' }
         ]);
     });
 

--- a/prompts/bulk_bugs_creation_prompt.md
+++ b/prompts/bulk_bugs_creation_prompt.md
@@ -12,14 +12,16 @@ Read `input/failed_tcs.json`. It contains an array of failed Test Case objects, 
 
 The `lastComment` is the **primary source** for bug description — it contains the latest run result.
 
-## Step 2 — Read existing bugs (open and recently fixed)
+## Step 2 — Read existing non-Done bugs
 
-Read `input/open_bugs.json`. It contains an array of **open** bug objects, each with:
+Read `input/open_bugs.json`. It contains an array of **non-Done** bug objects, each with:
 - `key` — existing bug key
 - `summary` — bug summary
 - `description` — bug description
 
-Read `input/done_bugs.json`. It contains an array of **recently fixed (Done)** bug objects with the same fields. Use these to detect TCs whose underlying bug has already been resolved.
+Done bugs are intentionally not provided and must not be used for matching.
+They are historical context only. If no matching non-Done bug exists for a
+current failed run, create a new bug.
 
 ### Duplicate / match rules (treat as match if ANY of the following):
 - Same component AND same failure symptom
@@ -30,11 +32,9 @@ Read `input/done_bugs.json`. It contains an array of **recently fixed (Done)** b
 
 For each failed TC, decide one of:
 
-**A — Link to existing open bug**: A clearly matching **open** bug already exists. The TC will be moved to "Bug To Fix" to wait for the fix.
+**A — Link to existing non-Done bug**: A clearly matching **non-Done** bug already exists. The TC will be moved to "Bug To Fix" to wait for the fix.
 
 **B — Create new bug**: No matching bug exists. If multiple TCs share the same root cause, group them under ONE new bug. The TC will be moved to "Bug To Fix".
-
-**C — Already fixed by a Done bug**: A matching bug exists in `input/done_bugs.json` that has already been fixed. The TC will be moved to "Backlog" for re-automation against the fixed code.
 
 **D — Skip (test code issue)**: The TC failed due to a test code issue (flaky selector, test environment problem, outdated test assertion), NOT an application bug. **You MUST provide a detailed reason** explaining exactly what test code issue caused the failure and why it is not an application bug. The TC will remain in "Failed" for the next review cycle.
 
@@ -69,13 +69,6 @@ Write a JSON object with this structure:
       "bugKey": "TS-123"
     }
   ],
-  "fixedByBug": [
-    {
-      "tcKey": "TS-800",
-      "bugKey": "TS-050",
-      "reason": "Bug TS-050 fixed the same component validation logic — TC should pass now"
-    }
-  ],
   "skipped": [
     {
       "tcKey": "TS-YYY",
@@ -87,8 +80,8 @@ Write a JSON object with this structure:
 
 **Rules for `bulk_bug_decisions.json`:**
 - `processed` MUST include the key of every TC you made a decision for
-- Every TC from `input/failed_tcs.json` MUST appear in exactly one of: `newBugs[].linkedTCs`, `links`, `fixedByBug`, or `skipped`
-- `fixedByBug` is for TCs matched to a **Done** bug from `input/done_bugs.json` — these TCs will be moved to Backlog for re-automation
+- Every TC from `input/failed_tcs.json` MUST appear in exactly one of: `newBugs[].linkedTCs`, `links`, or `skipped`
+- Do not output `fixedByBug`. Done bugs are excluded from bug matching; a current failed run with no matching non-Done bug requires a new bug unless it is clearly a test-code issue.
 - `skipped[].reason` MUST be a detailed explanation (not just "test issue") — explain the specific test code problem
 - `priority` must be one of: `Highest`, `High`, `Medium`, `Low`, `Lowest`
 - `descriptionFile` must reference a file you actually write (see below)


### PR DESCRIPTION
## Summary
- exclude Done bugs from linked-bug and bulk bug matching JQL
- stop generating or consuming done_bugs.json in bulk bug creation context
- release failed TCs with only historical Done bugs back to bulk bug creation

## Tests
- dmtools run js/unit-tests/run_all.json