### PR TITLE
Honor shared concurrency during stale recovery

### DIFF
--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -576,7 +576,8 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
                 var workflowFile = rule.workflowFile || 'ai-teammate.yml';
                 var resolvedCf = resolveConfigFile(rule, effectiveConfig);
                 var scm = scmModule.createScm(effectiveConfig);
-                if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, key)) {
+                var activeKey = rule.concurrencyKey || key;
+                if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, activeKey)) {
                     skippedKeys.push(key);
                     continue;
                 }

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -634,6 +634,36 @@ suite('smAgent: skipIfLabel', function() {
         assert.contains(inputs.encoded_config, 'T-1', 'T-1 was retriggered');
     });
 
+    test('uses shared concurrencyKey when checking active workflow for stale label recovery', function() {
+        var sm = makeSmAgent({
+            fileMap: {},
+            tickets: [
+                { key: 'T-1', fields: { labels: ['sm_bulk_bugs_creation_triggered'] } }
+            ],
+            workflowRuns: {
+                queued: [
+                    {
+                        display_title: 'agents/bulk_bugs_creation.json : bulk_bugs_creation',
+                        status: 'queued'
+                    }
+                ],
+                in_progress: []
+            }
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = X", {
+                configFile: 'agents/bulk_bugs_creation.json',
+                concurrencyKey: 'bulk_bugs_creation',
+                skipIfLabel: 'sm_bulk_bugs_creation_triggered',
+                addLabel: 'sm_bulk_bugs_creation_triggered',
+                recoverStaleTriggerLabel: true
+            })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 0, 'active shared-concurrency run should prevent relaunch');
+    });
+
     test('skips ticket that has any skipIfLabels entry', function() {
         var sm = makeSmAgent({
             fileMap: {},


### PR DESCRIPTION
## Summary
- use rule.concurrencyKey when stale trigger label recovery checks active workflow runs
- prevents shared bulk runs from being treated as stale by ticket-specific checks
- adds unit coverage for bulk_bugs_creation shared concurrency

## Tests
- dmtools run js/unit-tests/run_all.json