### PR TITLE
Ignore generated CodeGraph artifacts in bug post-actions

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -51,6 +51,33 @@ function hasCodeGraphUsage() {
     }
 }
 
+function isGeneratedToolingStatusLine(line) {
+    var trimmed = (line || '').trim();
+    return trimmed === 'A  .agent-bin/codegraph' ||
+        trimmed === '?? .agent-bin/codegraph' ||
+        trimmed === 'D  .codegraph/.gitignore' ||
+        trimmed.indexOf(' .agent-bin/codegraph') !== -1 ||
+        trimmed.indexOf(' .codegraph/.gitignore') !== -1;
+}
+
+function cleanupGeneratedToolingArtifacts() {
+    try {
+        cli_execute_command({
+            command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
+        });
+    } catch (e) {}
+    try {
+        cli_execute_command({
+            command: 'git checkout -- .codegraph/.gitignore 2>/dev/null || true'
+        });
+    } catch (e) {}
+    try {
+        cli_execute_command({
+            command: 'rm -f .agent-bin/codegraph'
+        });
+    } catch (e) {}
+}
+
 function removeLabels(ticketKey, params) {
     const wipLabel = params.metadata && params.metadata.contextId
         ? params.metadata.contextId + '_wip' : null;
@@ -230,11 +257,13 @@ function action(params) {
         let hasGitChanges = false;
         try {
             cli_execute_command({ command: 'git add .' });
+            cleanupGeneratedToolingArtifacts();
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {
                 return l.trim() &&
                        l.indexOf('Script started') === -1 &&
-                       l.indexOf('Script done') === -1;
+                       l.indexOf('Script done') === -1 &&
+                       !isGeneratedToolingStatusLine(l);
             });
             hasGitChanges = statusLines.length > 0;
         } catch (e) {

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -51,6 +51,24 @@ function runCmd(args) {
     return cli_execute_command(args);
 }
 
+function cleanupGeneratedToolingArtifacts() {
+    try {
+        runCmd({
+            command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
+        });
+    } catch (e) {}
+    try {
+        runCmd({
+            command: 'git checkout -- .codegraph/.gitignore 2>/dev/null || true'
+        });
+    } catch (e) {}
+    try {
+        runCmd({
+            command: 'rm -f .agent-bin/codegraph'
+        });
+    } catch (e) {}
+}
+
 /**
  * Clean command output from script wrapper artifacts
  * Removes "Script started/done" lines that DMTools CLI adds
@@ -230,6 +248,7 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
         runCmd({
             command: 'git add .'
         });
+        cleanupGeneratedToolingArtifacts();
 
         // Check if there are changes to commit
         const statusOutput = prHelper.readStagedDiffStat(function(command) {

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -83,6 +83,47 @@ suite('developBugAndCreatePR', function() {
         assert.contains(loaded.comments[0].comment, 'Development Interrupted');
     });
 
+    test('does not push CodeGraph setup artifacts as interrupted partial work', function() {
+        var loaded = loadDevelopBugAndCreatePR({
+            cli_execute_command: function(args) {
+                loaded.commands.push(args.command);
+                if (args.command.indexOf('gh pr list --head ') === 0) return '';
+                if (args.command === 'git status --porcelain') {
+                    return 'A  .agent-bin/codegraph\nD  .codegraph/.gitignore\n';
+                }
+                if (args.command === 'git branch --show-current') return 'main\n';
+                return '';
+            }
+        });
+
+        var result = loaded.mod.action({
+            ticket: {
+                key: 'TS-1298',
+                fields: { summary: 'Interrupted by rate limit', description: '', labels: [] }
+            },
+            metadata: { contextId: 'bug_development' },
+            jobParams: {
+                customParams: { removeLabel: 'sm_bug_development_triggered' }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'interrupted');
+        assert.notOk(
+            loaded.commands.indexOf('git checkout -B ai/TS-1298') !== -1,
+            'generated CodeGraph setup artifacts must not trigger a WIP branch push'
+        );
+        assert.notOk(
+            loaded.commands.some(function(c) { return c.indexOf('git commit -m "TS-1298 WIP') === 0; }),
+            'generated CodeGraph setup artifacts must not be committed'
+        );
+        assert.notOk(
+            loaded.commands.some(function(c) { return c.indexOf('git push -u origin ai/TS-1298') === 0; }),
+            'generated CodeGraph setup artifacts must not be pushed'
+        );
+        assert.contains(loaded.comments[0].comment, 'No partial work was produced');
+    });
+
     test('rejects already_fixed output when CodeGraph was not used', function() {
         var loaded = loadDevelopBugAndCreatePR({
             file_read: function(args) {


### PR DESCRIPTION
## Summary
- ignore CodeGraph setup-only status lines when deciding whether interrupted bug development produced partial work
- clean generated CodeGraph setup artifacts before bug/development post-actions stage commits
- add regression coverage for interrupted bug development with only CodeGraph setup artifacts

## Test
- dmtools run js/unit-tests/run_all.json --mini