### PR TITLE
Make AI branch alignment merge-aware

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -43,9 +43,54 @@ function cleanCommandOutput(output) {
     return lines.join('\n').trim();
 }
 
-var STALE_BRANCH_RESET_AHEAD_THRESHOLD = 100;
+function writeBranchConflictGuidance(ticketKey, branchName, baseBranch, details) {
+    try {
+        file_write({
+            path: 'input/' + ticketKey + '/merge_conflicts.md',
+            content: '# Branch Conflict Guidance\n\n' +
+                'Branch `' + branchName + '` has work that is not already merged into `origin/' + baseBranch + '`, ' +
+                'and `origin/' + baseBranch + '` is not an ancestor of this branch.\n\n' +
+                'Do not discard the branch work automatically. If a merge conflict appears while syncing with `origin/' + baseBranch + '`, ' +
+                'resolve it deliberately. In most cases, prefer `origin/' + baseBranch + '` for repository setup, generated workflow/config files, ' +
+                'and shared infrastructure, then re-apply only the ticket-specific implementation that is still relevant.\n\n' +
+                'Details:\n\n```\n' + (details || '(not available)') + '\n```\n'
+        });
+    } catch (e) {
+        console.warn('Could not write branch conflict guidance:', e);
+    }
+}
 
-function alignBranchWithBase(branchName, baseBranch) {
+function branchHasUniquePatches(baseBranch) {
+    try {
+        var cherry = cleanCommandOutput(runCmd({ command: 'git cherry origin/' + baseBranch + ' HEAD' }) || '');
+        if (!cherry.trim()) return false;
+        var lines = cherry.split('\n');
+        for (var i = 0; i < lines.length; i++) {
+            if (lines[i].trim().indexOf('+') === 0) return true;
+        }
+        return false;
+    } catch (e) {
+        console.warn('Could not inspect unique branch patches:', e);
+        return true;
+    }
+}
+
+function alignBranchWithBase(ticketKey, branchName, baseBranch) {
+    try {
+        runCmd({ command: 'git merge-base --is-ancestor HEAD origin/' + baseBranch });
+        console.log('Branch changes are already included in origin/' + baseBranch + ', resetting local branch:', branchName);
+        runCmd({ command: 'git reset --hard origin/' + baseBranch });
+        return;
+    } catch (mergedError) {
+        // Branch has work that is not trivially reachable from origin/base.
+    }
+
+    if (!branchHasUniquePatches(baseBranch)) {
+        console.log('Branch has no unique patches versus origin/' + baseBranch + ', resetting local branch:', branchName);
+        runCmd({ command: 'git reset --hard origin/' + baseBranch });
+        return;
+    }
+
     try {
         runCmd({ command: 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' });
         console.log('Branch already contains origin/' + baseBranch + ':', branchName);
@@ -54,31 +99,17 @@ function alignBranchWithBase(branchName, baseBranch) {
         console.warn('Branch does not contain origin/' + baseBranch + ':', branchName);
     }
 
-    var aheadCount = 0;
+    var details = '';
     try {
-        aheadCount = parseInt(cleanCommandOutput(
-            runCmd({ command: 'git rev-list --count origin/' + baseBranch + '..HEAD' }) || ''
-        ), 10) || 0;
-    } catch (countError) {
-        console.warn('Could not count branch commits ahead of origin/' + baseBranch + ':', countError);
+        var mergeBase = cleanCommandOutput(runCmd({ command: 'git merge-base HEAD origin/' + baseBranch }) || '');
+        if (mergeBase) {
+            details = cleanCommandOutput(runCmd({ command: 'git merge-tree ' + mergeBase + ' HEAD origin/' + baseBranch }) || '');
+        }
+    } catch (mergeTreeError) {
+        details = mergeTreeError && mergeTreeError.toString ? mergeTreeError.toString() : String(mergeTreeError);
     }
-
-    if (aheadCount <= STALE_BRANCH_RESET_AHEAD_THRESHOLD) {
-        console.warn(
-            'Keeping existing branch ' + branchName + ' because it has ' + aheadCount +
-            ' commit(s) ahead of origin/' + baseBranch + '. Publish-time sync will handle base conflicts.'
-        );
-        return;
-    }
-
-    console.warn(
-        'Branch ' + branchName + ' has ' + aheadCount + ' commits ahead of origin/' + baseBranch +
-        ', treating it as stale/bootstrap history and resetting local branch.'
-    );
-
-    try { runCmd({ command: 'git rebase --abort' }); } catch (_) {}
-    try { runCmd({ command: 'git merge --abort' }); } catch (_) {}
-    runCmd({ command: 'git reset --hard origin/' + baseBranch });
+    writeBranchConflictGuidance(ticketKey, branchName, baseBranch, details.substring(0, 6000));
+    console.warn('Keeping divergent branch ' + branchName + '; conflict guidance written for the agent.');
 }
 
 function checkoutBranch(ticketKey, config, ticket) {
@@ -112,7 +143,7 @@ function checkoutBranch(ticketKey, config, ticket) {
     if (localBranches.trim()) {
         console.log('Branch exists locally, aligning with base:', branchName);
         runCmd({ command: 'git checkout ' + branchName });
-        alignBranchWithBase(branchName, rebaseBase);
+        alignBranchWithBase(ticketKey, branchName, rebaseBase);
     } else {
         var remoteBranches = '';
         try {
@@ -134,7 +165,7 @@ function checkoutBranch(ticketKey, config, ticket) {
                 runCmd({ command: prHelper.buildOriginFetchCommand(branchName) });
                 runCmd({ command: 'git checkout -B ' + branchName + ' origin/' + branchName });
             }
-            alignBranchWithBase(branchName, rebaseBase);
+            alignBranchWithBase(ticketKey, branchName, rebaseBase);
         } else {
             // New branch: in two-branch mode, ensure feature branch exists first
             var branchBase = config.git.baseBranch;

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -193,15 +193,11 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         );
     });
 
-    test('does not rebase stale existing development branch', function() {
+    test('resets development branch that is already merged to main', function() {
         var calls = [];
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1306"') return '  ai/TS-1306\n';
-            if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
-                throw new Error('not ancestor');
-            }
-            if (args.command === 'git rev-list --count origin/main..HEAD') return '1427\n';
             return '';
         };
 
@@ -250,23 +246,29 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         assert.equal(
             calls.some(function(c) { return c.indexOf('git rebase origin/') === 0; }),
             false,
-            'stale AI branches must not be rebased through bootstrap history'
+            'already merged AI branches must not be rebased through bootstrap history'
         );
         assert.ok(
             calls.indexOf('git reset --hard origin/main') !== -1,
-            'stale AI branch should be reset to the base branch'
+            'already merged AI branch should be reset to the base branch'
         );
     });
 
-    test('keeps normal divergent development branch work for publish-time sync', function() {
+    test('keeps normal divergent development branch work and writes conflict guidance', function() {
         var calls = [];
+        var writes = [];
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1307"') return '  ai/TS-1307\n';
+            if (args.command === 'git merge-base --is-ancestor HEAD origin/main') {
+                throw new Error('not merged');
+            }
+            if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket work\n';
             if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
                 throw new Error('not ancestor');
             }
-            if (args.command === 'git rev-list --count origin/main..HEAD') return '3\n';
+            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
+            if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (content): Merge conflict in .dmtools/config.js\n';
             return '';
         };
 
@@ -300,7 +302,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 file_read: function(opts) {
                     try { return file_read(opts); } catch (e) { return null; }
                 },
-                file_write: function() {},
+                file_write: function(args) { writes.push(args); },
                 jira_move_to_status: function() {},
                 jira_search_by_jql: function() { return []; }
             }
@@ -317,6 +319,9 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
             -1,
             'normal branch work must not be discarded during pre-CLI setup'
         );
+        assert.equal(writes.length, 1, 'conflict guidance should be written');
+        assert.equal(writes[0].path, 'input/TS-1307/merge_conflicts.md');
+        assert.contains(writes[0].content, 'prefer `origin/main`');
     });
 
 });


### PR DESCRIPTION
## Summary
- reset ai/<ticket> branches only when their changes are already included in origin/<base> or have no unique patches
- keep divergent branches that still contain unique ticket work
- write input/<ticket>/merge_conflicts.md with guidance to prefer origin/<base> for shared setup/config/workflow conflicts

## Tests
- dmtools run js/unit-tests/run_all.json --mini (327 passed, 0 failed)