### PR TITLE
Keep CodeGraph cleanup in setup scripts

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -51,38 +51,6 @@ function hasCodeGraphUsage() {
     }
 }
 
-function isGeneratedToolingStatusLine(line) {
-    var trimmed = (line || '').trim();
-    var path = trimmed.length > 3 ? trimmed.substring(3).trim() : '';
-    return path.indexOf('.agent-bin/') === 0 ||
-        path.indexOf('.codegraph/') === 0 ||
-        path === 'agents';
-}
-
-function cleanupGeneratedToolingArtifacts(baseBranch) {
-    var originRef = 'origin/' + (baseBranch || 'main');
-    try {
-        cli_execute_command({
-            command: 'git reset -q -- .agent-bin .codegraph agents'
-        });
-    } catch (e) {}
-    try {
-        cli_execute_command({
-            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore'
-        });
-    } catch (e) {}
-    try {
-        cli_execute_command({
-            command: 'git checkout -- .codegraph/.gitignore'
-        });
-    } catch (e) {}
-    try {
-        cli_execute_command({
-            command: 'git clean -fd -- .agent-bin .codegraph'
-        });
-    } catch (e) {}
-}
-
 function removeLabels(ticketKey, params) {
     const wipLabel = params.metadata && params.metadata.contextId
         ? params.metadata.contextId + '_wip' : null;
@@ -262,13 +230,11 @@ function action(params) {
         let hasGitChanges = false;
         try {
             cli_execute_command({ command: 'git add .' });
-            cleanupGeneratedToolingArtifacts((config.git && config.git.baseBranch) || 'main');
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {
                 return l.trim() &&
                        l.indexOf('Script started') === -1 &&
-                       l.indexOf('Script done') === -1 &&
-                       !isGeneratedToolingStatusLine(l);
+                       l.indexOf('Script done') === -1;
             });
             hasGitChanges = statusLines.length > 0;
         } catch (e) {

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -27,25 +27,6 @@ function runCmd(args) {
     return cli_execute_command(args);
 }
 
-function cleanupGeneratedToolingArtifacts(baseBranch) {
-    var originRef = 'origin/' + (baseBranch || 'main');
-    try {
-        runCmd({
-            command: 'git reset -q -- .agent-bin/codegraph .codegraph/.gitignore 2>/dev/null || true'
-        });
-    } catch (e) {}
-    try {
-        runCmd({
-            command: 'git checkout ' + originRef + ' -- .codegraph/.gitignore 2>/dev/null || git checkout -- .codegraph/.gitignore 2>/dev/null || true'
-        });
-    } catch (e) {}
-    try {
-        runCmd({
-            command: 'rm -f .agent-bin/codegraph'
-        });
-    } catch (e) {}
-}
-
 /**
  * Clean command output from script wrapper artifacts
  * Removes "Script started/done" lines that DMTools CLI adds
@@ -225,7 +206,6 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
         runCmd({
             command: 'git add .'
         });
-        cleanupGeneratedToolingArtifacts(baseBranch || 'main');
 
         // Check if there are changes to commit
         const statusOutput = prHelper.readStagedDiffStat(function(command) {

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -83,22 +83,8 @@ suite('developBugAndCreatePR', function() {
         assert.contains(loaded.comments[0].comment, 'Development Interrupted');
     });
 
-    test('does not push CodeGraph setup artifacts as interrupted partial work', function() {
-        var loaded = loadDevelopBugAndCreatePR({
-            cli_execute_command: function(args) {
-                loaded.commands.push(args.command);
-                if (args.command.indexOf('gh pr list --head ') === 0) return '';
-                if (args.command === 'git status --porcelain') {
-                    return 'A  .agent-bin/codegraph\n' +
-                        '?? .agent-bin/codegraph-wrapper\n' +
-                        'D  .codegraph/.gitignore\n' +
-                        '?? .codegraph/index.sqlite\n' +
-                        'M  agents\n';
-                }
-                if (args.command === 'git branch --show-current') return 'main\n';
-                return '';
-            }
-        });
+    test('does not clean CodeGraph runtime artifacts from JS post-action', function() {
+        var loaded = loadDevelopBugAndCreatePR();
 
         var result = loaded.mod.action({
             ticket: {
@@ -114,34 +100,11 @@ suite('developBugAndCreatePR', function() {
         assert.equal(result.success, true);
         assert.equal(result.path, 'interrupted');
         assert.notOk(
-            loaded.commands.indexOf('git checkout -B ai/TS-1298') !== -1,
-            'generated CodeGraph setup artifacts must not trigger a WIP branch push'
-        );
-        assert.notOk(
-            loaded.commands.some(function(c) { return c.indexOf('git commit -m "TS-1298 WIP') === 0; }),
-            'generated CodeGraph setup artifacts must not be committed'
-        );
-        assert.notOk(
-            loaded.commands.some(function(c) { return c.indexOf('git push -u origin ai/TS-1298') === 0; }),
-            'generated CodeGraph setup artifacts must not be pushed'
-        );
-        assert.ok(
-            loaded.commands.indexOf('git reset -q -- .agent-bin .codegraph agents') !== -1,
-            'generated tooling and submodule pointer artifacts must be unstaged before status check'
-        );
-        assert.ok(
-            loaded.commands.indexOf('git clean -fd -- .agent-bin .codegraph') !== -1,
-            'untracked generated tooling artifacts must be cleaned with whitelisted git command'
-        );
-        assert.notOk(
             loaded.commands.some(function(c) {
-                return c.indexOf('||') !== -1 ||
-                    c.indexOf('2>') !== -1 ||
-                    c.indexOf('rm ') === 0;
+                return c.indexOf('.agent-bin') !== -1 || c.indexOf('.codegraph') !== -1;
             }),
-            'cleanup commands must be accepted by the restricted CLI executor'
+            'CodeGraph setup/cleanup belongs to setup scripts, not JS post-actions'
         );
-        assert.contains(loaded.comments[0].comment, 'No partial work was produced');
     });
 
     test('rejects already_fixed output when CodeGraph was not used', function() {

--- a/setup/_common.sh
+++ b/setup/_common.sh
@@ -94,6 +94,16 @@ parse_tool_arg() {
 # If .codegraph/ already exists (restored from cache) → sync.
 # If not → init non-interactively.
 # Skips silently if not inside a git repository or if codegraph is not installed.
+_codegraph_restore_gitignore() {
+  local workspace="$1"
+
+  if git -C "${workspace}" ls-files --error-unmatch .codegraph/.gitignore >/dev/null 2>&1; then
+    git -C "${workspace}" checkout -- .codegraph/.gitignore >/dev/null 2>&1 || true
+  else
+    rm -f "${workspace}/.codegraph/.gitignore"
+  fi
+}
+
 _codegraph_init_or_sync() {
   local workspace="${GITHUB_WORKSPACE:-${PWD}}"
 
@@ -109,12 +119,12 @@ _codegraph_init_or_sync() {
   if [ -d "${workspace}/.codegraph" ]; then
     echo "🔄 CodeGraph index found — syncing..."
     codegraph sync "${workspace}" 2>/dev/null || true
-    rm -f "${workspace}/.codegraph/.gitignore"
+    _codegraph_restore_gitignore "${workspace}"
     echo "✅ CodeGraph index synced"
   else
     echo "🔨 Initializing CodeGraph index..."
     codegraph init -i "${workspace}" 2>/dev/null || true
-    rm -f "${workspace}/.codegraph/.gitignore"
+    _codegraph_restore_gitignore "${workspace}"
     echo "✅ CodeGraph index initialized"
   fi
 }

--- a/setup/codegraph.sh
+++ b/setup/codegraph.sh
@@ -20,8 +20,10 @@ NPM_GLOBAL_BIN="${HOME}/.npm-global/bin"
 echo "🛠  CodeGraph (${CODEGRAPH_PACKAGE})"
 
 cleanup_workspace_artifacts() {
-  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git clean -fd -- .agent-bin >/dev/null 2>&1 || true
+  local workspace="${GITHUB_WORKSPACE:-${PWD}}"
+
+  if git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "${workspace}" clean -fd -- .agent-bin >/dev/null 2>&1 || true
   fi
 }
 


### PR DESCRIPTION
## Summary
- remove CodeGraph runtime artifact cleanup from JS post-actions
- keep .agent-bin cleanup in CodeGraph setup using GITHUB_WORKSPACE/PWD
- restore tracked .codegraph/.gitignore after CodeGraph init/sync so setup leaves the worktree clean

## Tests
- bash -n agents/setup/codegraph.sh agents/setup/_common.sh
- dmtools run js/unit-tests/run_all.json --mini
- temp git repo check for tracked .codegraph/.gitignore restore