### PR TITLE
Ignore stale queued workflows in active caps

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -1,4 +1,5 @@
 var scmModule = require('./scm.js');
+var STALE_NON_RUNNING_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 
 function deriveProjectKey(customParams) {
     if (!customParams) return '';
@@ -53,6 +54,7 @@ function hasActiveTargetRun(scm, configFile, ticketKey, workflowFile) {
         var runs = parseWorkflowRuns(runsRaw);
         for (var j = 0; j < runs.length; j++) {
             var run = runs[j] || {};
+            if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var name = run.display_title || run.displayTitle || run.name || '';
             if (name === expectedName) {
                 console.log('autoStart: skipped duplicate ' + expectedName + ' because run #' +
@@ -63,6 +65,20 @@ function hasActiveTargetRun(scm, configFile, ticketKey, workflowFile) {
     }
 
     return false;
+}
+
+function workflowRunTimestamp(run) {
+    var value = run && (run.updated_at || run.updatedAt || run.created_at || run.createdAt);
+    if (!value) return null;
+    var timestamp = Date.parse(value);
+    return isNaN(timestamp) ? null : timestamp;
+}
+
+function isStaleNonRunningWorkflowRun(run, status) {
+    if (status === 'in_progress') return false;
+    var timestamp = workflowRunTimestamp(run);
+    if (!timestamp) return false;
+    return (Date.now() - timestamp) > STALE_NON_RUNNING_WORKFLOW_MS;
 }
 
 function normalizePositiveInt(value) {
@@ -88,6 +104,7 @@ function countActiveWorkflowRuns(scm, workflowFile) {
         var runs = parseWorkflowRuns(runsRaw);
         for (var j = 0; j < runs.length; j++) {
             var run = runs[j] || {};
+            if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var id = run.id || run.databaseId || run.run_number || ((run.display_title || run.displayTitle || run.name || '') + ':' + j + ':' + statuses[i]);
             if (!seen[id]) {
                 seen[id] = true;
@@ -245,5 +262,6 @@ module.exports = {
     hasActiveTargetRun: hasActiveTargetRun,
     countActiveWorkflowRuns: countActiveWorkflowRuns,
     isGlobalWorkflowCapReached: isGlobalWorkflowCapReached,
+    isStaleNonRunningWorkflowRun: isStaleNonRunningWorkflowRun,
     triggerSmIfIdle: triggerSmIfIdle
 };

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -49,6 +49,7 @@ var scmModule = require('./common/scm.js');
 
 // Project config loaded once in action() — used as global default for rules without configPath
 var projectConfig = null;
+var STALE_NON_RUNNING_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -234,6 +235,7 @@ function hasActiveTargetWorkflowRun(scm, workflowFile, configFile, ticketKey) {
 
         for (var j = 0; j < runs.length; j++) {
             var run = runs[j] || {};
+            if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var runName = run.name || run.display_title || '';
             if (runName === expectedRunName) {
                 console.log('  ⏭️  ' + ticketKey + ' skipped (active workflow already exists: ' + expectedRunName + ')');
@@ -243,6 +245,20 @@ function hasActiveTargetWorkflowRun(scm, workflowFile, configFile, ticketKey) {
     }
 
     return false;
+}
+
+function workflowRunTimestamp(run) {
+    var value = run && (run.updated_at || run.updatedAt || run.created_at || run.createdAt);
+    if (!value) return null;
+    var timestamp = Date.parse(value);
+    return isNaN(timestamp) ? null : timestamp;
+}
+
+function isStaleNonRunningWorkflowRun(run, status) {
+    if (status === 'in_progress') return false;
+    var timestamp = workflowRunTimestamp(run);
+    if (!timestamp) return false;
+    return (Date.now() - timestamp) > STALE_NON_RUNNING_WORKFLOW_MS;
 }
 
 function countActiveWorkflowRuns(scm, workflowFile) {
@@ -263,6 +279,7 @@ function countActiveWorkflowRuns(scm, workflowFile) {
 
         for (var j = 0; j < runs.length; j++) {
             var run = runs[j] || {};
+            if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var id = run.id || run.databaseId || run.run_number || ((run.name || run.display_title || '') + ':' + j + ':' + statuses[i]);
             if (!seen[id]) {
                 seen[id] = true;

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -117,6 +117,39 @@ suite('autoStart helper', function() {
         assert.equal(triggered, false, 'global cap should prevent follow-up auto-starts');
     });
 
+    test('ignores stale queued runs when applying global active workflow cap', function() {
+        var triggered = false;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function(workspace, repository, status) {
+                if (status === 'queued') {
+                    return JSON.stringify({
+                        workflow_runs: [{
+                            id: 9002,
+                            name: 'AI Teammate',
+                            status: 'queued',
+                            created_at: '2020-01-01T00:00:00Z',
+                            updated_at: '2020-01-01T00:00:00Z'
+                        }]
+                    });
+                }
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function() {
+                triggered = true;
+            }
+        });
+
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'trackstate' }, smMaxWorkflows: 1 },
+            customParams: {},
+            configFile: 'agents/pr_review.json'
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggered, true, 'stale queued workflow should not consume the global slot');
+    });
+
 });
 
 suite('triggerSmIfIdle', function() {

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -438,6 +438,35 @@ suite('smAgent: ticket dispatch', function() {
         assert.equal(sm.capturedStatusMoves.length, 0, 'ticket should not move when no workflow slot is available');
     });
 
+    test('global maxTriggeredWorkflows ignores stale queued workflows before dispatch', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [
+                { key: 'P-1', fields: { labels: [] } }
+            ],
+            workflowRuns: {
+                queued: [
+                    {
+                        id: 1002,
+                        name: 'AI Teammate',
+                        status: 'queued',
+                        created_at: '2020-01-01T00:00:00Z',
+                        updated_at: '2020-01-01T00:00:00Z'
+                    }
+                ]
+            }
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject} AND status = 'Ready'")
+        ]);
+        params.jobParams.maxTriggeredWorkflows = 1;
+
+        sm.action(params);
+
+        assert.equal(sm.capturedTriggers.length, 1, 'stale queued workflow should not consume the global slot');
+    });
+
     test('maxWorkflowsPerRun alias also limits dispatches', function() {
         var sm = makeSmAgent({
             fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },


### PR DESCRIPTION
## Summary
- ignore queued/waiting/pending workflow runs older than six hours in active cap and duplicate checks
- keep in-progress runs counted normally
- add unit coverage for stale queued runs in smAgent and autoStart

## Test
- dmtools run js/unit-tests/run_all.json --mini