### PR TITLE
Add Playwright setup script

### DIFF
--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -8,7 +8,7 @@
 #   cache.sh info                      # print cache table for all known tools
 #
 # Examples:
-#   cache.sh keys dmtools maestro copilot node
+#   cache.sh keys dmtools maestro copilot node playwright
 #   cache.sh keys dmtools:v1.7.195 java:17
 #
 # After running, CI cache steps can reference exported env vars:
@@ -69,6 +69,12 @@ _cache_codegraph() {
   export_var "CODEGRAPH_INDEX_CACHE_KEY"  "codegraph-index-${OS_TAG}"
 }
 
+_cache_playwright() {
+  local version="${1:-${PLAYWRIGHT_VERSION:-latest}}"
+  export_var "PLAYWRIGHT_CACHE_PATH" "${HOME}/.cache/ms-playwright"
+  export_var "PLAYWRIGHT_CACHE_KEY"  "playwright-browsers-${version}-${OS_TAG}"
+}
+
 _cache_codemie() {
   local version="${1:-${CODEMIE_VERSION:-latest}}"
   export_var "CODEMIE_CACHE_PATH" "${HOME}/.local/bin"
@@ -86,6 +92,7 @@ _dispatch_tool() {
     maestro)  _cache_maestro  "${version}" ;;
     copilot)  _cache_copilot  "${version}" ;;
     codegraph) _cache_codegraph "${version}" ;;
+    playwright) _cache_playwright "${version}" ;;
     codemie)  _cache_codemie  "${version}" ;;
     cursor)   echo "ℹ️  cursor-agent is not cacheable (part of Cursor IDE)" ;;
     *)        echo "⚠️  Unknown tool '${tool}' — skipping cache config" ;;
@@ -105,6 +112,7 @@ _print_info() {
   printf "│ %-11s │ %-32s │ %-46s │\n" "codemie"  "~/.local/bin"   "codemie-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "cursor"   "(not cacheable)" "-"
   printf "│ %-11s │ %-32s │ %-46s │\n" "codegraph" "~/.npm-global + .codegraph/" "npm-global-codegraph-latest-linux-x86_64"
+  printf "│ %-11s │ %-32s │ %-46s │\n" "playwright" "~/.cache/ms-playwright" "playwright-browsers-latest-linux-x86_64"
   echo "└─────────────┴──────────────────────────────────┴────────────────────────────────────────────────┘"
   echo ""
   echo "Exported env vars per tool:"
@@ -122,7 +130,7 @@ _print_info() {
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-ALL_TOOLS="java node dmtools maestro copilot codemie codegraph"  # cursor has no cache
+ALL_TOOLS="java node dmtools maestro copilot codemie codegraph playwright"  # cursor has no cache
 
 MODE="${1:-info}"
 shift || true
@@ -188,4 +196,3 @@ for arg in ${TOOL_LIST}; do
   KEY_VAR="${VAR_PREFIX}_CACHE_KEY"
   echo "📦 ${TOOL_NAME}: key=${!KEY_VAR:-?}  path=${!PATH_VAR:-?}"
 done
-

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -8,8 +8,8 @@
 #   install.sh all -tool1 -tool2            # install all except listed
 #
 # Examples:
-#   install.sh dmtools maestro copilot
-#   install.sh java:17 dmtools:v1.7.195 node:20 maestro copilot
+#   install.sh dmtools maestro copilot playwright
+#   install.sh java:17 dmtools:v1.7.195 node:20 maestro copilot playwright
 #   install.sh all
 #   install.sh all -cursor -codemie
 set -eu
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_common.sh"
 
 # Canonical order for "all" (node before copilot, java before dmtools)
-ALL_TOOLS="java node dmtools maestro copilot codemie cursor codegraph"
+ALL_TOOLS="java node dmtools maestro copilot codemie cursor codegraph playwright"
 
 if [ $# -eq 0 ]; then
   echo "Usage: install.sh tool1[:version] tool2[:version] ..."
@@ -33,10 +33,11 @@ if [ $# -eq 0 ]; then
   echo "  codemie   — codemie-claude CLI.      Default version: latest"
   echo "  cursor    — cursor-agent (check only; cannot be auto-installed)"
   echo "  codegraph — CodeGraph CLI (npm).     Default version: latest"
+  echo "  playwright — Playwright + Chromium.  Default version: latest"
   echo ""
   echo "Examples:"
-  echo "  install.sh dmtools maestro copilot"
-  echo "  install.sh java:17 dmtools:v1.7.195 node:20 maestro copilot"
+  echo "  install.sh dmtools maestro copilot playwright"
+  echo "  install.sh java:17 dmtools:v1.7.195 node:20 maestro copilot playwright"
   echo "  install.sh all"
   echo "  install.sh all -cursor -codemie"
   exit 0
@@ -164,6 +165,7 @@ for tool in ${TOOL_LIST}; do
     codemie) BIN="codemie-claude" ;;
     cursor)  BIN="cursor-agent" ;;
     codegraph) BIN="codegraph" ;;
+    playwright) BIN="playwright" ;;
     *)       continue ;;
   esac
 

--- a/setup/playwright.sh
+++ b/setup/playwright.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Install Playwright Python package and Chromium browser dependencies.
+#
+# Usage:
+#   playwright.sh [version]                  # Python package version
+#   PLAYWRIGHT_VERSION=1.52.0 playwright.sh  # env override
+#
+# Version examples: latest (default), 1.52.0
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+PLAYWRIGHT_VERSION="${1:-${PLAYWRIGHT_VERSION:-latest}}"
+
+echo "🎭 Playwright (${PLAYWRIGHT_VERSION})"
+
+if ! is_installed python3; then
+  echo "❌ python3 not found. Install Python before Playwright." >&2
+  exit 1
+fi
+
+python3 -m pip install --upgrade pip
+
+if [ "${PLAYWRIGHT_VERSION}" = "latest" ] || [ -z "${PLAYWRIGHT_VERSION}" ]; then
+  python3 -m pip install playwright pytest
+else
+  python3 -m pip install "playwright==${PLAYWRIGHT_VERSION}" pytest
+fi
+
+python3 -m playwright install --with-deps chromium
+
+echo "✅ Playwright $(python3 -m playwright --version 2>/dev/null || echo "${PLAYWRIGHT_VERSION}")"


### PR DESCRIPTION
## Summary
- add agents/setup/playwright.sh for Playwright + Chromium installation
- register playwright in agents/setup/install.sh
- register Playwright browser cache keys in agents/setup/cache.sh

## Tests
- bash -n agents/setup/install.sh agents/setup/cache.sh agents/setup/playwright.sh agents/setup/copilot.sh agents/setup/codegraph.sh
- bash agents/setup/cache.sh keys dmtools:v1.7.196 codegraph copilot:1.0.44 playwright
- bash agents/setup/install.sh (usage output)