### PR TITLE
Limit bug development retries to one per SM cycle

### DIFF
--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -204,6 +204,7 @@ suite('sm.json rule ordering', function() {
 
         assert.ok(bugDevelopment, 'bug development rule exists');
         assert.contains(bugDevelopment.jql, 'updated <= -15m');
+        assert.equal(bugDevelopment.limit, 1, 'bug development should retry one ticket per SM cycle to avoid Copilot rate-limit bursts');
     });
 });
 

--- a/sm.json
+++ b/sm.json
@@ -84,6 +84,7 @@
           "configFile": "agents/bug_development.json",
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",
+          "limit": 1,
           "enabled": true
         },
         {


### PR DESCRIPTION
## Summary
- add a per-rule limit of 1 to bug_development dispatches
- keep the 15m cooldown and assert the retry throttle in SM unit tests

## Rationale
Bug-development runs are currently failing in bursts due Copilot rate limits. More parallel runners would worsen this; single-flight retries reduce rate-limit pressure while keeping the queue moving.

## Tests
- dmtools run js/unit-tests/run_smAgent.json --mini