### PR TITLE
Require exact discovered bug input paths

### DIFF
--- a/prompts/bug_development_prompt.md
+++ b/prompts/bug_development_prompt.md
@@ -1,7 +1,14 @@
-User request is in the `input` folder. First list `input/`, then read every file
-that actually exists there. Do not repeatedly retry hard-coded paths that are
-missing; after one "file not found", use the directory listing as the source of
-truth and continue with the available files.
+User request is in the `input` folder. Before reading any named input file, run:
+
+```bash
+find input -maxdepth 2 -type f -print
+```
+
+Read the exact paths returned by that command. Do not read `input/request.md`,
+`input/comments.md`, `input/linked_tests.md`, or `input/existing_questions.json`
+unless that exact path appears in the `find` output. If a listed file has a
+ticket-key subfolder path such as `input/TS-123/request.md`, read that exact
+path instead. If `instruction.md` is missing at the repo root, do not retry it.
 
 **IMPORTANT** Before anything else, read inputs in this order:
 1. `instruction.md` (repo root) — **read this first**: project stack, deployment constraints, approved frameworks, and infrastructure access. All implementation decisions must respect the constraints defined here.


### PR DESCRIPTION
## Summary
- bug development prompt now requires 
- tells agents to read only exact discovered input paths, including ticket-key subfolders
- prevents repeated  reads when generated input lives under 

## Test
- prompt-only change; not run