### PR TITLE
Recover unresolved bulk bug creation locks

### DIFF
--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -152,6 +152,10 @@ function removeProcessingLabels(tcKey, labels) {
     });
 }
 
+function markResolved(resolvedSet, tcKey) {
+    if (tcKey) resolvedSet[tcKey] = true;
+}
+
 function moveFailedTcToRework(tcKey) {
     jira_move_to_status({ key: tcKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
     console.log('  🔧 Moved to ' + (STATUSES.IN_REWORK || 'In Rework') + ':', tcKey);
@@ -222,11 +226,12 @@ function action(params) {
             skipped.length + ' skipped');
         console.log('Processed TCs: ' + processed.join(', '));
 
-        var results = { created: [], linked: [], skipped: [], errors: [] };
+        var results = { created: [], linked: [], skipped: [], released: [], errors: [] };
 
         // Build a set of processed TC keys for safety check
         var processedSet = {};
         processed.forEach(function(k) { processedSet[k] = true; });
+        var resolvedSet = {};
 
         // ── 1. Create new bugs and link their TCs ─────────────────────────────
         newBugs.forEach(function(bugDef, idx) {
@@ -261,13 +266,13 @@ function action(params) {
                     try {
                         linkBugToTC(tcKey, existingBugKey);
                         moveToBugToFix(tcKey);
-                        addTriggerLabel(tcKey, triggerLabel);
-                        removeTriggerLabel(tcKey, smTriggerLabel);
+                        removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                         postComment(tcKey,
                             'h3. 🔗 Existing Bug Linked (Batch Live Re-check)\n\n' +
                             'Linked to existing non-Done bug: *' + existingBugKey + '*'
                         );
                         results.linked.push({ tcKey: tcKey, bugKey: existingBugKey, source: 'live_recheck' });
+                        markResolved(resolvedSet, tcKey);
                     } catch (e) {
                         console.error('  ❌ Failed to link', tcKey, '→', existingBugKey, ':', e);
                         results.errors.push({ tcKey: tcKey, bugKey: existingBugKey, error: e.toString() });
@@ -305,14 +310,14 @@ function action(params) {
                 try {
                     linkBugToTC(tcKey, bugKey);
                     moveToBugToFix(tcKey);
-                    addTriggerLabel(tcKey, triggerLabel);
-                    removeTriggerLabel(tcKey, smTriggerLabel);
+                    removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                     postComment(tcKey,
                         'h3. 🐛 New Bug Created (Batch)\n\n' +
                         'Created: *' + bugKey + '*\n' +
                         '*Summary*: ' + summary
                     );
                     results.created.push({ tcKey: tcKey, bugKey: bugKey });
+                    markResolved(resolvedSet, tcKey);
                 } catch (e) {
                     console.error('  ❌ Failed to process TC', tcKey, ':', e);
                     results.errors.push({ tcKey: tcKey, bugKey: bugKey, error: e.toString() });
@@ -338,13 +343,13 @@ function action(params) {
             try {
                 linkBugToTC(tcKey, bugKey);
                 moveToBugToFix(tcKey);
-                addTriggerLabel(tcKey, triggerLabel);
-                removeTriggerLabel(tcKey, smTriggerLabel);
+                removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 postComment(tcKey,
                     'h3. 🔗 Existing Bug Linked (Batch)\n\n' +
                     'Linked to existing bug: *' + bugKey + '*'
                 );
                 results.linked.push({ tcKey: tcKey, bugKey: bugKey });
+                markResolved(resolvedSet, tcKey);
             } catch (e) {
                 console.error('  ❌ Failed to link', tcKey, '→', bugKey, ':', e);
                 results.errors.push({ tcKey: tcKey, bugKey: bugKey, error: e.toString() });
@@ -371,6 +376,37 @@ function action(params) {
                 '\n\n_TC moved to *In Rework* so the test automation can be fixed instead of staying in *Failed*._'
             );
             results.skipped.push({ tcKey: tcKey, reason: skipDef.reason });
+            markResolved(resolvedSet, tcKey);
+        });
+
+        // ── 4. Recovery guard: processed TCs must never keep a stale bulk lock ──
+        processed.forEach(function(tcKey) {
+            if (!tcKey || resolvedSet[tcKey]) return;
+
+            console.warn('  ⚠️ Processed TC has no successful bulk outcome:', tcKey);
+            var linkedBugKey = findLinkedNonDoneBug(tcKey);
+            if (linkedBugKey) {
+                moveToBugToFix(tcKey);
+                removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
+                postComment(tcKey,
+                    'h3. 🔗 Existing Bug Found After Batch\n\n' +
+                    'Bulk bug creation did not produce a final decision for this TC, ' +
+                    'but a linked non-Done bug already exists: *' + linkedBugKey + '*.\n\n' +
+                    '_TC moved to *Bug To Fix* and stale bug-creation locks were removed._'
+                );
+                results.linked.push({ tcKey: tcKey, bugKey: linkedBugKey, source: 'post_batch_recovery' });
+                markResolved(resolvedSet, tcKey);
+                return;
+            }
+
+            removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
+            postComment(tcKey,
+                'h3. ⚠️ Bulk Bug Creation Released\n\n' +
+                'Bulk bug creation processed this TC but did not create, link, or skip it. ' +
+                'No linked non-Done bug was found during the post-action live check.\n\n' +
+                '_Stale bug-creation locks were removed so the next bulk cycle can retry from Failed._'
+            );
+            results.released.push({ tcKey: tcKey, reason: 'no bulk outcome and no linked non-Done bug' });
         });
 
         // ── Summary ───────────────────────────────────────────────────────────
@@ -378,6 +414,7 @@ function action(params) {
         console.log('  Created:', results.created.length, 'bug links');
         console.log('  Linked:', results.linked.length, 'to existing bugs');
         console.log('  Skipped:', results.skipped.length);
+        console.log('  Released:', results.released.length, 'without outcome');
         console.log('  Errors:', results.errors.length);
 
         return { success: true, results: results };

--- a/js/unit-tests/test_postBulkBugsCreation.js
+++ b/js/unit-tests/test_postBulkBugsCreation.js
@@ -126,6 +126,7 @@ suite('postBulkBugsCreation', function() {
         var created = [];
         var linked = [];
         var statusMoves = [];
+        var removedLabels = [];
 
         var module = loadPostBulkBugsCreation({
             file_read: function(opts) {
@@ -159,7 +160,8 @@ suite('postBulkBugsCreation', function() {
                 return '{"key":"TS-9999"}';
             },
             jira_link_issues: function(args) { linked.push(args); },
-            jira_move_to_status: function(args) { statusMoves.push(args); }
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
         });
 
         var result = module.action({
@@ -180,6 +182,107 @@ suite('postBulkBugsCreation', function() {
         assert.deepEqual(statusMoves, [
             { key: 'TS-657', statusName: 'Bug To Fix' }
         ]);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-657', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-657', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+    });
+
+    test('recovers processed TC without outcome when a linked non-Done bug exists', function() {
+        var statusMoves = [];
+        var removedLabels = [];
+        var comments = [];
+
+        var module = loadPostBulkBugsCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bulk_bug_decisions.json') {
+                    return JSON.stringify({
+                        processed: ['TS-42'],
+                        newBugs: [],
+                        links: [],
+                        skipped: []
+                    });
+                }
+                return null;
+            },
+            jira_search_by_jql: function(args) {
+                assert.contains(args.jql, 'linkedIssues("TS-42")');
+                assert.contains(args.jql, 'status not in (Done)');
+                return [{ key: 'TS-1300' }];
+            },
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        });
+
+        var result = module.action({
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered',
+                    smTriggerLabel: 'sm_bulk_bugs_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.results.linked.length, 1);
+        assert.equal(result.results.linked[0].source, 'post_batch_recovery');
+        assert.deepEqual(statusMoves, [
+            { key: 'TS-42', statusName: 'Bug To Fix' }
+        ]);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-42', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-42', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'linked non-Done bug already exists');
+    });
+
+    test('releases processed TC without outcome when no linked non-Done bug exists', function() {
+        var statusMoves = [];
+        var removedLabels = [];
+        var comments = [];
+
+        var module = loadPostBulkBugsCreation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/bulk_bug_decisions.json') {
+                    return JSON.stringify({
+                        processed: ['TS-208'],
+                        newBugs: [],
+                        links: [],
+                        skipped: []
+                    });
+                }
+                return null;
+            },
+            jira_search_by_jql: function(args) {
+                assert.contains(args.jql, 'linkedIssues("TS-208")');
+                assert.contains(args.jql, 'status not in (Done)');
+                return [];
+            },
+            jira_move_to_status: function(args) { statusMoves.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        });
+
+        var result = module.action({
+            jobParams: {
+                customParams: {
+                    removeLabel: 'sm_bug_creation_triggered',
+                    smTriggerLabel: 'sm_bulk_bugs_creation_triggered'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.deepEqual(statusMoves, []);
+        assert.equal(result.results.released.length, 1);
+        assert.deepEqual(removedLabels, [
+            { key: 'TS-208', label: 'sm_bug_creation_triggered' },
+            { key: 'TS-208', label: 'sm_bulk_bugs_creation_triggered' }
+        ]);
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'No linked non-Done bug was found');
     });
 
 });

--- a/prompts/bulk_bugs_creation_prompt.md
+++ b/prompts/bulk_bugs_creation_prompt.md
@@ -48,7 +48,7 @@ For each failed TC, decide one of:
 
 **A — Link to existing non-Done bug**: A clearly matching **non-Done** bug already exists. The TC will be moved to "Bug To Fix" to wait for the fix.
 
-**B — Create new bug**: No matching bug exists. If multiple TCs share the same root cause, group them under ONE new bug. The TC will be moved to "Bug To Fix".
+**B — Create new bug**: No matching bug exists. If multiple TCs share the same root cause, group them under ONE new bug and include all affected TC keys in that bug's `linkedTCs`. The TCs will be moved to "Bug To Fix".
 
 **D — Skip (test code issue)**: The TC failed due to a test code issue (flaky selector, test environment problem, outdated test assertion), NOT an application bug. **You MUST provide a detailed reason** explaining exactly what test code issue caused the failure and why it is not an application bug. The TC will remain in "Failed" for the next review cycle.
 
@@ -61,6 +61,8 @@ For each failed TC, decide one of:
 ### Grouping rules:
 - TCs that test the same UI component and fail with the same symptom → group under one bug
 - TCs that fail at the same step with the same error → group under one bug
+- If one existing non-Done bug explains multiple failed TCs, add one `links` entry per TC to that same bug.
+- If one new bug explains multiple failed TCs, create one `newBugs` entry and put every affected TC in `linkedTCs`.
 - When in doubt, create separate bugs (better safe than under-reported)
 
 ## Step 4 — Write outputs
@@ -97,6 +99,7 @@ Write a JSON object with this structure:
 **Rules for `bulk_bug_decisions.json`:**
 - `processed` MUST include the key of every TC you made a decision for
 - Every TC from `input/failed_tcs.json` MUST appear in exactly one of: `newBugs[].linkedTCs`, `links`, or `skipped`
+- Never leave a `processed` TC without one of those final outcomes. A missing outcome leaves the TC in Failed and forces cleanup/retry.
 - Do not output `fixedByBug`. Done bugs are excluded from bug matching; a current failed run with no matching non-Done bug requires a new bug unless it is clearly a test-code issue.
 - `skipped[].reason` MUST be a detailed explanation (not just "test issue") — explain the specific test code problem
 - `priority` must be one of: `Highest`, `High`, `Medium`, `Low`, `Lowest`


### PR DESCRIPTION
## Summary
- clear both bug-creation labels when bulk creation moves a TC to Bug To Fix
- recover processed TCs that have no final bulk outcome by live-checking linked non-Done bugs or releasing locks for retry
- tighten bulk bug creation prompt so grouped bugs link every affected TC and no processed TC is left without an outcome

## Tests
- dmtools run js/unit-tests/run_all.json --mini