### PR TITLE
Use shared concurrency for bug development

### DIFF
--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -205,6 +205,7 @@ suite('sm.json rule ordering', function() {
         assert.ok(bugDevelopment, 'bug development rule exists');
         assert.contains(bugDevelopment.jql, 'updated <= -15m');
         assert.equal(bugDevelopment.limit, 1, 'bug development should retry one ticket per SM cycle to avoid Copilot rate-limit bursts');
+        assert.equal(bugDevelopment.concurrencyKey, 'bug_development', 'bug development should use shared active-run detection across SM cycles');
     });
 });
 

--- a/sm.json
+++ b/sm.json
@@ -82,6 +82,7 @@
           "description": "Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development",
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Backlog', 'To Do', 'Ready For Development', 'In Development', 'In Progress') AND updated <= -15m ORDER BY updated ASC",
           "configFile": "agents/bug_development.json",
+          "concurrencyKey": "bug_development",
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",
           "limit": 1,


### PR DESCRIPTION
## Summary
- set bug_development SM rule concurrencyKey to 
- keep ticket-specific input_jql while allowing active-run detection to prevent overlapping bug-development bursts across nearby SM cycles
- extend SM throttle unit assertion

## Tests
- dmtools run js/unit-tests/run_smAgent.json --mini