### PR TITLE
Prevent duplicate bulk bug creation

### DIFF
--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -70,6 +70,47 @@ function linkBugToTC(tcKey, bugKey) {
     console.log('  ✅ Linked:', bugKey, 'blocks', tcKey);
 }
 
+function extractTickets(result) {
+    if (!result) return [];
+    if (Array.isArray(result)) return result;
+    if (typeof result === 'string') {
+        try {
+            var parsed = JSON.parse(result);
+            return extractTickets(parsed);
+        } catch (e) {
+            return [];
+        }
+    }
+    if (Array.isArray(result.issues)) return result.issues;
+    if (Array.isArray(result.data)) return result.data;
+    if (Array.isArray(result.results)) return result.results;
+    return [];
+}
+
+function findLinkedNonDoneBug(tcKey) {
+    if (!tcKey || typeof jira_search_by_jql !== 'function') return null;
+    try {
+        var result = jira_search_by_jql({
+            jql: 'issue in linkedIssues("' + tcKey + '") AND issuetype = Bug AND status not in (Done)',
+            fields: ['key', 'summary', 'status'],
+            maxResults: 1
+        });
+        var tickets = extractTickets(result);
+        return tickets.length > 0 ? (tickets[0].key || null) : null;
+    } catch (e) {
+        console.warn('  ⚠️ Could not live-check linked non-Done bugs for', tcKey, e);
+        return null;
+    }
+}
+
+function findAnyLinkedNonDoneBug(tcKeys) {
+    for (var i = 0; i < tcKeys.length; i++) {
+        var bugKey = findLinkedNonDoneBug(tcKeys[i]);
+        if (bugKey) return bugKey;
+    }
+    return null;
+}
+
 function moveToBugToFix(tcKey) {
     try {
         jira_move_to_status({ key: tcKey, statusName: STATUSES.BUG_TO_FIX || 'Bug To Fix' });
@@ -208,6 +249,32 @@ function action(params) {
 
             var linkedTCs = bugDef.linkedTCs || [];
             console.log('  Creating bug:', summary, '| links to:', linkedTCs.join(', '));
+
+            var existingBugKey = findAnyLinkedNonDoneBug(linkedTCs);
+            if (existingBugKey) {
+                console.log('  🔁 Existing linked non-Done bug found during live re-check:', existingBugKey);
+                linkedTCs.forEach(function(tcKey) {
+                    if (!processedSet[tcKey]) {
+                        console.warn('  ⚠️ TC', tcKey, 'not in processed list — skipping (safety guard)');
+                        return;
+                    }
+                    try {
+                        linkBugToTC(tcKey, existingBugKey);
+                        moveToBugToFix(tcKey);
+                        addTriggerLabel(tcKey, triggerLabel);
+                        removeTriggerLabel(tcKey, smTriggerLabel);
+                        postComment(tcKey,
+                            'h3. 🔗 Existing Bug Linked (Batch Live Re-check)\n\n' +
+                            'Linked to existing non-Done bug: *' + existingBugKey + '*'
+                        );
+                        results.linked.push({ tcKey: tcKey, bugKey: existingBugKey, source: 'live_recheck' });
+                    } catch (e) {
+                        console.error('  ❌ Failed to link', tcKey, '→', existingBugKey, ':', e);
+                        results.errors.push({ tcKey: tcKey, bugKey: existingBugKey, error: e.toString() });
+                    }
+                });
+                return;
+            }
 
             var bugKey = null;
             try {

--- a/js/unit-tests/test_postBulkBugsCreation.js
+++ b/js/unit-tests/test_postBulkBugsCreation.js
@@ -10,6 +10,7 @@ function loadPostBulkBugsCreation(mocks) {
         jira_add_label: function() {},
         jira_link_issues: function() {},
         jira_create_ticket_basic: function() { return ''; },
+        jira_search_by_jql: function() { return []; },
         file_read: function() { return null; }
     };
 
@@ -118,6 +119,66 @@ suite('postBulkBugsCreation', function() {
         assert.deepEqual(removedLabels, [
             { key: 'TS-706', label: 'sm_bug_creation_triggered' },
             { key: 'TS-706', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+    });
+
+    test('live-checks linked non-Done bugs before creating a duplicate', function() {
+        var created = [];
+        var linked = [];
+        var statusMoves = [];
+
+        var module = loadPostBulkBugsCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bulk_bug_decisions.json') {
+                    return JSON.stringify({
+                        processed: ['TS-657'],
+                        newBugs: [
+                            {
+                                summary: 'Duplicate candidate',
+                                priority: 'Medium',
+                                descriptionFile: 'outputs/bug_001_description.md',
+                                linkedTCs: ['TS-657']
+                            }
+                        ],
+                        links: [],
+                        skipped: []
+                    });
+                }
+                if (opts.path === 'outputs/bug_001_description.md') {
+                    return 'Bug description';
+                }
+                return null;
+            },
+            jira_search_by_jql: function(args) {
+                assert.contains(args.jql, 'linkedIssues("TS-657")');
+                assert.contains(args.jql, 'status not in (Done)');
+                return [{ key: 'TS-1291' }];
+            },
+            jira_create_ticket_basic: function() {
+                created.push(Array.prototype.slice.call(arguments));
+                return '{"key":"TS-9999"}';
+            },
+            jira_link_issues: function(args) { linked.push(args); },
+            jira_move_to_status: function(args) { statusMoves.push(args); }
+        });
+
+        var result = module.action({
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered',
+                    smTriggerLabel: 'sm_bulk_bugs_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(created.length, 0);
+        assert.equal(result.results.linked.length, 1);
+        assert.deepEqual(linked, [
+            { sourceKey: 'TS-657', anotherKey: 'TS-1291', relationship: 'Blocks' }
+        ]);
+        assert.deepEqual(statusMoves, [
+            { key: 'TS-657', statusName: 'Bug To Fix' }
         ]);
     });
 


### PR DESCRIPTION
## Summary
- live-check linked non-Done bugs before creating a new bulk bug
- link/move TCs to the existing bug when the check finds one
- cover the duplicate prevention path with a unit test

## Tests
- dmtools run js/unit-tests/run_all.json