### PR TITLE
Retry Copilot rate limits in agent runner

### DIFF
--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -161,11 +161,24 @@ function action(params) {
         var processed = decisions.processed || [];
         var newBugs = decisions.newBugs || [];
         var links = decisions.links || [];
-        var fixedByBug = decisions.fixedByBug || [];
         var skipped = decisions.skipped || [];
+        var fixedByBug = decisions.fixedByBug || [];
+
+        if (fixedByBug.length > 0) {
+            console.error('❌ fixedByBug is not supported for bulk bug creation; Done bugs are excluded from matching');
+            fixedByBug.forEach(function(fixDef) {
+                if (fixDef && fixDef.tcKey) {
+                    removeProcessingLabels(fixDef.tcKey, [triggerLabel, smTriggerLabel]);
+                }
+            });
+            return {
+                success: false,
+                error: 'fixedByBug is not supported; create or link a non-Done bug, or skip only confirmed test-code issues'
+            };
+        }
 
         console.log('Decisions: ' + newBugs.length + ' new bugs, ' + links.length + ' links, ' +
-            fixedByBug.length + ' fixed by done bug, ' + skipped.length + ' skipped');
+            skipped.length + ' skipped');
         console.log('Processed TCs: ' + processed.join(', '));
 
         var results = { created: [], linked: [], skipped: [], errors: [] };
@@ -271,50 +284,7 @@ function action(params) {
             }
         });
 
-        // ── 3. Handle TCs fixed by Done bugs → Backlog ────────────────────
-        var fixedByBug = decisions.fixedByBug || [];
-        fixedByBug.forEach(function(fixDef) {
-            var tcKey = fixDef.tcKey;
-            var bugKey = fixDef.bugKey;
-
-            if (!tcKey) return;
-            if (!processedSet[tcKey]) {
-                console.warn('  ⚠️ TC', tcKey, 'not in processed list — skipping (safety guard)');
-                return;
-            }
-
-            console.log('  Fixed by Done bug:', tcKey, '→', bugKey || 'unknown');
-            try {
-                if (bugKey) {
-                    linkBugToTC(tcKey, bugKey);
-                }
-                // Move to Backlog for re-automation against fixed code
-                try {
-                    jira_move_to_status({ key: tcKey, statusName: 'Backlog' });
-                    console.log('  📋 Moved to Backlog:', tcKey);
-                } catch (e) {
-                    console.warn('  ⚠️ Could not move to Backlog:', tcKey, e);
-                }
-                // Remove test automation label so SM can re-trigger automation
-                try {
-                    jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
-                } catch (e) {}
-                // Remove bug creation trigger label
-                removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
-                postComment(tcKey,
-                    'h3. 🔄 Bug Already Fixed — Ready for Re-automation\n\n' +
-                    (bugKey ? 'Matching bug *' + bugKey + '* is already in *Done* status.\n\n' : '') +
-                    (fixDef.reason || 'The underlying bug has been fixed.') +
-                    '\n\n_TC moved to *Backlog* for re-automation against the fixed code._'
-                );
-                results.created.push({ tcKey: tcKey, bugKey: bugKey || 'done', action: 'fixed_by_bug' });
-            } catch (e) {
-                console.error('  ❌ Failed to process fixed TC', tcKey, ':', e);
-                results.errors.push({ tcKey: tcKey, bugKey: bugKey, error: e.toString() });
-            }
-        });
-
-        // ── 4. Test-code issues → In Rework so they leave Failed and rework runs ─
+        // ── 3. Test-code issues → In Rework so they leave Failed and rework runs ─
         skipped.forEach(function(skipDef) {
             var tcKey = skipDef.tcKey;
             if (!tcKey) return;

--- a/js/unit-tests/test_postBulkBugsCreation.js
+++ b/js/unit-tests/test_postBulkBugsCreation.js
@@ -77,4 +77,48 @@ suite('postBulkBugsCreation', function() {
         assert.contains(comments[0].comment, 'In Rework');
     });
 
+    test('rejects fixedByBug decisions and does not move TC to Backlog', function() {
+        var statusMoves = [];
+        var removedLabels = [];
+        var links = [];
+
+        var module = loadPostBulkBugsCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bulk_bug_decisions.json') {
+                    return JSON.stringify({
+                        processed: ['TS-706'],
+                        newBugs: [],
+                        links: [],
+                        fixedByBug: [
+                            { tcKey: 'TS-706', bugKey: 'TS-1', reason: 'Done bug matched' }
+                        ],
+                        skipped: []
+                    });
+                }
+                return null;
+            },
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); },
+            jira_link_issues: function(args) { links.push(args); }
+        });
+
+        var result = module.action({
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered',
+                    smTriggerLabel: 'sm_bulk_bugs_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, false);
+        assert.contains(result.error, 'fixedByBug is not supported');
+        assert.deepEqual(statusMoves, []);
+        assert.deepEqual(links, []);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-706', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-706', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+    });
+
 });

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -160,17 +160,51 @@ elif [ "$PROVIDER" = "copilot" ]; then
   if ! command -v copilot >/dev/null 2>&1; then
     COPILOT_CMD=(npx @github/copilot@1.0.44)
   fi
-  if [ -f "${PROMPT_ARG}" ]; then
-    echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} (prompt: ${PROMPT_BYTES} bytes via stdin)"
-    echo ""
-    "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}"
-  else
-    echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} -p <inline prompt>"
-    echo ""
-    "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}"
-  fi
+  run_copilot_once() {
+    local log_file="$1"
+    set +e
+    if [ -f "${PROMPT_ARG}" ]; then
+      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} (prompt: ${PROMPT_BYTES} bytes via stdin)"
+      echo ""
+      "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
+    else
+      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} -p <inline prompt>"
+      echo ""
+      "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
+    fi
+    local status=${PIPESTATUS[0]}
+    set -e
+    return "$status"
+  }
 
-  exit_code=$?
+  max_attempts="${COPILOT_RATE_LIMIT_RETRIES:-2}"
+  retry_delay="${COPILOT_RATE_LIMIT_RETRY_DELAY_SECONDS:-90}"
+  attempt=1
+  exit_code=1
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    copilot_log="$(mktemp)"
+    run_copilot_once "$copilot_log"
+    exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+      rm -f "$copilot_log"
+      break
+    fi
+
+    if grep -Eiq "rate limit|limit reset|You've hit your rate limit" "$copilot_log" && [ "$attempt" -lt "$max_attempts" ]; then
+      echo ""
+      echo "Copilot rate limit detected; retrying in ${retry_delay}s (attempt $((attempt + 1))/${max_attempts})"
+      rm -f "$copilot_log"
+      sleep "$retry_delay"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    rm -f "$copilot_log"
+    break
+  done
+
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="
   exit $exit_code


### PR DESCRIPTION
## Summary
- retry Copilot CLI once on transient rate-limit failures instead of ending immediately
- keep final non-zero exit status when retry does not recover
- reject unsupported fixedByBug bulk decisions so Done bugs cannot move failed TCs to Backlog

## Tests
- bash -n scripts/run-agent.sh
- dmtools run js/unit-tests/run_all.json