### PR TITLE
Include Done bug history in bug creation context

### DIFF
--- a/js/prepareBugCreationContext.js
+++ b/js/prepareBugCreationContext.js
@@ -12,6 +12,52 @@ function sanitizeFilename(str) {
     return str.replace(/[\/\\:*?"<>|]/g, '-').replace(/\s+/g, ' ').substring(0, 100).trim();
 }
 
+function fetchHistoricalDoneBugs(ticketKey) {
+    try {
+        return jira_search_by_jql({
+            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status in (Done) ORDER BY updated DESC',
+            fields: ['key', 'summary', 'description', 'status', 'updated'],
+            maxResults: 10
+        }) || [];
+    } catch (e) {
+        console.warn('Could not fetch historical Done bugs:', e);
+        return [];
+    }
+}
+
+function writeHistoricalDoneBugs(inputFolder, ticketKey) {
+    var doneBugs = fetchHistoricalDoneBugs(ticketKey);
+    if (!doneBugs || doneBugs.length === 0) {
+        return 0;
+    }
+
+    var lines = [];
+    lines.push('# Historical Done Bugs');
+    lines.push('');
+    lines.push('These linked Done bugs are recurrence context only. Do not treat them as open duplicate matches.');
+    lines.push('If the Test Case is currently Failed and no non-Done bug matches, create a new bug and mention these prior attempts.');
+    lines.push('');
+
+    doneBugs.forEach(function(bug) {
+        var fields = bug.fields || {};
+        var status = fields.status ? fields.status.name : '';
+        lines.push('---');
+        lines.push('## ' + bug.key + ': ' + (fields.summary || ''));
+        if (status) lines.push('**Status**: ' + status);
+        if (fields.updated) lines.push('**Updated**: ' + fields.updated);
+        if (fields.description) {
+            lines.push('');
+            lines.push('**Description**:');
+            lines.push(String(fields.description).substring(0, 1200));
+        }
+        lines.push('');
+    });
+
+    file_write(inputFolder + '/historical_done_bugs.md', lines.join('\n'));
+    console.log('Wrote historical_done_bugs.md with ' + doneBugs.length + ' Done bug(s)');
+    return doneBugs.length;
+}
+
 function action(params) {
     try {
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
@@ -45,6 +91,8 @@ function action(params) {
             file_write(inputFolder + '/ticket.md', tcContent);
             console.log('Wrote ticket.md for', ticketKey);
         }
+
+        var historicalDoneCount = writeHistoricalDoneBugs(inputFolder, ticketKey);
 
         // Fetch all open bugs
         console.log('Fetching open bugs with JQL:', openBugsJql);
@@ -94,6 +142,9 @@ function action(params) {
                 key: ticketKey,
                 comment: 'h3. 🔍 Bug Detection Started\n\n' +
                     'Checking ' + bugs.length + ' open bug(s) for duplicates...\n\n' +
+                    (historicalDoneCount > 0
+                        ? 'Also loaded ' + historicalDoneCount + ' linked Done bug(s) as recurrence history only.\n\n'
+                        : '') +
                     '_Result will be posted shortly._'
             });
         } catch (e) {
@@ -103,7 +154,8 @@ function action(params) {
         return {
             success: true,
             ticketKey: ticketKey,
-            bugsLoaded: bugs.length
+            bugsLoaded: bugs.length,
+            historicalDoneBugsLoaded: historicalDoneCount
         };
 
     } catch (error) {
@@ -113,5 +165,9 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action };
+    module.exports = {
+        action: action,
+        fetchHistoricalDoneBugs: fetchHistoricalDoneBugs,
+        writeHistoricalDoneBugs: writeHistoricalDoneBugs
+    };
 }

--- a/js/prepareBulkBugsCreationContext.js
+++ b/js/prepareBulkBugsCreationContext.js
@@ -13,6 +13,31 @@
  * fetches ALL eligible failed TCs up to batchSize.
  */
 
+function summarizeDoneBug(bug) {
+    var fields = bug.fields || {};
+    return {
+        key: bug.key,
+        summary: fields.summary || '',
+        status: fields.status ? fields.status.name : '',
+        updated: fields.updated || '',
+        description: (fields.description || '').substring(0, 500)
+    };
+}
+
+function fetchHistoricalDoneBugs(tcKey) {
+    try {
+        var bugs = jira_search_by_jql({
+            jql: 'issue in linkedIssues("' + tcKey + '") AND issuetype = Bug AND status in (Done) ORDER BY updated DESC',
+            fields: ['key', 'summary', 'description', 'status', 'updated'],
+            maxResults: 10
+        }) || [];
+        return bugs.map(summarizeDoneBug);
+    } catch (e) {
+        console.warn('Failed to fetch historical Done bugs for ' + tcKey + ':', e);
+        return [];
+    }
+}
+
 function action(params) {
     try {
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
@@ -57,18 +82,22 @@ function action(params) {
         }
 
         // Build TC list for AI
+        var totalHistoricalDoneBugs = 0;
         var tcList = failedTCs.map(function(tc) {
             var fields = tc.fields || {};
             var comments = fields.comment && fields.comment.comments;
             var lastComment = comments && comments.length > 0
                 ? comments[comments.length - 1].body
                 : '';
+            var historicalDoneBugs = fetchHistoricalDoneBugs(tc.key);
+            totalHistoricalDoneBugs += historicalDoneBugs.length;
             return {
                 key: tc.key,
                 summary: fields.summary || '',
                 description: fields.description || '',
                 lastComment: lastComment,
-                parent: fields.parent ? fields.parent.key + ' — ' + (fields.parent.fields && fields.parent.fields.summary || '') : ''
+                parent: fields.parent ? fields.parent.key + ' — ' + (fields.parent.fields && fields.parent.fields.summary || '') : '',
+                historicalDoneBugs: historicalDoneBugs
             };
         });
 
@@ -115,6 +144,7 @@ function action(params) {
             '- **Project**: ' + projectKey + '\n' +
             '- **Failed TCs to process**: ' + tcList.length + '\n' +
             '- **Non-Done bugs for dedup check**: ' + bugList.length + '\n\n' +
+            '- **Historical Done linked bugs**: ' + totalHistoricalDoneBugs + ' (recurrence context only; not open matches)\n\n' +
             'Read `input/failed_tcs.json` and `input/open_bugs.json`, then follow the prompt instructions.\n';
         file_write(inputFolder + '/context.md', contextMd);
         console.log('=== Context preparation complete ===');
@@ -123,4 +153,11 @@ function action(params) {
         console.error('prepareBulkBugsCreationContext failed:', e);
         throw e;
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        action: action,
+        fetchHistoricalDoneBugs: fetchHistoricalDoneBugs
+    };
 }

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -24,6 +24,7 @@
         "js/unit-tests/test_feedbackLoop.js",
         "js/unit-tests/test_fetchParentContextToInput.js",
         "js/unit-tests/test_testsGeneratedGuard.js",
+        "js/unit-tests/test_prepareBugCreationContext.js",
         "js/unit-tests/test_postBugCreation.js",
         "js/unit-tests/test_postBulkBugsCreation.js",
         "js/unit-tests/test_postTestAutomationResults.js",

--- a/js/unit-tests/test_prepareBugCreationContext.js
+++ b/js/unit-tests/test_prepareBugCreationContext.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for bug creation context preparation scripts.
+ */
+
+function loadPrepareBugCreationContext(mocks) {
+    var calls = {
+        searches: [],
+        writes: [],
+        comments: []
+    };
+
+    var defaults = {
+        jira_get_ticket: function(args) {
+            return {
+                key: args.key,
+                fields: {
+                    summary: 'Test summary',
+                    description: 'Test description'
+                }
+            };
+        },
+        jira_search_by_jql: function(args) {
+            calls.searches.push(args);
+            return [];
+        },
+        jira_post_comment: function(args) { calls.comments.push(args); },
+        file_write: function(path, content) { calls.writes.push({ path: path, content: content }); }
+    };
+
+    var mod = loadModule(
+        'js/prepareBugCreationContext.js',
+        makeRequire({}),
+        Object.assign({}, defaults, mocks || {})
+    );
+
+    return { mod: mod, calls: calls };
+}
+
+function loadPrepareBulkBugsCreationContext(mocks) {
+    var calls = {
+        searches: [],
+        writes: []
+    };
+
+    var defaults = {
+        jira_search_by_jql: function(args) {
+            calls.searches.push(args);
+            return [];
+        },
+        file_write: function(path, content) { calls.writes.push({ path: path, content: content }); }
+    };
+
+    var mod = loadModule(
+        'js/prepareBulkBugsCreationContext.js',
+        makeRequire({}),
+        Object.assign({}, defaults, mocks || {})
+    );
+
+    return { mod: mod, calls: calls };
+}
+
+suite('prepareBugCreationContext', function() {
+
+    test('writes linked Done bugs as recurrence history without adding them to open bug matches', function() {
+        var loaded = loadPrepareBugCreationContext({
+            jira_search_by_jql: function(args) {
+                loaded.calls.searches.push(args);
+                if (args.jql.indexOf('status in (Done)') !== -1) {
+                    return [{
+                        key: 'TS-1196',
+                        fields: {
+                            summary: 'Desktop header controls are mis-sized',
+                            description: 'Prior fix details',
+                            status: { name: 'Done' },
+                            updated: '2026-05-28T11:36:51.621+0300'
+                        }
+                    }];
+                }
+                assert.contains(args.jql, 'status not in (Done)');
+                return [];
+            }
+        });
+
+        var result = loaded.mod.action({
+            inputFolderPath: 'input/TS-614'
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.historicalDoneBugsLoaded, 1);
+        assert.equal(loaded.calls.searches.length, 2);
+        assert.contains(loaded.calls.searches[0].jql, 'status in (Done)');
+        assert.contains(loaded.calls.searches[1].jql, 'status not in (Done)');
+
+        var historyWrite = loaded.calls.writes.filter(function(w) {
+            return w.path === 'input/TS-614/historical_done_bugs.md';
+        })[0];
+        assert.ok(historyWrite, 'historical_done_bugs.md should be written');
+        assert.contains(historyWrite.content, 'TS-1196');
+        assert.contains(historyWrite.content, 'recurrence context only');
+    });
+
+});
+
+suite('prepareBulkBugsCreationContext', function() {
+
+    test('includes linked Done bug history inside failed_tcs.json', function() {
+        var loaded = loadPrepareBulkBugsCreationContext({
+            jira_search_by_jql: function(args) {
+                loaded.calls.searches.push(args);
+                if (args.jql.indexOf('status = Failed') !== -1) {
+                    return [{
+                        key: 'TS-614',
+                        fields: {
+                            summary: 'Desktop header alignment',
+                            description: 'Expected 32px controls',
+                            comment: { comments: [{ body: 'Still failing at 32px alignment' }] }
+                        }
+                    }];
+                }
+                if (args.jql.indexOf('linkedIssues("TS-614")') !== -1 && args.jql.indexOf('status in (Done)') !== -1) {
+                    return [{
+                        key: 'TS-1196',
+                        fields: {
+                            summary: 'Desktop header controls are mis-sized',
+                            description: 'Prior fix details',
+                            status: { name: 'Done' },
+                            updated: '2026-05-28T11:36:51.621+0300'
+                        }
+                    }];
+                }
+                assert.contains(args.jql, 'status not in (Done)');
+                return [];
+            }
+        });
+
+        loaded.mod.action({
+            inputFolderPath: 'input/bulk',
+            customParams: {
+                batchSize: 50
+            },
+            jira: { project: 'TS' }
+        });
+
+        var failedWrite = loaded.calls.writes.filter(function(w) {
+            return w.path === 'input/bulk/failed_tcs.json';
+        })[0];
+        assert.ok(failedWrite, 'failed_tcs.json should be written');
+        assert.contains(failedWrite.content, '"historicalDoneBugs"');
+        assert.contains(failedWrite.content, 'TS-1196');
+
+        var contextWrite = loaded.calls.writes.filter(function(w) {
+            return w.path === 'input/bulk/context.md';
+        })[0];
+        assert.ok(contextWrite, 'context.md should be written');
+        assert.contains(contextWrite.content, 'Historical Done linked bugs**: 1');
+    });
+
+});

--- a/prompts/bug_creation_prompt.md
+++ b/prompts/bug_creation_prompt.md
@@ -5,6 +5,7 @@ You are a QA Engineer analyzing a failed Test Case to determine if a bug already
 Always read these files first if present:
 - `request.md` — full Test Case ticket details
 - `comments.md` — ticket comment history; the most recent comment contains the actual test run result with failure evidence and root cause — **this is the primary source for bug description**
+- `historical_done_bugs.md` — linked Done bugs for this Test Case. Use this as recurrence context only, never as an open duplicate match.
 
 If the most recent comment is a PR/test review, interpret it as follows:
 - "APPROVE", "automation implements the ticket correctly", or "valid product evidence" means the test failure is accepted as a product bug signal.
@@ -44,9 +45,10 @@ If `input/no_open_bugs.md` exists — there are no open bugs, skip to Step 3 dir
 
 Do not decide that the TC is already fixed because an older linked bug is Done.
 Done bugs are history, not open matches. If the TC is currently Failed and no
-open bug matches, create a new bug and mention the older Done bug(s) as prior
-attempts in `outputs/bug_description.md`. This prevents loops where the same TC
-returns to Failed but bug creation keeps suppressing new work.
+open bug matches, create a new bug and mention the older Done bug(s) from
+`historical_done_bugs.md` as prior attempts in `outputs/bug_description.md`.
+This prevents loops where the same TC returns to Failed but bug creation keeps
+suppressing new work or creates a context-free duplicate.
 
 ## Output
 

--- a/prompts/bulk_bugs_creation_prompt.md
+++ b/prompts/bulk_bugs_creation_prompt.md
@@ -9,6 +9,7 @@ Read `input/failed_tcs.json`. It contains an array of failed Test Case objects, 
 - `summary` — what the TC tests
 - `description` — test case details
 - `lastComment` — the most recent comment with the actual failure evidence and root cause
+- `historicalDoneBugs` — linked Done bugs for the same TC, if any. This is recurrence context only.
 
 The `lastComment` is the **primary source** for bug description — it contains the latest run result.
 If the latest comment is a PR/test review instead of the raw test run, interpret it carefully:
@@ -31,9 +32,10 @@ current failed run, create a new bug.
 
 Never decide "already fixed" from Done bugs or historical comments. A current
 `Failed` TC means the prior fix did not prove the scenario anymore. If the TC
-mentions prior Done bugs, include them in the new bug description as history
-under "Prior Attempts / Related Done Bugs", but still create or link only a
-non-Done bug.
+has `historicalDoneBugs`, include them in the new bug description as history
+under "Prior Attempts / Related Done Bugs", explain that the current failure is
+a recurrence after those Done tickets, but still create or link only a non-Done
+bug.
 
 ### Duplicate / match rules (treat as match if ANY of the following):
 - Same component AND same failure symptom


### PR DESCRIPTION
## Summary
- load linked Done bugs as recurrence history for single and bulk bug creation
- keep active duplicate matching limited to non-Done bugs
- add unit coverage for historical Done bug context

## Tests
- dmtools run js/unit-tests/run_all.json --mini