### PR TITLE
fix: require codegraph for blocked bug claims

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -120,6 +120,27 @@ function action(params) {
         if (blocked) {
             console.log('outputs/blocked.json found — bug cannot be fixed automatically');
 
+            if (!hasCodeGraphUsage()) {
+                console.warn('outputs/blocked.json rejected — no CodeGraph usage was recorded');
+                try {
+                    jira_post_comment({
+                        key: ticketKey,
+                        comment: 'h3. ⚠️ Blocked Claim Needs CodeGraph Verification\n\n' +
+                            'The agent wrote `outputs/blocked.json`, but no CodeGraph usage was recorded. ' +
+                            'Source-code bugs must use CodeGraph before declaring the work blocked.\n\n' +
+                            'Resetting to *Ready For Development* for an automatic retry.'
+                    });
+                } catch (e) {}
+                try {
+                    jira_move_to_status({ key: ticketKey, statusName: statuses.READY_FOR_DEVELOPMENT });
+                    console.log('✅ Moved', ticketKey, 'to Ready For Development for CodeGraph retry');
+                } catch (e) {
+                    console.warn('Failed to move ticket to Ready For Development:', e);
+                }
+                removeLabels(ticketKey, params);
+                return { success: true, path: 'blocked_without_codegraph', ticketKey };
+            }
+
             let comment = 'h3. 🚫 Bug Cannot Be Fixed Automatically\n\n';
             comment += '*Reason*: ' + (blocked.reason || '(see details below)') + '\n\n';
             if (blocked.tried && blocked.tried.length > 0) {

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -123,6 +123,42 @@ suite('developBugAndCreatePR', function() {
         ]);
     });
 
+    test('rejects blocked output when CodeGraph was not used', function() {
+        var loaded = loadDevelopBugAndCreatePR({
+            file_read: function(args) {
+                if (args.path === 'outputs/blocked.json') {
+                    return JSON.stringify({
+                        reason: 'Session tooling did not return repository file contents',
+                        tried: ['Read input files'],
+                        needs: 'A working session'
+                    });
+                }
+                if (args.path === '.dmtools/codegraph-usage.log') {
+                    throw new Error('missing codegraph usage log');
+                }
+                throw new Error('missing ' + args.path);
+            }
+        });
+
+        var result = loaded.mod.action({
+            ticket: {
+                key: 'TS-1304',
+                fields: { summary: 'Blocked claim', description: '', labels: [] }
+            },
+            metadata: { contextId: 'bug_development' },
+            jobParams: {
+                customParams: { removeLabel: 'sm_bug_development_triggered' }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'blocked_without_codegraph');
+        assert.deepEqual(loaded.moves, [
+            { key: 'TS-1304', statusName: 'Ready For Development' }
+        ]);
+        assert.contains(loaded.comments[0].comment, 'Blocked Claim Needs CodeGraph Verification');
+    });
+
     test('accepts already_fixed output when CodeGraph usage was recorded', function() {
         var loaded = loadDevelopBugAndCreatePR({
             file_read: function(args) {


### PR DESCRIPTION
## Summary
- reject bug_development `outputs/blocked.json` when no CodeGraph usage was recorded
- reset the bug to Ready For Development for retry instead of moving it to Blocked
- add regression coverage for blocked-without-codegraph retry path

## Verification
- `dmtools run js/unit-tests/run_all.json` (315 passed, 0 failed)