### PR TITLE
Respect global workflow cap for auto-starts

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -65,6 +65,60 @@ function hasActiveTargetRun(scm, configFile, ticketKey, workflowFile) {
     return false;
 }
 
+function normalizePositiveInt(value) {
+    if (typeof value !== 'number' || !isFinite(value)) return null;
+    var normalized = Math.floor(value);
+    return normalized > 0 ? normalized : null;
+}
+
+function countActiveWorkflowRuns(scm, workflowFile) {
+    var statuses = ['queued', 'in_progress', 'waiting', 'pending'];
+    var seen = {};
+    var count = 0;
+
+    for (var i = 0; i < statuses.length; i++) {
+        var runsRaw = null;
+        try {
+            runsRaw = scm.listWorkflowRuns(statuses[i], workflowFile, 50);
+        } catch (e) {
+            console.warn('autoStart: could not count ' + statuses[i] + ' workflow runs:', e.message || e);
+            continue;
+        }
+
+        var runs = parseWorkflowRuns(runsRaw);
+        for (var j = 0; j < runs.length; j++) {
+            var run = runs[j] || {};
+            var id = run.id || run.databaseId || run.run_number || ((run.display_title || run.displayTitle || run.name || '') + ':' + j + ':' + statuses[i]);
+            if (!seen[id]) {
+                seen[id] = true;
+                count += 1;
+            }
+        }
+    }
+
+    return count;
+}
+
+function resolveActiveWorkflowCap(options) {
+    var explicitCap = normalizePositiveInt(options.maxActiveWorkflows);
+    if (explicitCap) return explicitCap;
+    return normalizePositiveInt(options.config && options.config.smMaxWorkflows);
+}
+
+function isGlobalWorkflowCapReached(scm, workflowFile, options) {
+    var cap = resolveActiveWorkflowCap(options || {});
+    if (!cap) return false;
+
+    var activeCount = countActiveWorkflowRuns(scm, workflowFile);
+    if (activeCount >= cap) {
+        console.log('autoStart: skipped workflow trigger because ' + activeCount +
+            ' active workflow run(s) reached global cap ' + cap);
+        return true;
+    }
+
+    return false;
+}
+
 function triggerConfiguredWorkflowForTicket(options) {
     var ticketKey = options.ticketKey;
     var customParams = options.customParams || {};
@@ -92,6 +146,13 @@ function triggerConfiguredWorkflowForTicket(options) {
     var scm = options.scm || scmModule.createScm(config);
     var projectKey = deriveProjectKey(customParams);
     var encodedCfg = buildAutoStartEncodedConfig(ticketKey, customParams, stripKeys);
+
+    if (isGlobalWorkflowCapReached(scm, workflowFile, {
+            config: config,
+            maxActiveWorkflows: options.maxActiveWorkflows
+        })) {
+        return false;
+    }
 
     if (hasActiveTargetRun(scm, configFile, ticketKey, workflowFile)) {
         return false;
@@ -182,5 +243,7 @@ module.exports = {
     buildAutoStartEncodedConfig: buildAutoStartEncodedConfig,
     triggerConfiguredWorkflowForTicket: triggerConfiguredWorkflowForTicket,
     hasActiveTargetRun: hasActiveTargetRun,
+    countActiveWorkflowRuns: countActiveWorkflowRuns,
+    isGlobalWorkflowCapReached: isGlobalWorkflowCapReached,
     triggerSmIfIdle: triggerSmIfIdle
 };

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -13,30 +13,6 @@ var autoStart = require('./common/autoStart.js');
 const { GIT_CONFIG, STATUSES, LABELS, resolveStatuses } = require('./config.js');
 var cacheToReleases = require('./cacheToReleases.js');
 
-function deriveProjectKey(customParams) {
-    if (!customParams) return '';
-    if (customParams.projectKey) return customParams.projectKey;
-    var cp = customParams.configPath || '';
-    if (!cp) return '';
-    var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
-    return (base && base !== 'config') ? base : '';
-}
-
-function buildAutoStartEncodedConfig(ticketKey, customParams) {
-    var p = { inputJql: 'key = ' + ticketKey };
-    if (customParams) {
-        // Pass the full customParams to the next agent so it has all config
-        // (autoStartReworkConfigFile, customStatuses, targetRepository, etc.)
-        // Strip fields that are only relevant to the current agent's execution.
-        var nextCustomParams = Object.assign({}, customParams);
-        delete nextCustomParams.removeLabel;   // SM idempotency label — per-agent, not inherited
-        delete nextCustomParams.autoStartReview;             // dev → review trigger, not needed downstream
-        delete nextCustomParams.autoStartReviewConfigFile;   // same
-        p.customParams = nextCustomParams;
-    }
-    return encodeURIComponent(JSON.stringify({ params: p }));
-}
-
 function hasPrApprovedLabel(ticket) {
     var labels = (ticket && ticket.fields && ticket.fields.labels) ? ticket.fields.labels : [];
     return labels.indexOf(LABELS.PR_APPROVED) !== -1;
@@ -980,29 +956,18 @@ function action(params) {
                 console.log('ℹ️ autoStartReview: skipped — ticket has pr_approved label');
             } else {
                 try {
-                    // Use customParams.aiRepository if set (avoids targetRepository override in configLoader)
-                    const aiRepoCfg = customParams && customParams.aiRepository;
-                    const aiOwner = (aiRepoCfg && aiRepoCfg.owner) || (config.repository && config.repository.owner);
-                    const aiRepo  = (aiRepoCfg && aiRepoCfg.repo)  || (config.repository && config.repository.repo);
-                    const projectKey = deriveProjectKey(customParams);
-                    const encodedCfg = buildAutoStartEncodedConfig(ticketKey, customParams);
-                    if (aiOwner && aiRepo) {
-                        github_trigger_workflow(
-                            aiOwner, aiRepo, 'ai-teammate.yml',
-                            JSON.stringify({
-                                concurrency_key: ticketKey,
-                                config_file:     reviewConfigFile,
-                                encoded_config:  encodedCfg,
-                                project_key:     projectKey || ''
-                            }),
-                            'main'
-                        );
-                        reviewStarted = true;
-                        console.log('✅ Auto-started pr_review for', ticketKey,
-                            '[config=' + reviewConfigFile + (projectKey ? ', project=' + projectKey : '') + ']');
-                    } else {
-                        console.warn('⚠️ autoStartReview: config.repository.owner/repo not set — skipping');
-                    }
+                    reviewStarted = autoStart.triggerConfiguredWorkflowForTicket({
+                        ticketKey: ticketKey,
+                        customParams: customParams,
+                        config: config,
+                        configFile: reviewConfigFile,
+                        label: 'pr_review',
+                        stripKeys: [
+                            'removeLabel',
+                            'autoStartReview',
+                            'autoStartReviewConfigFile'
+                        ]
+                    });
                 } catch (e) {
                     console.warn('⚠️ autoStartReview trigger failed:', e.message || e);
                 }

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -86,6 +86,37 @@ suite('autoStart helper', function() {
         assert.equal(triggeredPayload.ref, 'main');
     });
 
+    test('skips trigger when global active workflow cap is reached', function() {
+        var triggered = false;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function(workspace, repository, status) {
+                if (status === 'in_progress') {
+                    return JSON.stringify({
+                        workflow_runs: [{
+                            id: 9001,
+                            name: 'agents/pr_rework.json : TS-91',
+                            status: 'in_progress'
+                        }]
+                    });
+                }
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function() {
+                triggered = true;
+            }
+        });
+
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'trackstate' }, smMaxWorkflows: 1 },
+            customParams: {},
+            configFile: 'agents/pr_review.json'
+        });
+
+        assert.equal(result, false);
+        assert.equal(triggered, false, 'global cap should prevent follow-up auto-starts');
+    });
+
 });
 
 suite('triggerSmIfIdle', function() {


### PR DESCRIPTION
## Summary
- make common autoStart count active ai-teammate runs against smMaxWorkflows
- route developTicketAndCreatePR autoStartReview through the shared autoStart helper
- add unit coverage for global cap blocking follow-up auto-starts

## Test
- dmtools run js/unit-tests/run_all.json --mini