### PR TITLE
fix: make dev branch checkout idempotent

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -103,9 +103,9 @@ function checkoutBranch(ticketKey, config, ticket) {
                 runCmd({ command: prHelper.buildOriginFetchCommand(branchName + ':' + branchName) });
                 runCmd({ command: 'git checkout ' + branchName });
             } catch (fetchCheckoutErr) {
-                console.warn('fetch+checkout failed, falling back to -b from origin:', fetchCheckoutErr);
+                console.warn('fetch+checkout failed, resetting local branch from origin:', fetchCheckoutErr);
                 runCmd({ command: prHelper.buildOriginFetchCommand(branchName) });
-                runCmd({ command: 'git checkout -b ' + branchName + ' origin/' + branchName });
+                runCmd({ command: 'git checkout -B ' + branchName + ' origin/' + branchName });
             }
             try {
                 var rebaseOutput2 = cleanCommandOutput(
@@ -227,4 +227,8 @@ function action(params) {
         console.error('Error in preCliDevelopmentSetup:', error);
         throw error;
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
 }

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -115,6 +115,84 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         assert.ok(true, 'workingDirectory propagated correctly');
     });
 
+    test('remote branch fallback is idempotent when local branch already exists', function() {
+        var loaded = loadPreCli(null);
+        var commands = loaded.calls.map(function(c) { return c.command; });
+        var fetchCheckoutFailed = false;
+
+        loaded.calls.length = 0;
+        var originalAction = loaded.mod.action;
+        var mod = loaded.mod;
+
+        // Reload with a CLI mock that exercises the remote-branch fallback:
+        // local branch check is empty, remote branch exists, explicit fetch+checkout
+        // fails, then checkout -B must be used instead of checkout -b.
+        var calls = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "ai/TS-1302"') return '';
+            if (args.command === 'git ls-remote --heads origin ai/TS-1302') return 'abc\trefs/heads/ai/TS-1302\n';
+            if (args.command === 'git -c fetch.recurseSubmodules=no fetch origin ai/TS-1302:ai/TS-1302') {
+                fetchCheckoutFailed = true;
+                throw new Error('fatal: refusing to fetch into checked out branch');
+            }
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                var p = opts && (opts.path || opts);
+                if (p && p.indexOf('.dmtools/config') !== -1) return null;
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        mod = loadModule(
+            'js/preCliDevelopmentSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchParentContextToInput.js': { action: function() {} },
+                './fetchQuestionsToInput.js': { action: function() {} },
+                './fetchLinkedTestsToInput.js': { action: function() {} },
+                './restoreFromReleases.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function() {},
+                jira_move_to_status: function() {},
+                jira_search_by_jql: function() { return []; }
+            }
+        );
+
+        mod.action({
+            ticket: { key: 'TS-1302', fields: { summary: 'Remote branch recovery', labels: [] } },
+            inputFolderPath: 'input/TS-1302',
+            jobParams: {}
+        });
+
+        assert.ok(fetchCheckoutFailed, 'test should exercise fallback path');
+        assert.ok(
+            calls.indexOf('git checkout -B ai/TS-1302 origin/ai/TS-1302') !== -1,
+            'fallback must reset/create local branch idempotently'
+        );
+        assert.equal(
+            calls.indexOf('git checkout -b ai/TS-1302 origin/ai/TS-1302'),
+            -1,
+            'fallback must not fail when local branch already exists'
+        );
+    });
+
 });
 
 // ── preCliTestAutomationSetup: workingDir support ─────────────────────────────


### PR DESCRIPTION
## Summary
- make remote branch fallback use `git checkout -B` so retrying an existing local ai/<ticket> branch is idempotent
- add regression coverage for the TS-1302-style fallback path

## Verification
- `dmtools run js/unit-tests/run_all.json` (311 passed, 0 failed)