### PR TITLE
Avoid rebasing stale AI development branches

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -43,6 +43,20 @@ function cleanCommandOutput(output) {
     return lines.join('\n').trim();
 }
 
+function resetDivergentBranchToBase(branchName, baseBranch) {
+    try {
+        runCmd({ command: 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' });
+        console.log('Branch already contains origin/' + baseBranch + ':', branchName);
+        return;
+    } catch (ancestorError) {
+        console.warn('Branch does not contain origin/' + baseBranch + ', resetting local branch:', branchName);
+    }
+
+    try { runCmd({ command: 'git rebase --abort' }); } catch (_) {}
+    try { runCmd({ command: 'git merge --abort' }); } catch (_) {}
+    runCmd({ command: 'git reset --hard origin/' + baseBranch });
+}
+
 function checkoutBranch(ticketKey, config, ticket) {
     ticket = ticket || { key: ticketKey, fields: {} };
     _workingDir = config.workingDir || null;
@@ -72,20 +86,9 @@ function checkoutBranch(ticketKey, config, ticket) {
     }
 
     if (localBranches.trim()) {
-        console.log('Branch exists locally, rebasing from main:', branchName);
+        console.log('Branch exists locally, aligning with base:', branchName);
         runCmd({ command: 'git checkout ' + branchName });
-        try {
-            var rebaseOutput = cleanCommandOutput(
-                runCmd({ command: 'git rebase origin/' + rebaseBase }) || ''
-            );
-            if (rebaseOutput.indexOf('CONFLICT') !== -1) {
-                throw new Error('Rebase conflict detected: ' + rebaseOutput.substring(0, 200));
-            }
-        } catch (rebaseErr) {
-            console.warn('Rebase failed, resetting to main:', rebaseErr);
-            try { runCmd({ command: 'git rebase --abort' }); } catch (_) {}
-            runCmd({ command: 'git reset --hard origin/' + rebaseBase });
-        }
+        resetDivergentBranchToBase(branchName, rebaseBase);
     } else {
         var remoteBranches = '';
         try {
@@ -96,7 +99,7 @@ function checkoutBranch(ticketKey, config, ticket) {
         }
 
         if (remoteBranches.trim()) {
-            console.log('Branch exists on remote, fetching and checking out:', branchName);
+            console.log('Branch exists on remote, fetching and aligning with base:', branchName);
             // Explicitly fetch the branch so origin/<branch> tracking ref is available locally.
             // git fetch origin --prune may not populate it if the repo is sparse/shallow.
             try {
@@ -107,18 +110,7 @@ function checkoutBranch(ticketKey, config, ticket) {
                 runCmd({ command: prHelper.buildOriginFetchCommand(branchName) });
                 runCmd({ command: 'git checkout -B ' + branchName + ' origin/' + branchName });
             }
-            try {
-                var rebaseOutput2 = cleanCommandOutput(
-                    runCmd({ command: 'git rebase origin/' + rebaseBase }) || ''
-                );
-                if (rebaseOutput2.indexOf('CONFLICT') !== -1) {
-                    throw new Error('Rebase conflict detected: ' + rebaseOutput2.substring(0, 200));
-                }
-            } catch (rebaseErr) {
-                console.warn('Rebase failed, resetting to main:', rebaseErr);
-                try { runCmd({ command: 'git rebase --abort' }); } catch (_) {}
-                runCmd({ command: 'git reset --hard origin/' + rebaseBase });
-            }
+            resetDivergentBranchToBase(branchName, rebaseBase);
         } else {
             // New branch: in two-branch mode, ensure feature branch exists first
             var branchBase = config.git.baseBranch;

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -193,6 +193,70 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         );
     });
 
+    test('does not rebase stale existing development branch', function() {
+        var calls = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "ai/TS-1306"') return '  ai/TS-1306\n';
+            if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
+                throw new Error('not ancestor');
+            }
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                var p = opts && (opts.path || opts);
+                if (p && p.indexOf('.dmtools/config') !== -1) return null;
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        var mod = loadModule(
+            'js/preCliDevelopmentSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchParentContextToInput.js': { action: function() {} },
+                './fetchQuestionsToInput.js': { action: function() {} },
+                './fetchLinkedTestsToInput.js': { action: function() {} },
+                './restoreFromReleases.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function() {},
+                jira_move_to_status: function() {},
+                jira_search_by_jql: function() { return []; }
+            }
+        );
+
+        mod.action({
+            ticket: { key: 'TS-1306', fields: { summary: 'Stale branch', labels: [] } },
+            inputFolderPath: 'input/TS-1306',
+            jobParams: {}
+        });
+
+        assert.equal(
+            calls.some(function(c) { return c.indexOf('git rebase origin/') === 0; }),
+            false,
+            'stale AI branches must not be rebased through bootstrap history'
+        );
+        assert.ok(
+            calls.indexOf('git reset --hard origin/main') !== -1,
+            'stale AI branch should be reset to the base branch'
+        );
+    });
+
 });
 
 // ── preCliTestAutomationSetup: workingDir support ─────────────────────────────


### PR DESCRIPTION
## Summary
- stop preCliDevelopmentSetup from rebasing existing ai/<ticket> branches through old bootstrap history
- if an existing branch does not contain origin/<base>, reset the local branch to origin/<base> before agent work
- keep existing branches that already contain the base unchanged

## Tests
- dmtools run js/unit-tests/run_all.json --mini (326 passed, 0 failed)