### PR TITLE
Preserve workflow input JQL with shared concurrency

### DIFF
--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -271,6 +271,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig) {
             workflowFile,
             JSON.stringify({
                 concurrency_key: concurrencyKey,
+                input_jql:       'key = ' + ticketKey,
                 config_file:     resolvedCf,
                 encoded_config:  buildEncodedConfig(ticketKey, rule, effectiveConfig),
                 project_key:     projectKey

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -403,6 +403,7 @@ suite('smAgent: ticket dispatch', function() {
         assert.equal(sm.capturedTriggers.length, 1);
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         assert.equal(inputs.concurrency_key, 'P-42', 'concurrency key set to ticket key');
+        assert.equal(inputs.input_jql, 'key = P-42', 'workflow input JQL set to ticket key');
         assert.equal(inputs.config_file, 'agents/story_development.json', 'config_file passed');
         assert.ok(inputs.encoded_config, 'encoded_config present');
 
@@ -426,6 +427,7 @@ suite('smAgent: ticket dispatch', function() {
         assert.equal(sm.capturedTriggers.length, 1);
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         assert.equal(inputs.concurrency_key, 'bulk_bugs_creation', 'rule concurrency key used');
+        assert.equal(inputs.input_jql, 'key = P-42', 'workflow input JQL remains ticket-specific');
 
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.contains(decoded.params.inputJql, 'P-42', 'ticket key still used for agent input');


### PR DESCRIPTION
## Summary
- pass ticket-specific input_jql when SM dispatch uses a shared concurrencyKey
- keep encoded config inputJql ticket-specific
- cover the workflow input payload in unit tests

## Tests
- dmtools run js/unit-tests/run_all.json