### PR TITLE
fix: require codegraph for already fixed bug claims

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -42,6 +42,15 @@ function readJson(path) {
     }
 }
 
+function hasCodeGraphUsage() {
+    try {
+        const raw = file_read({ path: '.dmtools/codegraph-usage.log' });
+        return !!(raw && raw.trim());
+    } catch (e) {
+        return false;
+    }
+}
+
 function removeLabels(ticketKey, params) {
     const wipLabel = params.metadata && params.metadata.contextId
         ? params.metadata.contextId + '_wip' : null;
@@ -139,6 +148,27 @@ function action(params) {
         const alreadyFixed = readJson('outputs/already_fixed.json');
         if (alreadyFixed) {
             console.log('outputs/already_fixed.json found — bug already resolved in codebase');
+
+            if (!hasCodeGraphUsage()) {
+                console.warn('outputs/already_fixed.json rejected — no CodeGraph usage was recorded');
+                try {
+                    jira_post_comment({
+                        key: ticketKey,
+                        comment: 'h3. ⚠️ Already Fixed Claim Needs CodeGraph Verification\n\n' +
+                            'The agent wrote `outputs/already_fixed.json`, but no CodeGraph usage was recorded. ' +
+                            'Already-fixed conclusions for source-code bugs must use CodeGraph to locate the relevant implementation and impact path.\n\n' +
+                            'Resetting to *Ready For Development* for an automatic retry.'
+                    });
+                } catch (e) {}
+                try {
+                    jira_move_to_status({ key: ticketKey, statusName: statuses.READY_FOR_DEVELOPMENT });
+                    console.log('✅ Moved', ticketKey, 'to Ready For Development for CodeGraph retry');
+                } catch (e) {
+                    console.warn('Failed to move ticket to Ready For Development:', e);
+                }
+                removeLabels(ticketKey, params);
+                return { success: true, path: 'already_fixed_without_codegraph', ticketKey };
+            }
 
             let comment = 'h3. ✅ Bug Already Fixed\n\n';
             if (alreadyFixed.rca) {

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -83,4 +83,81 @@ suite('developBugAndCreatePR', function() {
         assert.contains(loaded.comments[0].comment, 'Development Interrupted');
     });
 
+    test('rejects already_fixed output when CodeGraph was not used', function() {
+        var loaded = loadDevelopBugAndCreatePR({
+            file_read: function(args) {
+                if (args.path === 'outputs/already_fixed.json') {
+                    return JSON.stringify({
+                        rca: 'Current code already covers this behavior',
+                        commit: 'abc123',
+                        description: 'Verified without CodeGraph'
+                    });
+                }
+                if (args.path === '.dmtools/codegraph-usage.log') {
+                    throw new Error('missing codegraph usage log');
+                }
+                throw new Error('missing ' + args.path);
+            }
+        });
+
+        var result = loaded.mod.action({
+            ticket: {
+                key: 'TS-1303',
+                fields: { summary: 'Already fixed claim', description: '', labels: [] }
+            },
+            metadata: { contextId: 'bug_development' },
+            jobParams: {
+                customParams: { removeLabel: 'sm_bug_development_triggered' }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'already_fixed_without_codegraph');
+        assert.deepEqual(loaded.moves, [
+            { key: 'TS-1303', statusName: 'Ready For Development' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Needs CodeGraph Verification');
+        assert.deepEqual(loaded.removed, [
+            { key: 'TS-1303', label: 'bug_development_wip' },
+            { key: 'TS-1303', label: 'sm_bug_development_triggered' }
+        ]);
+    });
+
+    test('accepts already_fixed output when CodeGraph usage was recorded', function() {
+        var loaded = loadDevelopBugAndCreatePR({
+            file_read: function(args) {
+                if (args.path === 'outputs/already_fixed.json') {
+                    return JSON.stringify({
+                        rca: 'Current code already covers this behavior',
+                        commit: 'abc123',
+                        description: 'Verified with CodeGraph'
+                    });
+                }
+                if (args.path === '.dmtools/codegraph-usage.log') {
+                    return '2026-05-31T00:00:00Z\tcodegraph search symbol\n';
+                }
+                throw new Error('missing ' + args.path);
+            },
+            jira_add_label: function() {}
+        });
+
+        var result = loaded.mod.action({
+            ticket: {
+                key: 'TS-1303',
+                fields: { summary: 'Already fixed claim', description: '', labels: [] }
+            },
+            metadata: { contextId: 'bug_development' },
+            jobParams: {
+                customParams: { removeLabel: 'sm_bug_development_triggered' }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'already_fixed');
+        assert.deepEqual(loaded.moves, [
+            { key: 'TS-1303', statusName: 'Merged' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Bug Already Fixed');
+    });
+
 });


### PR DESCRIPTION
## Summary
- reject bug_development `outputs/already_fixed.json` when no CodeGraph usage was recorded
- reset the bug to Ready For Development for retry instead of moving it to Merged
- add regression coverage for rejecting and accepting already-fixed paths based on CodeGraph usage

## Verification
- `dmtools run js/unit-tests/run_all.json` (314 passed, 0 failed)