### PR TITLE
Dispatch SM recovery without unsupported inputs

### DIFF
--- a/js/dfManager.js
+++ b/js/dfManager.js
@@ -456,7 +456,7 @@ function triggerSmWorkflow(context, reason) {
         context.repoInfo.owner,
         context.repoInfo.repo,
         context.params.smWorkflowFile || 'sm.yml',
-        JSON.stringify({ reason: reason || 'df-manager' }),
+        '{}',
         context.params.workflowRef || 'main'
     );
     context.recoveryState.smTriggered = true;

--- a/js/unit-tests/test_dfManager.js
+++ b/js/unit-tests/test_dfManager.js
@@ -249,6 +249,8 @@ suite('dfManager', function() {
         assert.deepEqual(df.removedLabels[0], { key: 'TS-86', label: 'sm_story_rework_triggered' });
         assert.equal(df.triggered.length, 1);
         assert.equal(df.triggered[0].workflowFile, 'sm.yml');
+        assert.equal(df.triggered[0].payload, '{}');
+        assert.equal(report.actions[1].reason, 'released stale SM label for TS-86');
     });
 
     test('classifies labels from previous statuses as obsolete cleanup', function() {


### PR DESCRIPTION
## Summary
- send  when df_manager dispatches sm.yml so GitHub does not reject unsupported inputs
- keep the recovery reason in df_manager actions/report for diagnostics
- cover the safe-recovery dispatch payload in df_manager unit tests

## Tests
- dmtools run js/unit-tests/run_dfManager.json --mini