### PR TITLE
Guard stale AI branch reset

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -43,14 +43,38 @@ function cleanCommandOutput(output) {
     return lines.join('\n').trim();
 }
 
-function resetDivergentBranchToBase(branchName, baseBranch) {
+var STALE_BRANCH_RESET_AHEAD_THRESHOLD = 100;
+
+function alignBranchWithBase(branchName, baseBranch) {
     try {
         runCmd({ command: 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' });
         console.log('Branch already contains origin/' + baseBranch + ':', branchName);
         return;
     } catch (ancestorError) {
-        console.warn('Branch does not contain origin/' + baseBranch + ', resetting local branch:', branchName);
+        console.warn('Branch does not contain origin/' + baseBranch + ':', branchName);
     }
+
+    var aheadCount = 0;
+    try {
+        aheadCount = parseInt(cleanCommandOutput(
+            runCmd({ command: 'git rev-list --count origin/' + baseBranch + '..HEAD' }) || ''
+        ), 10) || 0;
+    } catch (countError) {
+        console.warn('Could not count branch commits ahead of origin/' + baseBranch + ':', countError);
+    }
+
+    if (aheadCount <= STALE_BRANCH_RESET_AHEAD_THRESHOLD) {
+        console.warn(
+            'Keeping existing branch ' + branchName + ' because it has ' + aheadCount +
+            ' commit(s) ahead of origin/' + baseBranch + '. Publish-time sync will handle base conflicts.'
+        );
+        return;
+    }
+
+    console.warn(
+        'Branch ' + branchName + ' has ' + aheadCount + ' commits ahead of origin/' + baseBranch +
+        ', treating it as stale/bootstrap history and resetting local branch.'
+    );
 
     try { runCmd({ command: 'git rebase --abort' }); } catch (_) {}
     try { runCmd({ command: 'git merge --abort' }); } catch (_) {}
@@ -88,7 +112,7 @@ function checkoutBranch(ticketKey, config, ticket) {
     if (localBranches.trim()) {
         console.log('Branch exists locally, aligning with base:', branchName);
         runCmd({ command: 'git checkout ' + branchName });
-        resetDivergentBranchToBase(branchName, rebaseBase);
+        alignBranchWithBase(branchName, rebaseBase);
     } else {
         var remoteBranches = '';
         try {
@@ -110,7 +134,7 @@ function checkoutBranch(ticketKey, config, ticket) {
                 runCmd({ command: prHelper.buildOriginFetchCommand(branchName) });
                 runCmd({ command: 'git checkout -B ' + branchName + ' origin/' + branchName });
             }
-            resetDivergentBranchToBase(branchName, rebaseBase);
+            alignBranchWithBase(branchName, rebaseBase);
         } else {
             // New branch: in two-branch mode, ensure feature branch exists first
             var branchBase = config.git.baseBranch;

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -201,6 +201,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
             if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
                 throw new Error('not ancestor');
             }
+            if (args.command === 'git rev-list --count origin/main..HEAD') return '1427\n';
             return '';
         };
 
@@ -254,6 +255,67 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         assert.ok(
             calls.indexOf('git reset --hard origin/main') !== -1,
             'stale AI branch should be reset to the base branch'
+        );
+    });
+
+    test('keeps normal divergent development branch work for publish-time sync', function() {
+        var calls = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "ai/TS-1307"') return '  ai/TS-1307\n';
+            if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
+                throw new Error('not ancestor');
+            }
+            if (args.command === 'git rev-list --count origin/main..HEAD') return '3\n';
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                var p = opts && (opts.path || opts);
+                if (p && p.indexOf('.dmtools/config') !== -1) return null;
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        var mod = loadModule(
+            'js/preCliDevelopmentSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchParentContextToInput.js': { action: function() {} },
+                './fetchQuestionsToInput.js': { action: function() {} },
+                './fetchLinkedTestsToInput.js': { action: function() {} },
+                './restoreFromReleases.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function() {},
+                jira_move_to_status: function() {},
+                jira_search_by_jql: function() { return []; }
+            }
+        );
+
+        mod.action({
+            ticket: { key: 'TS-1307', fields: { summary: 'Normal branch work', labels: [] } },
+            inputFolderPath: 'input/TS-1307',
+            jobParams: {}
+        });
+
+        assert.equal(
+            calls.indexOf('git reset --hard origin/main'),
+            -1,
+            'normal branch work must not be discarded during pre-CLI setup'
         );
     });
 


### PR DESCRIPTION
## Summary
- only reset existing ai/<ticket> branches when they have anomalously large bootstrap history
- keep normal divergent branches with small commit counts so WIP is not discarded
- add regression coverage for both stale bootstrap and normal divergent branch paths

## Tests
- dmtools run js/unit-tests/run_all.json --mini (327 passed, 0 failed)