### PR TITLE
Prioritize failed test case bug triage

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -170,14 +170,6 @@
           "addLabel": "sm_test_review_triggered"
         },
         {
-          "description": "Backlog / To Do / Ready For Development Test Cases → In Development + automate",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Backlog', 'To Do', 'Ready For Development')",
-          "targetStatus": "In Development",
-          "configFile": "agents/test_case_automation.json",
-          "skipIfLabel": "sm_test_automation_triggered",
-          "addLabel": "sm_test_automation_triggered"
-        },
-        {
           "description": "Failed Test Cases with linked Bugs → recover Bug To Fix",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') ORDER BY updated ASC",
           "configFile": "agents/recover_failed_tc_bug_status.json",
@@ -201,6 +193,14 @@
           "recoverStaleTriggerLabel": true,
           "limit": 1,
           "enabled": true
+        },
+        {
+          "description": "Backlog / To Do / Ready For Development Test Cases → In Development + automate",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Backlog', 'To Do', 'Ready For Development')",
+          "targetStatus": "In Development",
+          "configFile": "agents/test_case_automation.json",
+          "skipIfLabel": "sm_test_automation_triggered",
+          "addLabel": "sm_test_automation_triggered"
         },
         {
           "description": "Bug To Fix Test Cases → all linked Bugs Done → move to Backlog",


### PR DESCRIPTION
## Summary
- move Failed Test Case recovery and bulk bug creation before new Backlog/Ready Test Case automation
- prevents Failed TC bug triage from starving when SM workflow cap is consumed by new automation triggers first

## Tests
- dmtools run js/unit-tests/run_all.json: 302 passed, 0 failed