### PR TITLE
fix: push interrupted bug work to ticket branch

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -23,6 +23,16 @@ var configLoader = require('./configLoader.js');
 const { STATUSES, LABELS, resolveStatuses } = require('./config.js');
 const developTicket = require('./developTicketAndCreatePR.js');
 
+function cleanCliOutput(output) {
+    return (output || '').split('\n').filter(function(l) {
+        return l.trim() &&
+               l.indexOf('Script started') === -1 &&
+               l.indexOf('Script done') === -1 &&
+               l.indexOf('COMMAND=') === -1 &&
+               l.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('').trim();
+}
+
 function readJson(path) {
     try {
         const raw = file_read({ path: path });
@@ -195,16 +205,28 @@ function action(params) {
                 console.log('Partial git changes found — pushing to preserve analysis work...');
                 try {
                     const rawBranch = cli_execute_command({ command: 'git branch --show-current' }) || '';
-                    const partialBranch = rawBranch.split('\n').filter(function(l) {
-                        return l.trim() &&
-                               l.indexOf('Script started') === -1 &&
-                               l.indexOf('Script done') === -1;
-                    }).join('').trim();
+                    const currentBranch = cleanCliOutput(rawBranch);
+                    const expectedBranch = configLoader.resolveBranchName(
+                        config,
+                        actualParamsForCheck.ticket,
+                        'development'
+                    );
+                    const baseBranch = (config.git && config.git.baseBranch) || 'main';
+                    const partialBranch = expectedBranch || currentBranch;
                     if (partialBranch) {
+                        if (currentBranch !== partialBranch) {
+                            console.log('Switching partial work from ' + (currentBranch || '(unknown)') +
+                                ' to development branch: ' + partialBranch);
+                            cli_execute_command({ command: 'git checkout -B ' + partialBranch });
+                        }
                         cli_execute_command({ command: 'git config user.name "' + config.git.authorName + '"' });
                         cli_execute_command({ command: 'git config user.email "' + config.git.authorEmail + '"' });
                         cli_execute_command({ command: 'git commit -m "' + configLoader.formatTemplate(config.formats.commitMessage.wip, {ticketKey: ticketKeyForCheck}) + '"' });
-                        cli_execute_command({ command: 'git push -u origin ' + partialBranch });
+                        var pushCommand = 'git push -u origin ' + partialBranch;
+                        if (currentBranch === baseBranch || currentBranch === 'main' || currentBranch === 'master') {
+                            pushCommand += ' --force-with-lease';
+                        }
+                        cli_execute_command({ command: pushCommand });
                         console.log('✅ Pushed partial analysis to branch:', partialBranch);
                     }
                 } catch (pushErr) {

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -14,6 +14,7 @@
         "js/unit-tests/test_submodules.js",
         "js/unit-tests/test_pullRequestHelper.js",
         "js/unit-tests/test_developTicketAndCreatePR.js",
+        "js/unit-tests/test_developBugAndCreatePR.js",
         "js/unit-tests/test_autoStart.js",
         "js/unit-tests/test_dfManager.js",
         "js/unit-tests/test_retryMergePR.js",

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for js/developBugAndCreatePR.js.
+ */
+
+function loadDevelopBugAndCreatePR(mocks) {
+    mocks = mocks || {};
+    var comments = [];
+    var moves = [];
+    var removed = [];
+    var commands = [];
+
+    var mod = loadModule(
+        'js/developBugAndCreatePR.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': configLoaderModule,
+            './developTicketAndCreatePR.js': { action: function() { return { success: true, path: 'delegated' }; } }
+        }),
+        Object.assign({
+            file_read: function(args) {
+                if (args.path === 'outputs/response.md') throw new Error('missing response');
+                throw new Error('missing ' + args.path);
+            },
+            cli_execute_command: function(args) {
+                commands.push(args.command);
+                if (args.command.indexOf('gh pr list --head ') === 0) return '';
+                if (args.command === 'git status --porcelain') return 'A  outputs/rca.md\n';
+                if (args.command === 'git branch --show-current') return 'main\n';
+                return '';
+            },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_move_to_status: function(args) { moves.push(args); },
+            jira_remove_label: function(args) { removed.push(args); }
+        }, mocks)
+    );
+
+    return {
+        mod: mod,
+        commands: commands,
+        comments: comments,
+        moves: moves,
+        removed: removed
+    };
+}
+
+suite('developBugAndCreatePR', function() {
+
+    test('pushes interrupted partial work to development branch instead of main', function() {
+        var loaded = loadDevelopBugAndCreatePR();
+
+        var result = loaded.mod.action({
+            ticket: {
+                key: 'TS-1296',
+                fields: { summary: 'Bug loop', description: '', labels: [] }
+            },
+            metadata: { contextId: 'bug_development' },
+            jobParams: {
+                customParams: { removeLabel: 'sm_bug_development_triggered' }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'interrupted');
+        assert.ok(
+            loaded.commands.indexOf('git checkout -B ai/TS-1296') !== -1,
+            'expected partial work to switch away from main'
+        );
+        assert.ok(
+            loaded.commands.indexOf('git push -u origin ai/TS-1296 --force-with-lease') !== -1,
+            'expected partial work push to target ai branch'
+        );
+        assert.notOk(
+            loaded.commands.indexOf('git push -u origin main') !== -1,
+            'must never push partial work to main'
+        );
+        assert.deepEqual(loaded.moves, [
+            { key: 'TS-1296', statusName: 'Ready For Development' }
+        ]);
+        assert.deepEqual(loaded.removed, [
+            { key: 'TS-1296', label: 'bug_development_wip' },
+            { key: 'TS-1296', label: 'sm_bug_development_triggered' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Development Interrupted');
+    });
+
+});


### PR DESCRIPTION
## Summary
- Preserve interrupted bug-development partial work on the expected ai/<ticket> branch instead of current main
- Use --force-with-lease when moving partial work off a base branch
- Add regression test that forbids pushing interrupted partial work to main

## Verification
- dmtools run js/unit-tests/run_all.json (310 passed, 0 failed)