### PR TITLE
fix: harden repeated failed tc bug loops

### DIFF
--- a/instructions/development/bug_implementation_instructions.md
+++ b/instructions/development/bug_implementation_instructions.md
@@ -13,6 +13,7 @@ The Teammate job has already prepared the full ticket context in the `input/<TIC
    - Human notes clarifying the bug, edge cases, or reproduction steps
 3. **`existing_questions.json`** — questions previously asked and their answers.
 4. **`linked_tests.md`** — linked test cases, if any.
+   - If a linked Test Case is currently `Failed` after older linked bugs reached `Done`, this ticket is a repeated-fix loop until proven otherwise. Read the latest failed run evidence, list the older Done bug(s) in `outputs/rca.md`, and verify the exact linked test before considering `already_fixed.json`.
 
 ## ⚠️ STEP 0.1 — Bug Returned to Development = Previous Fix Did NOT Work
 
@@ -23,6 +24,17 @@ If `comments.md` shows that **this ticket has been through development before** 
 3. **DO NOT repeat the same approach** — if the previous fix modified file X to add a null check, and the bug is still happening, the null check is not the root cause. Dig deeper.
 4. **DO NOT assume "it was fixed in #NNN"** — the whole reason the ticket is back is that #NNN did not actually fix the problem (or fixed it incompletely). Never write `outputs/already_fixed.json` for a returned bug.
 5. Document in `outputs/rca.md` what the previous attempt missed and why your new approach is different.
+
+### STEP 0.1b — Linked Test Failed After Done Bug
+
+When `linked_tests.md` shows a Test Case that is still `Failed` while comments
+or linked issues mention older Done bugs for the same scenario, handle it like a
+returned bug even if the current Bug ticket is new:
+
+1. Identify the older Done bug(s) and any PRs they reference.
+2. Run the linked test or the closest available command before editing.
+3. Explain in `outputs/rca.md` why the Done bug did not cover the current failure.
+4. Do not write `already_fixed.json` unless the exact linked test passes now in the target environment.
 
 ## ⚠️ STEP 0.2 — Verify the Bug Actually Reproduces NOW
 

--- a/prompts/bug_creation_prompt.md
+++ b/prompts/bug_creation_prompt.md
@@ -6,6 +6,11 @@ Always read these files first if present:
 - `request.md` — full Test Case ticket details
 - `comments.md` — ticket comment history; the most recent comment contains the actual test run result with failure evidence and root cause — **this is the primary source for bug description**
 
+If the most recent comment is a PR/test review, interpret it as follows:
+- "APPROVE", "automation implements the ticket correctly", or "valid product evidence" means the test failure is accepted as a product bug signal.
+- Those phrases are **not** a reason to return `none` or `tests_pass`.
+- Only use `tests_pass` when the most recent actual test run says all relevant checks passed.
+
 ## Step 1 — Read the failed Test Case
 
 Read `input/ticket.md` to understand:
@@ -34,6 +39,14 @@ If `input/no_open_bugs.md` exists — there are no open bugs, skip to Step 3 dir
 **Case C — Tests are currently passing**: Check `comments.md` carefully. If the **most recent test run** shows all tests **PASSED** (regardless of the ticket's current Failed status), use this case. The ticket status is stale — it failed in a previous run but the underlying issue has since been fixed. Do NOT create a bug.
 
 **Case D — No action needed**: If the Test Case failed due to a test code issue (not an application bug), and tests are **not** currently passing, state so.
+
+### Historical Done bugs / loop prevention
+
+Do not decide that the TC is already fixed because an older linked bug is Done.
+Done bugs are history, not open matches. If the TC is currently Failed and no
+open bug matches, create a new bug and mention the older Done bug(s) as prior
+attempts in `outputs/bug_description.md`. This prevents loops where the same TC
+returns to Failed but bug creation keeps suppressing new work.
 
 ## Output
 

--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -9,6 +9,7 @@ User request is in 'input' folder, read all files there and do what is requested
    - Read the **test run comments** to understand prior fix attempts and why they didn't work.
    - If a previous comment says "Bug Already Fixed" but the test is still failing, the fix was **incomplete or the test has timing/async requirements** that the code doesn't yet satisfy.
    - Before writing `already_fixed.json`, verify the linked test actually passes with the current code.
+   - If the linked TC has failed again after one or more Done bugs, treat this as a repeated-fix loop. Summarize the prior Done bug(s) in `outputs/rca.md`, run the linked test or its closest available command first, and do not claim already fixed unless that exact TC passes now.
 5. `existing_questions.json` — if present, clarification answers from the PO — treat as binding requirements
 
 ## GitHub token and workflow self-service

--- a/prompts/bulk_bugs_creation_prompt.md
+++ b/prompts/bulk_bugs_creation_prompt.md
@@ -11,6 +11,10 @@ Read `input/failed_tcs.json`. It contains an array of failed Test Case objects, 
 - `lastComment` — the most recent comment with the actual failure evidence and root cause
 
 The `lastComment` is the **primary source** for bug description — it contains the latest run result.
+If the latest comment is a PR/test review instead of the raw test run, interpret it carefully:
+- "automation implements the ticket correctly", "APPROVE", or "valid product evidence" means the failed TC is ready for bug creation.
+- These review phrases are **not** a reason to skip bug creation.
+- A TC in `Failed` with no matching non-Done bug must get a new bug unless the comment explicitly says the failure is test code, flaky infrastructure, or an invalid assertion.
 
 ## Step 2 — Read existing non-Done bugs
 
@@ -22,6 +26,14 @@ Read `input/open_bugs.json`. It contains an array of **non-Done** bug objects, e
 Done bugs are intentionally not provided and must not be used for matching.
 They are historical context only. If no matching non-Done bug exists for a
 current failed run, create a new bug.
+
+### Loop / historical Done bug rule
+
+Never decide "already fixed" from Done bugs or historical comments. A current
+`Failed` TC means the prior fix did not prove the scenario anymore. If the TC
+mentions prior Done bugs, include them in the new bug description as history
+under "Prior Attempts / Related Done Bugs", but still create or link only a
+non-Done bug.
 
 ### Duplicate / match rules (treat as match if ANY of the following):
 - Same component AND same failure symptom
@@ -41,6 +53,8 @@ For each failed TC, decide one of:
 ### IMPORTANT: Prefer creating a bug over skipping
 - If you are unsure whether the failure is a test issue or an app bug, **create a bug** (option B). It is better to over-report than to leave a TC stuck in Failed with no action.
 - Only use Skip (option D) when you are confident the failure is purely a test infrastructure or test code problem.
+- Do not skip because a review says the test is correct. That is the signal to create a product bug from the failed evidence.
+- Do not skip because a previous Done bug has a similar title. Done bugs are not matches in this workflow.
 
 ### Grouping rules:
 - TCs that test the same UI component and fail with the same symptom → group under one bug
@@ -115,6 +129,10 @@ h2. Actual Result
 h2. Environment
 
 <browser, OS, URL from the TC context>
+
+h2. Prior Attempts / Related Done Bugs
+
+<mention any prior Done bugs or repeated failed attempts from the TC context; write "None observed" if unavailable>
 
 h2. Linked Test Cases
 


### PR DESCRIPTION
## Summary
- Treat approved failed test automation as product-bug evidence, not skip evidence
- Keep Done bugs as historical attempts only during bug creation
- Require bug development to verify exact linked Failed TCs before already_fixed decisions

## Verification
- git diff --check