### PR TITLE
Enable df manager safe recovery

### DIFF
--- a/df_manager.json
+++ b/df_manager.json
@@ -4,7 +4,7 @@
     "jsPath": "agents/js/dfManager.js",
     "jobParams": {
       "customParams": {
-        "autoRecover": false,
+        "autoRecover": true,
         "staleMinutes": 45,
         "jiraLimit": 100,
         "workflowRunLimit": 100,


### PR DESCRIPTION
## Summary
- enable df_manager autoRecover so stale SM labels are actually cleaned up
- keeps existing safe recovery behavior: remove stale labels and trigger SM once

## Tests
- dmtools run js/unit-tests/run_dfManager.json --mini