### PR TITLE
fix: repair stuck test case recovery

### DIFF
--- a/js/recoverStuckTestCase.js
+++ b/js/recoverStuckTestCase.js
@@ -37,9 +37,8 @@ function findPRForTicket(scm, ticketKey) {
 }
 
 function action(params) {
-    var config = configLoader.loadConfig(params);
-    var ticketKey = config.ticketKey;
-    var customParams = config.customParams || {};
+    var ticketKey = params.ticket && params.ticket.key;
+    var config = configLoader.loadProjectConfig(params.jobParams || params || {});
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -48,7 +47,7 @@ function action(params) {
 
     console.log('Recovering stuck Test Case:', ticketKey);
 
-    var scm = scmModule.createSCM();
+    var scm = scmModule.createScm(config);
     var pr = findPRForTicket(scm, ticketKey);
 
     if (!pr) {
@@ -61,7 +60,7 @@ function action(params) {
         }
         // Remove automation label so SM can re-trigger
         try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-        jira_add_comment({
+        jira_post_comment({
             key: ticketKey,
             comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with no open PR. Moved back to Backlog for re-automation.'
         });
@@ -94,7 +93,7 @@ function action(params) {
         // Remove stale labels so rework agent can pick it up
         try { jira_remove_label({ key: ticketKey, label: 'sm_test_rework_triggered' }); } catch (e) {}
         try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-        jira_add_comment({
+        jira_post_comment({
             key: ticketKey,
             comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with a conflicting PR #' + pr.number + '. Moved to In Rework for conflict resolution.'
         });
@@ -110,7 +109,7 @@ function action(params) {
         console.error('Failed to move to In Review - Passed:', e);
     }
     try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-    jira_add_comment({
+    jira_post_comment({
         key: ticketKey,
         comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with clean PR #' + pr.number + '. Moved to In Review - Passed for code review.'
     });

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -18,6 +18,7 @@
         "js/unit-tests/test_dfManager.js",
         "js/unit-tests/test_retryMergePR.js",
         "js/unit-tests/test_recoverMergedPRTicket.js",
+        "js/unit-tests/test_recoverStuckTestCase.js",
         "js/unit-tests/test_recoverFailedTCBugStatus.js",
         "js/unit-tests/test_feedbackLoop.js",
         "js/unit-tests/test_fetchParentContextToInput.js",

--- a/js/unit-tests/test_recoverStuckTestCase.js
+++ b/js/unit-tests/test_recoverStuckTestCase.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for js/recoverStuckTestCase.js.
+ */
+
+function loadRecoverStuckTestCase(options) {
+    options = options || {};
+    var scm = options.scm || {
+        listPrs: function() { return []; }
+    };
+    var statusMoves = [];
+    var removedLabels = [];
+    var comments = [];
+
+    var mod = loadModule(
+        'js/recoverStuckTestCase.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': {
+                loadProjectConfig: function() {
+                    return { repository: { owner: 'IstiN', repo: 'trackstate' } };
+                }
+            },
+            './common/scm.js': { createScm: function() { return scm; } }
+        }),
+        {
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        }
+    );
+
+    return {
+        mod: mod,
+        statusMoves: statusMoves,
+        removedLabels: removedLabels,
+        comments: comments
+    };
+}
+
+suite('recoverStuckTestCase', function() {
+
+    test('moves stuck TC back to Backlog when no open PR exists', function() {
+        var loaded = loadRecoverStuckTestCase();
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-1290' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_backlog');
+        assert.deepEqual(loaded.statusMoves, [
+            { key: 'TS-1290', statusName: 'Backlog' }
+        ]);
+        assert.deepEqual(loaded.removedLabels, [
+            { key: 'TS-1290', label: 'sm_test_automation_triggered' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Moved back to Backlog');
+    });
+
+    test('moves stuck TC to review when matching PR is clean', function() {
+        var loaded = loadRecoverStuckTestCase({
+            scm: {
+                listPrs: function(state) {
+                    assert.equal(state, 'open');
+                    return [{
+                        number: 1559,
+                        title: 'TS-409 test automation',
+                        head: { ref: 'test/TS-409' }
+                    }];
+                },
+                getPr: function(number) {
+                    assert.equal(number, 1559);
+                    return { number: 1559, mergeable: true, mergeable_state: 'clean' };
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-409' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_review');
+        assert.deepEqual(loaded.statusMoves, [
+            { key: 'TS-409', statusName: 'In Review - Passed' }
+        ]);
+        assert.deepEqual(loaded.removedLabels, [
+            { key: 'TS-409', label: 'sm_test_automation_triggered' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Moved to In Review - Passed');
+    });
+
+    test('moves stuck TC to rework when matching PR is conflicting', function() {
+        var loaded = loadRecoverStuckTestCase({
+            scm: {
+                listPrs: function() {
+                    return [{
+                        number: 1433,
+                        title: 'TS-409 test automation',
+                        head: { ref: 'test/TS-409' }
+                    }];
+                },
+                getPr: function() {
+                    return { number: 1433, mergeable: false, mergeable_state: 'dirty' };
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-409' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_rework');
+        assert.deepEqual(loaded.statusMoves, [
+            { key: 'TS-409', statusName: 'In Rework' }
+        ]);
+        assert.deepEqual(loaded.removedLabels, [
+            { key: 'TS-409', label: 'sm_test_rework_triggered' },
+            { key: 'TS-409', label: 'sm_test_automation_triggered' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Moved to In Rework');
+    });
+
+});


### PR DESCRIPTION
## Summary
- Use loadProjectConfig and createScm in recoverStuckTestCase local action
- Use jira_post_comment for recovery comments
- Add unit tests for no-PR, clean-PR, and conflicting-PR recovery paths

## Verification
- dmtools run js/unit-tests/run_all.json (309 passed, 0 failed)