### PR TITLE
Ignore generated tooling in interrupted bug runs

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -53,28 +53,32 @@ function hasCodeGraphUsage() {
 
 function isGeneratedToolingStatusLine(line) {
     var trimmed = (line || '').trim();
-    return trimmed === 'A  .agent-bin/codegraph' ||
-        trimmed === '?? .agent-bin/codegraph' ||
-        trimmed === 'D  .codegraph/.gitignore' ||
-        trimmed.indexOf(' .agent-bin/codegraph') !== -1 ||
-        trimmed.indexOf(' .codegraph/.gitignore') !== -1;
+    var path = trimmed.length > 3 ? trimmed.substring(3).trim() : '';
+    return path.indexOf('.agent-bin/') === 0 ||
+        path.indexOf('.codegraph/') === 0 ||
+        path === 'agents';
 }
 
 function cleanupGeneratedToolingArtifacts(baseBranch) {
     var originRef = 'origin/' + (baseBranch || 'main');
     try {
         cli_execute_command({
-            command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
+            command: 'git reset -q -- .agent-bin .codegraph agents'
         });
     } catch (e) {}
     try {
         cli_execute_command({
-            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore 2>/dev/null || git checkout -- .codegraph/.gitignore 2>/dev/null || true'
+            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore'
         });
     } catch (e) {}
     try {
         cli_execute_command({
-            command: 'rm -f .agent-bin/codegraph'
+            command: 'git checkout -- .codegraph/.gitignore'
+        });
+    } catch (e) {}
+    try {
+        cli_execute_command({
+            command: 'git clean -fd -- .agent-bin .codegraph'
         });
     } catch (e) {}
 }

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -89,7 +89,11 @@ suite('developBugAndCreatePR', function() {
                 loaded.commands.push(args.command);
                 if (args.command.indexOf('gh pr list --head ') === 0) return '';
                 if (args.command === 'git status --porcelain') {
-                    return 'A  .agent-bin/codegraph\nD  .codegraph/.gitignore\n';
+                    return 'A  .agent-bin/codegraph\n' +
+                        '?? .agent-bin/codegraph-wrapper\n' +
+                        'D  .codegraph/.gitignore\n' +
+                        '?? .codegraph/index.sqlite\n' +
+                        'M  agents\n';
                 }
                 if (args.command === 'git branch --show-current') return 'main\n';
                 return '';
@@ -120,6 +124,22 @@ suite('developBugAndCreatePR', function() {
         assert.notOk(
             loaded.commands.some(function(c) { return c.indexOf('git push -u origin ai/TS-1298') === 0; }),
             'generated CodeGraph setup artifacts must not be pushed'
+        );
+        assert.ok(
+            loaded.commands.indexOf('git reset -q -- .agent-bin .codegraph agents') !== -1,
+            'generated tooling and submodule pointer artifacts must be unstaged before status check'
+        );
+        assert.ok(
+            loaded.commands.indexOf('git clean -fd -- .agent-bin .codegraph') !== -1,
+            'untracked generated tooling artifacts must be cleaned with whitelisted git command'
+        );
+        assert.notOk(
+            loaded.commands.some(function(c) {
+                return c.indexOf('||') !== -1 ||
+                    c.indexOf('2>') !== -1 ||
+                    c.indexOf('rm ') === 0;
+            }),
+            'cleanup commands must be accepted by the restricted CLI executor'
         );
         assert.contains(loaded.comments[0].comment, 'No partial work was produced');
     });


### PR DESCRIPTION
## Summary
- clean generated CodeGraph tooling through restricted git-only commands in bug-development post-action
- ignore .agent-bin, .codegraph, and agents submodule pointer artifacts when deciding whether to save interrupted WIP
- extend unit coverage for the rate-limit/interrupted cleanup path

## Tests
- dmtools run js/unit-tests/run_all.json --mini