### PR TITLE
Restore ticket key in AI workflow display names

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -40,6 +40,7 @@ function parseWorkflowRuns(raw) {
 
 function hasActiveTargetRun(scm, configFile, ticketKey, workflowFile) {
     var expectedName = configFile + ' : ' + ticketKey;
+    var expectedNameSuffix = ' : ' + ticketKey;
     var statuses = ['queued', 'in_progress', 'waiting', 'pending'];
 
     for (var i = 0; i < statuses.length; i++) {
@@ -56,7 +57,10 @@ function hasActiveTargetRun(scm, configFile, ticketKey, workflowFile) {
             var run = runs[j] || {};
             if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var name = run.display_title || run.displayTitle || run.name || '';
-            if (name === expectedName) {
+            var matchesOldName = name === expectedName;
+            var matchesDisplayName = name.indexOf(configFile + ' : ') === 0 &&
+                name.substring(name.length - expectedNameSuffix.length) === expectedNameSuffix;
+            if (matchesOldName || matchesDisplayName) {
                 console.log('autoStart: skipped duplicate ' + expectedName + ' because run #' +
                     (run.run_number || run.runNumber || run.id || '?') + ' is ' + (run.status || statuses[i]));
                 return true;
@@ -181,6 +185,7 @@ function triggerConfiguredWorkflowForTicket(options) {
         workflowFile,
         JSON.stringify({
             concurrency_key: ticketKey,
+            display_key: ticketKey,
             config_file: configFile,
             encoded_config: encodedCfg,
             project_key: projectKey || ''

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -222,6 +222,7 @@ function hasActiveTargetWorkflowRun(scm, workflowFile, configFile, ticketKey) {
     if (!scm || typeof scm.listWorkflowRuns !== 'function') return false;
 
     var expectedRunName = configFile + ' : ' + ticketKey;
+    var expectedRunNameSuffix = ' : ' + ticketKey;
     var statuses = ['queued', 'in_progress', 'waiting', 'pending'];
 
     for (var i = 0; i < statuses.length; i++) {
@@ -237,7 +238,10 @@ function hasActiveTargetWorkflowRun(scm, workflowFile, configFile, ticketKey) {
             var run = runs[j] || {};
             if (isStaleNonRunningWorkflowRun(run, statuses[i])) continue;
             var runName = run.name || run.display_title || '';
-            if (runName === expectedRunName) {
+            var matchesOldName = runName === expectedRunName;
+            var matchesDisplayName = runName.indexOf(configFile + ' : ') === 0 &&
+                runName.substring(runName.length - expectedRunNameSuffix.length) === expectedRunNameSuffix;
+            if (matchesOldName || matchesDisplayName) {
                 console.log('  ⏭️  ' + ticketKey + ' skipped (active workflow already exists: ' + expectedRunName + ')');
                 return true;
             }
@@ -346,6 +350,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig, workflowBud
             workflowFile,
             JSON.stringify({
                 concurrency_key: concurrencyKey,
+                display_key:     ticketKey,
                 input_jql:       'key = ' + ticketKey,
                 config_file:     resolvedCf,
                 encoded_config:  buildEncodedConfig(ticketKey, rule, effectiveConfig),

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -28,7 +28,7 @@ suite('autoStart helper', function() {
                 if (status === 'in_progress') {
                     return JSON.stringify({
                         workflow_runs: [{
-                            name: 'agents/pr_test_automation_rework.json : TS-90',
+                            name: 'agents/pr_test_automation_rework.json : TS-90 : TS-90',
                             status: 'in_progress',
                             run_number: 584
                         }]
@@ -82,6 +82,7 @@ suite('autoStart helper', function() {
         assert.equal(triggeredPayload.repo, 'trackstate');
         assert.equal(triggeredPayload.workflowFile, 'ai-teammate.yml');
         assert.equal(triggeredPayload.payload.concurrency_key, 'TS-90');
+        assert.equal(triggeredPayload.payload.display_key, 'TS-90');
         assert.equal(triggeredPayload.payload.config_file, 'agents/pr_test_automation_rework.json');
         assert.equal(triggeredPayload.ref, 'main');
     });

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -499,6 +499,7 @@ suite('smAgent: ticket dispatch', function() {
         assert.equal(sm.capturedTriggers.length, 1);
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         assert.equal(inputs.concurrency_key, 'P-42', 'concurrency key set to ticket key');
+        assert.equal(inputs.display_key, 'P-42', 'workflow display key set to ticket key');
         assert.equal(inputs.input_jql, 'key = P-42', 'workflow input JQL set to ticket key');
         assert.equal(inputs.config_file, 'agents/story_development.json', 'config_file passed');
         assert.ok(inputs.encoded_config, 'encoded_config present');
@@ -523,6 +524,7 @@ suite('smAgent: ticket dispatch', function() {
         assert.equal(sm.capturedTriggers.length, 1);
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         assert.equal(inputs.concurrency_key, 'bulk_bugs_creation', 'rule concurrency key used');
+        assert.equal(inputs.display_key, 'P-42', 'workflow display key preserves ticket key');
         assert.equal(inputs.input_jql, 'key = P-42', 'workflow input JQL remains ticket-specific');
 
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
@@ -739,7 +741,7 @@ suite('smAgent: skipIfLabel', function() {
             workflowRuns: {
                 queued: [
                     {
-                        display_title: 'agents/bulk_bugs_creation.json : bulk_bugs_creation',
+                        display_title: 'agents/bulk_bugs_creation.json : T-1 : bulk_bugs_creation',
                         status: 'queued'
                     }
                 ],


### PR DESCRIPTION
## Summary
- pass display_key=ticketKey when SM and auto-start trigger ai-teammate.yml
- keep concurrency_key unchanged for shared workflow caps
- make duplicate active-run checks understand both old and new run-name formats

## Tests
- dmtools run js/unit-tests/run_all.json --mini