### PR TITLE
fix: prioritize failed tc bug creation

### DIFF
--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -170,6 +170,28 @@ var MINIMAL_AGENT_CONFIG = JSON.stringify({
     }
 });
 
+suite('sm.json rule ordering', function() {
+    test('failed test case bug creation runs before bug development consumes workflow cap', function() {
+        var config = JSON.parse(file_read({ path: 'sm.json' }));
+        var rules = config.params.jobParams.rules;
+        var indexByDescription = {};
+
+        rules.forEach(function(rule, index) {
+            indexByDescription[rule.description] = index;
+        });
+
+        var failedTcBulk = indexByDescription['Failed Test Cases → create or link bugs in batch'];
+        var bugDevelopment = indexByDescription['Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development'];
+
+        assert.ok(failedTcBulk >= 0, 'failed TC bulk creation rule exists');
+        assert.ok(bugDevelopment >= 0, 'bug development rule exists');
+        assert.ok(
+            failedTcBulk < bugDevelopment,
+            'failed TC bug creation must be prioritized before bug development uses maxTriggeredWorkflows'
+        );
+    });
+});
+
 // ── JQL interpolation ─────────────────────────────────────────────────────────
 
 suite('smAgent: JQL interpolation', function() {

--- a/sm.json
+++ b/sm.json
@@ -62,6 +62,23 @@
           "addLabel": "sm_story_development_triggered"
         },
         {
+          "description": "Failed Test Cases with linked Bugs → recover Bug To Fix",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') ORDER BY updated ASC",
+          "configFile": "agents/recover_failed_tc_bug_status.json",
+          "localExecution": true
+        },
+        {
+          "description": "Failed Test Cases → create or link bugs in batch",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') AND (labels is EMPTY OR labels NOT IN ('sm_bug_creation_triggered')) ORDER BY created ASC",
+          "configFile": "agents/bulk_bugs_creation.json",
+          "concurrencyKey": "bulk_bugs_creation",
+          "skipIfLabel": "sm_bulk_bugs_creation_triggered",
+          "addLabel": "sm_bulk_bugs_creation_triggered",
+          "recoverStaleTriggerLabel": true,
+          "limit": 1,
+          "enabled": true
+        },
+        {
           "description": "Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development",
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development', 'In Development', 'In Progress')",
           "configFile": "agents/bug_development.json",
@@ -170,12 +187,6 @@
           "addLabel": "sm_test_review_triggered"
         },
         {
-          "description": "Failed Test Cases with linked Bugs → recover Bug To Fix",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') ORDER BY updated ASC",
-          "configFile": "agents/recover_failed_tc_bug_status.json",
-          "localExecution": true
-        },
-        {
           "description": "Failed Test Cases → create or link bug (single, disabled by default — use bulk_bugs_creation instead)",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed')",
           "configFile": "agents/bug_creation.json",
@@ -183,17 +194,6 @@
           "addLabel": "sm_bug_creation_triggered",
           "limit": 5,
           "enabled": false
-        },
-        {
-          "description": "Failed Test Cases → create or link bugs in batch",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') AND (labels is EMPTY OR labels NOT IN ('sm_bug_creation_triggered')) ORDER BY created ASC",
-          "configFile": "agents/bulk_bugs_creation.json",
-          "concurrencyKey": "bulk_bugs_creation",
-          "skipIfLabel": "sm_bulk_bugs_creation_triggered",
-          "addLabel": "sm_bulk_bugs_creation_triggered",
-          "recoverStaleTriggerLabel": true,
-          "limit": 1,
-          "enabled": true
         },
         {
           "description": "Backlog / To Do / Ready For Development Test Cases → In Development + automate",


### PR DESCRIPTION
## Summary
- move failed Test Case recovery and bulk bug creation before bug development in sm.json
- prevents Ready For Development bugs from consuming the global workflow cap before Failed TCs can create/link bugs
- add a regression test for sm.json rule ordering

## Verification
- `dmtools run js/unit-tests/run_smAgent.json` (43 passed, 0 failed)