### PR TITLE
Clean runtime CodeGraph artifacts before checkout

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -43,6 +43,19 @@ function cleanCommandOutput(output) {
     return lines.join('\n').trim();
 }
 
+function cleanupRuntimeGitArtifacts() {
+    try {
+        runCmd({ command: 'git reset -q -- .agent-bin .codegraph' });
+    } catch (e) {
+        console.warn('Runtime artifact reset skipped:', e);
+    }
+    try {
+        runCmd({ command: 'git clean -fd -- .agent-bin .codegraph' });
+    } catch (e) {
+        console.warn('Runtime artifact cleanup skipped:', e);
+    }
+}
+
 function checkoutBranch(ticketKey, config, ticket) {
     ticket = ticket || { key: ticketKey, fields: {} };
     _workingDir = config.workingDir || null;
@@ -62,6 +75,11 @@ function checkoutBranch(ticketKey, config, ticket) {
     } catch (e) {
         console.warn('Could not fetch remote branches:', e);
     }
+
+    // CodeGraph wrappers are installed by the workflow before branch setup.
+    // They are runtime-only files and can block git checkout when target branches
+    // contain or remove the same paths.
+    cleanupRuntimeGitArtifacts();
 
     var localBranches = '';
     try {

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -193,6 +193,75 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         );
     });
 
+    test('cleans runtime CodeGraph artifacts before branch checkout', function() {
+        var calls = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "ai/TS-1298"') return '  ai/TS-1298\n';
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                var p = opts && (opts.path || opts);
+                if (p && p.indexOf('.dmtools/config') !== -1) return null;
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        var mod = loadModule(
+            'js/preCliDevelopmentSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchParentContextToInput.js': { action: function() {} },
+                './fetchQuestionsToInput.js': { action: function() {} },
+                './fetchLinkedTestsToInput.js': { action: function() {} },
+                './restoreFromReleases.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function() {},
+                jira_move_to_status: function() {},
+                jira_search_by_jql: function() { return []; }
+            }
+        );
+
+        mod.action({
+            ticket: { key: 'TS-1298', fields: { summary: 'CodeGraph checkout guard', labels: [] } },
+            inputFolderPath: 'input/TS-1298',
+            jobParams: {}
+        });
+
+        var resetIndex = calls.indexOf('git reset -q -- .agent-bin .codegraph');
+        var cleanIndex = calls.indexOf('git clean -fd -- .agent-bin .codegraph');
+        var checkoutIndex = calls.indexOf('git checkout ai/TS-1298');
+
+        assert.ok(resetIndex !== -1, 'runtime artifacts should be reset before checkout');
+        assert.ok(cleanIndex !== -1, 'runtime artifacts should be cleaned before checkout');
+        assert.ok(checkoutIndex !== -1, 'existing branch should still be checked out');
+        assert.ok(resetIndex < checkoutIndex, 'reset must happen before checkout');
+        assert.ok(cleanIndex < checkoutIndex, 'clean must happen before checkout');
+        assert.notOk(
+            calls.some(function(c) {
+                return c.indexOf('||') !== -1 ||
+                    c.indexOf('2>') !== -1 ||
+                    c.indexOf('rm ') === 0;
+            }),
+            'cleanup commands must be accepted by the restricted CLI executor'
+        );
+    });
+
 });
 
 // ── preCliTestAutomationSetup: workingDir support ─────────────────────────────


### PR DESCRIPTION
## Summary
- clean runtime-only .agent-bin/.codegraph artifacts before development branch checkout
- prevents git checkout failures when .agent-bin/codegraph would be overwritten
- add unit coverage that cleanup runs before git checkout and uses CommandLineUtils-safe git commands

## Test
- dmtools run js/unit-tests/run_all.json --mini