### PR TITLE
Increase bug development retry cooldown

### DIFF
--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -190,6 +190,21 @@ suite('sm.json rule ordering', function() {
             'failed TC bug creation must be prioritized before bug development uses maxTriggeredWorkflows'
         );
     });
+
+    test('bug development has a cooldown to avoid Copilot rate-limit retry storms', function() {
+        var config = JSON.parse(file_read({ path: 'sm.json' }));
+        var rules = config.params.jobParams.rules;
+        var bugDevelopment = null;
+
+        rules.forEach(function(rule) {
+            if (rule.description === 'Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development') {
+                bugDevelopment = rule;
+            }
+        });
+
+        assert.ok(bugDevelopment, 'bug development rule exists');
+        assert.contains(bugDevelopment.jql, 'updated <= -15m');
+    });
 });
 
 // ── JQL interpolation ─────────────────────────────────────────────────────────

--- a/sm.json
+++ b/sm.json
@@ -80,7 +80,7 @@
         },
         {
           "description": "Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development",
-          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development', 'In Development', 'In Progress') AND updated <= -5m ORDER BY updated ASC",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development', 'In Development', 'In Progress') AND updated <= -15m ORDER BY updated ASC",
           "configFile": "agents/bug_development.json",
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",


### PR DESCRIPTION
## Summary
- increase bug_development SM cooldown from 5m to 15m
- add unit coverage so cooldown does not regress

## Why
Repeated Copilot rate limits were causing no-output retries every few minutes with no partial work.

## Tests
- dmtools run js/unit-tests/run_smAgent.json --mini