### PR TITLE
Tell bug agents to discover input files first

### DIFF
--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -1,4 +1,7 @@
-User request is in 'input' folder, read all files there and do what is requested.
+User request is in the `input` folder. First list `input/`, then read every file
+that actually exists there. Do not repeatedly retry hard-coded paths that are
+missing; after one "file not found", use the directory listing as the source of
+truth and continue with the available files.
 
 **IMPORTANT** Before anything else, read inputs in this order:
 1. `instruction.md` (repo root) — **read this first**: project stack, deployment constraints, approved frameworks, and infrastructure access. All implementation decisions must respect the constraints defined here.


### PR DESCRIPTION
## Summary
- bug development prompt now tells the CLI agent to list input/ first
- avoids repeated reads of hard-coded missing paths when the generated input folder uses a different filename

## Test
- prompt-only change; not run