### PR TITLE
Serialize bulk bug creation runs

### DIFF
--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -26,6 +26,7 @@
  *   targetStatus   (optional) — Jira status to transition tickets to before triggering
  *   workflowFile   (optional) — GitHub Actions workflow file  (default: ai-teammate.yml)
  *   workflowRef    (optional) — git ref for dispatch           (default: main)
+ *   concurrencyKey (optional) — workflow concurrency key override (default: ticket key)
  *   projectKey     (optional) — value passed as the `project_key` workflow input so the runner
  *                               activates the correct project-specific dependency setup (e.g. "myproject",
  *                               "bice"). Auto-derived from configPath basename when not set
@@ -248,6 +249,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig) {
     var workflowFile = rule.workflowFile || 'ai-teammate.yml';
     var workflowRef  = rule.workflowRef  || 'main';
     var resolvedCf   = resolveConfigFile(rule, effectiveConfig);
+    var concurrencyKey = rule.concurrencyKey || ticketKey;
 
     // Resolve project_key: explicit rule field takes priority, then auto-derive from configPath
     // e.g. ".dmtools/configs/myproject.js" → "myproject", ".dmtools/configs/bice.js" → "bice"
@@ -260,7 +262,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig) {
 
     try {
         var scm = scmModule.createScm(effectiveConfig);
-        if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, ticketKey)) {
+        if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, concurrencyKey)) {
             return false;
         }
         scm.triggerWorkflow(
@@ -268,7 +270,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig) {
             repoInfo.repo,
             workflowFile,
             JSON.stringify({
-                concurrency_key: ticketKey,
+                concurrency_key: concurrencyKey,
                 config_file:     resolvedCf,
                 encoded_config:  buildEncodedConfig(ticketKey, rule, effectiveConfig),
                 project_key:     projectKey

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -410,6 +410,27 @@ suite('smAgent: ticket dispatch', function() {
         assert.contains(decoded.params.inputJql, 'P-42', 'ticket key in inputJql');
     });
 
+    test('uses rule concurrencyKey override while preserving ticket inputJql', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-42', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/bulk_bugs_creation.json',
+                concurrencyKey: 'bulk_bugs_creation'
+            })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 1);
+        var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
+        assert.equal(inputs.concurrency_key, 'bulk_bugs_creation', 'rule concurrency key used');
+
+        var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
+        assert.contains(decoded.params.inputJql, 'P-42', 'ticket key still used for agent input');
+    });
+
     test('interpolates project placeholders from target agent params into encoded config', function() {
         var sm = makeSmAgent({
             fileMap: {

--- a/sm.json
+++ b/sm.json
@@ -188,6 +188,7 @@
           "description": "Failed Test Cases → create or link bugs in batch",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') AND (labels is EMPTY OR labels NOT IN ('sm_bug_creation_triggered')) ORDER BY created ASC",
           "configFile": "agents/bulk_bugs_creation.json",
+          "concurrencyKey": "bulk_bugs_creation",
           "skipIfLabel": "sm_bulk_bugs_creation_triggered",
           "addLabel": "sm_bulk_bugs_creation_triggered",
           "recoverStaleTriggerLabel": true,


### PR DESCRIPTION
## Summary
- add rule-level concurrencyKey override for SM-triggered workflows
- serialize bulk bug creation under one shared key while preserving ticket-specific inputJql
- cover the override with a unit test

## Tests
- dmtools run js/unit-tests/run_all.json