### PR TITLE
Restore CodeGraph gitignore from base branch

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -60,7 +60,8 @@ function isGeneratedToolingStatusLine(line) {
         trimmed.indexOf(' .codegraph/.gitignore') !== -1;
 }
 
-function cleanupGeneratedToolingArtifacts() {
+function cleanupGeneratedToolingArtifacts(baseBranch) {
+    var originRef = 'origin/' + (baseBranch || 'main');
     try {
         cli_execute_command({
             command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
@@ -68,7 +69,7 @@ function cleanupGeneratedToolingArtifacts() {
     } catch (e) {}
     try {
         cli_execute_command({
-            command: 'git checkout -- .codegraph/.gitignore 2>/dev/null || true'
+            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore 2>/dev/null || git checkout -- .codegraph/.gitignore 2>/dev/null || true'
         });
     } catch (e) {}
     try {
@@ -257,7 +258,7 @@ function action(params) {
         let hasGitChanges = false;
         try {
             cli_execute_command({ command: 'git add .' });
-            cleanupGeneratedToolingArtifacts();
+            cleanupGeneratedToolingArtifacts((config.git && config.git.baseBranch) || 'main');
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {
                 return l.trim() &&

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -51,7 +51,8 @@ function runCmd(args) {
     return cli_execute_command(args);
 }
 
-function cleanupGeneratedToolingArtifacts() {
+function cleanupGeneratedToolingArtifacts(baseBranch) {
+    var originRef = 'origin/' + (baseBranch || 'main');
     try {
         runCmd({
             command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
@@ -59,7 +60,7 @@ function cleanupGeneratedToolingArtifacts() {
     } catch (e) {}
     try {
         runCmd({
-            command: 'git checkout -- .codegraph/.gitignore 2>/dev/null || true'
+            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore 2>/dev/null || git checkout -- .codegraph/.gitignore 2>/dev/null || true'
         });
     } catch (e) {}
     try {
@@ -248,7 +249,7 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
         runCmd({
             command: 'git add .'
         });
-        cleanupGeneratedToolingArtifacts();
+        cleanupGeneratedToolingArtifacts(baseBranch || 'main');
 
         // Check if there are changes to commit
         const statusOutput = prHelper.readStagedDiffStat(function(command) {


### PR DESCRIPTION
## Summary
- restore .codegraph/.gitignore from origin/<baseBranch> when cleaning generated CodeGraph artifacts
- lets older polluted ai branches clean themselves on the next normal post-action

## Test
- dmtools run js/unit-tests/run_all.json --mini