### PR TITLE
feat: add ai teammate token usage reporter

### DIFF
--- a/ai_teammate_token_usage_reporter.json
+++ b/ai_teammate_token_usage_reporter.json
@@ -1,0 +1,19 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "agents/js/aiTeammateTokenUsageReporter.js",
+    "jobParams": {
+      "customParams": {
+        "workspace": "{owner}",
+        "repository": "{repo}",
+        "workflowId": "ai-teammate.yml",
+        "statuses": [
+          "completed"
+        ],
+        "perStatusLimit": 50,
+        "maxRuns": 50,
+        "outputDir": "outputs/token_usage"
+      }
+    }
+  }
+}

--- a/js/aiTeammateTokenUsageReporter.js
+++ b/js/aiTeammateTokenUsageReporter.js
@@ -1,0 +1,423 @@
+var configLoader = require('./configLoader.js');
+
+/**
+ * AI Teammate Token Usage Reporter (JSRunner)
+ *
+ * Downloads completed GitHub Actions logs for ai-teammate runs, extracts Copilot
+ * token summaries printed by CommandLineUtils, and writes CSV/JSON/HTML outputs.
+ */
+
+function parseJson(raw, fallback) {
+    if (raw == null) return fallback;
+    if (typeof raw !== 'string') return raw;
+    try { return JSON.parse(raw); } catch (e) { return fallback; }
+}
+
+function asArray(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    if (value.workflow_runs && Array.isArray(value.workflow_runs)) return value.workflow_runs;
+    if (value.jobs && Array.isArray(value.jobs)) return value.jobs;
+    if (value.result) return asArray(parseJson(value.result, value.result));
+    return [];
+}
+
+function parseNumberWithSuffix(raw) {
+    if (raw == null) return 0;
+    var text = String(raw).trim().toLowerCase().replace(/,/g, '');
+    var match = text.match(/^([0-9]+(?:\.[0-9]+)?)([kmb])?$/);
+    if (!match) return 0;
+    var value = parseFloat(match[1]);
+    var suffix = match[2] || '';
+    if (suffix === 'k') value *= 1000;
+    if (suffix === 'm') value *= 1000000;
+    if (suffix === 'b') value *= 1000000000;
+    return Math.round(value);
+}
+
+function parseRequestsLine(line) {
+    var match = String(line || '').match(/Requests\s+([0-9]+)\s+([^(\n\r]+)?(?:\(([^)]+)\))?/);
+    if (!match) return null;
+    return {
+        requests: parseInt(match[1], 10) || 0,
+        requestTier: (match[2] || '').trim(),
+        requestDuration: (match[3] || '').trim()
+    };
+}
+
+function parseTokensLine(line) {
+    var text = String(line || '');
+    if (text.indexOf('Tokens') === -1) return null;
+
+    var readMatch = text.match(/(?:↑|\^|read(?:\s+tokens?)?)\s*([0-9][0-9.,]*\s*[kmb]?)/i);
+    var writeMatch = text.match(/(?:↓|v|write(?:\s+tokens?)?)\s*([0-9][0-9.,]*\s*[kmb]?)/i);
+    var cachedMatch = text.match(/([0-9][0-9.,]*\s*[kmb]?)\s*\(cached\)/i);
+    var reasoningMatch = text.match(/([0-9][0-9.,]*\s*[kmb]?)\s*\(reasoning\)/i);
+
+    if (!readMatch && !writeMatch && !cachedMatch && !reasoningMatch) return null;
+    return {
+        readTokens: parseNumberWithSuffix(readMatch && readMatch[1]),
+        writeTokens: parseNumberWithSuffix(writeMatch && writeMatch[1]),
+        cachedTokens: parseNumberWithSuffix(cachedMatch && cachedMatch[1]),
+        reasoningTokens: parseNumberWithSuffix(reasoningMatch && reasoningMatch[1]),
+        rawTokensLine: text.trim()
+    };
+}
+
+function extractTokenUsage(logs) {
+    var lines = String(logs || '').split(/\r?\n/);
+    var lastRequests = null;
+    var samples = [];
+
+    for (var i = 0; i < lines.length; i++) {
+        var request = parseRequestsLine(lines[i]);
+        if (request) {
+            lastRequests = request;
+            continue;
+        }
+
+        var tokens = parseTokensLine(lines[i]);
+        if (tokens) {
+            samples.push(Object.assign({}, lastRequests || {}, tokens));
+        }
+    }
+
+    if (!samples.length) return null;
+    var finalSample = samples[samples.length - 1];
+    finalSample.samples = samples.length;
+    return finalSample;
+}
+
+function normalizeLogPayload(raw) {
+    if (raw == null) return '';
+    if (typeof raw !== 'string') {
+        if (raw.result) return normalizeLogPayload(raw.result);
+        if (raw.logs) return normalizeLogPayload(raw.logs);
+        return JSON.stringify(raw);
+    }
+    var parsed = parseJson(raw, null);
+    if (parsed && parsed.result) return normalizeLogPayload(parsed.result);
+    if (parsed && parsed.logs) return normalizeLogPayload(parsed.logs);
+    return raw;
+}
+
+function getRunTitle(run) {
+    return run.display_title || run.displayTitle || run.name || run.run_name || '';
+}
+
+function extractAgentAndKey(run) {
+    var title = getRunTitle(run);
+    var parts = title.split(/\s+:\s+/);
+    var configFile = parts[0] || '';
+    var agent = configFile.replace(/^.*\//, '').replace(/\.json$/, '') || 'unknown';
+    var keyMatch = title.match(/[A-Z][A-Z0-9]+-\d+/);
+    return {
+        title: title,
+        configFile: configFile,
+        agent: agent,
+        ticketKey: keyMatch ? keyMatch[0] : ''
+    };
+}
+
+function isoDay(value) {
+    if (!value) return '';
+    return String(value).substring(0, 10);
+}
+
+function toCsvValue(value) {
+    if (value == null) return '';
+    var text = String(value);
+    if (/[",\n\r]/.test(text)) return '"' + text.replace(/"/g, '""') + '"';
+    return text;
+}
+
+function buildCsv(rows) {
+    var headers = [
+        'runId', 'runNumber', 'createdAt', 'startedAt', 'updatedAt', 'day',
+        'conclusion', 'agent', 'ticketKey', 'configFile', 'title',
+        'requests', 'requestTier', 'requestDuration',
+        'readTokens', 'writeTokens', 'cachedTokens', 'reasoningTokens',
+        'samples', 'url'
+    ];
+    var out = [headers.join(',')];
+    rows.forEach(function(row) {
+        out.push(headers.map(function(key) { return toCsvValue(row[key]); }).join(','));
+    });
+    return out.join('\n') + '\n';
+}
+
+function groupBy(rows, keyFn) {
+    var map = {};
+    rows.forEach(function(row) {
+        var key = keyFn(row) || 'unknown';
+        if (!map[key]) {
+            map[key] = {
+                key: key,
+                runs: 0,
+                requests: 0,
+                readTokens: 0,
+                writeTokens: 0,
+                cachedTokens: 0,
+                reasoningTokens: 0
+            };
+        }
+        var bucket = map[key];
+        bucket.runs += 1;
+        bucket.requests += row.requests || 0;
+        bucket.readTokens += row.readTokens || 0;
+        bucket.writeTokens += row.writeTokens || 0;
+        bucket.cachedTokens += row.cachedTokens || 0;
+        bucket.reasoningTokens += row.reasoningTokens || 0;
+    });
+    return Object.keys(map).sort().map(function(key) {
+        var item = map[key];
+        item.avgReadTokens = item.runs ? Math.round(item.readTokens / item.runs) : 0;
+        item.avgWriteTokens = item.runs ? Math.round(item.writeTokens / item.runs) : 0;
+        item.avgCachedTokens = item.runs ? Math.round(item.cachedTokens / item.runs) : 0;
+        item.avgReasoningTokens = item.runs ? Math.round(item.reasoningTokens / item.runs) : 0;
+        return item;
+    });
+}
+
+function formatShort(value) {
+    value = value || 0;
+    if (value >= 1000000000) return (value / 1000000000).toFixed(1).replace(/\.0$/, '') + 'b';
+    if (value >= 1000000) return (value / 1000000).toFixed(1).replace(/\.0$/, '') + 'm';
+    if (value >= 1000) return (value / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+    return String(value);
+}
+
+function htmlEscape(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function buildHtml(rows, summary) {
+    var payload = JSON.stringify({ rows: rows, summary: summary });
+    var topAgents = summary.byAgent.slice().sort(function(a, b) {
+        return (b.readTokens + b.writeTokens + b.cachedTokens + b.reasoningTokens) -
+               (a.readTokens + a.writeTokens + a.cachedTokens + a.reasoningTokens);
+    }).slice(0, 20);
+    var recentRows = rows.slice().sort(function(a, b) {
+        return String(b.createdAt).localeCompare(String(a.createdAt));
+    }).slice(0, 200);
+
+    return '<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n' +
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n' +
+        '<title>AI Teammate Token Usage</title>\n<style>\n' +
+        ':root{color-scheme:light;--bg:#f6f7f9;--panel:#fff;--ink:#18202a;--muted:#5f6b7a;--grid:#e1e5ea;--blue:#2563eb;--green:#059669;--amber:#b7791f;--red:#dc2626;--violet:#7c3aed}' +
+        '*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.45 -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}' +
+        'header{padding:24px 28px 12px}h1{margin:0 0 6px;font-size:26px;letter-spacing:0}p{margin:0;color:var(--muted)}' +
+        '.wrap{padding:12px 28px 32px;display:grid;gap:16px}.kpis{display:grid;grid-template-columns:repeat(5,minmax(140px,1fr));gap:12px}' +
+        '.kpi,.panel{background:var(--panel);border:1px solid var(--grid);border-radius:8px;box-shadow:0 1px 2px rgba(0,0,0,.04)}.kpi{padding:14px}.kpi b{display:block;font-size:22px;margin-top:4px}.kpi span{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}' +
+        '.grid{display:grid;grid-template-columns:1.4fr 1fr;gap:16px}.panel{padding:16px}.panel h2{font-size:16px;margin:0 0 12px}.chart{width:100%;height:280px;display:block}' +
+        'table{width:100%;border-collapse:collapse}th,td{padding:8px 10px;border-bottom:1px solid var(--grid);text-align:left;white-space:nowrap}th{font-size:12px;color:var(--muted);font-weight:600}td.num{text-align:right;font-variant-numeric:tabular-nums}.scroll{overflow:auto;max-height:520px}' +
+        '.legend{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px;color:var(--muted);font-size:12px}.dot{width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:5px}' +
+        '@media(max-width:900px){.kpis,.grid{grid-template-columns:1fr}.wrap,header{padding-left:16px;padding-right:16px}}\n' +
+        '</style>\n</head>\n<body>\n<header><h1>AI Teammate Token Usage</h1><p>Generated ' + htmlEscape(summary.generatedAt) + ' from completed workflow logs.</p></header>\n' +
+        '<main class="wrap">\n<section class="kpis">' +
+        '<div class="kpi"><span>Runs Parsed</span><b>' + summary.runsWithTokens + '</b></div>' +
+        '<div class="kpi"><span>Read Tokens</span><b>' + formatShort(summary.totals.readTokens) + '</b></div>' +
+        '<div class="kpi"><span>Write Tokens</span><b>' + formatShort(summary.totals.writeTokens) + '</b></div>' +
+        '<div class="kpi"><span>Cached Tokens</span><b>' + formatShort(summary.totals.cachedTokens) + '</b></div>' +
+        '<div class="kpi"><span>Reasoning Tokens</span><b>' + formatShort(summary.totals.reasoningTokens) + '</b></div>' +
+        '</section>\n<section class="grid"><div class="panel"><h2>Daily Token Trend</h2><canvas id="daily" class="chart"></canvas><div class="legend"><span><i class="dot" style="background:#2563eb"></i>read</span><span><i class="dot" style="background:#059669"></i>write</span><span><i class="dot" style="background:#b7791f"></i>cached</span><span><i class="dot" style="background:#dc2626"></i>reasoning</span></div></div>' +
+        '<div class="panel"><h2>Tokens By Agent</h2><canvas id="agents" class="chart"></canvas></div></section>\n' +
+        '<section class="panel"><h2>Agent Totals And Averages</h2><div class="scroll"><table><thead><tr><th>Agent</th><th>Runs</th><th>Read</th><th>Avg Read</th><th>Write</th><th>Avg Write</th><th>Cached</th><th>Reasoning</th></tr></thead><tbody>' +
+        topAgents.map(function(a) {
+            return '<tr><td>' + htmlEscape(a.key) + '</td><td class="num">' + a.runs + '</td><td class="num">' + formatShort(a.readTokens) + '</td><td class="num">' + formatShort(a.avgReadTokens) + '</td><td class="num">' + formatShort(a.writeTokens) + '</td><td class="num">' + formatShort(a.avgWriteTokens) + '</td><td class="num">' + formatShort(a.cachedTokens) + '</td><td class="num">' + formatShort(a.reasoningTokens) + '</td></tr>';
+        }).join('') +
+        '</tbody></table></div></section>\n' +
+        '<section class="panel"><h2>Recent Runs</h2><div class="scroll"><table><thead><tr><th>Created</th><th>Agent</th><th>Key</th><th>Conclusion</th><th>Read</th><th>Write</th><th>Cached</th><th>Reasoning</th><th>Run</th></tr></thead><tbody>' +
+        recentRows.map(function(r) {
+            return '<tr><td>' + htmlEscape(r.createdAt) + '</td><td>' + htmlEscape(r.agent) + '</td><td>' + htmlEscape(r.ticketKey) + '</td><td>' + htmlEscape(r.conclusion) + '</td><td class="num">' + formatShort(r.readTokens) + '</td><td class="num">' + formatShort(r.writeTokens) + '</td><td class="num">' + formatShort(r.cachedTokens) + '</td><td class="num">' + formatShort(r.reasoningTokens) + '</td><td><a href="' + htmlEscape(r.url) + '">#' + htmlEscape(r.runNumber) + '</a></td></tr>';
+        }).join('') +
+        '</tbody></table></div></section>\n</main>\n<script>const DATA=' + payload.replace(/</g, '\\u003c') + ';\n' +
+        'function short(v){v=v||0;if(v>=1e9)return(v/1e9).toFixed(1).replace(/\\.0$/,"")+"b";if(v>=1e6)return(v/1e6).toFixed(1).replace(/\\.0$/,"")+"m";if(v>=1e3)return(v/1e3).toFixed(1).replace(/\\.0$/,"")+"k";return String(v)}' +
+        'function drawBars(id, labels, series){const c=document.getElementById(id),ctx=c.getContext("2d"),dpr=devicePixelRatio||1,w=c.clientWidth,h=c.clientHeight;c.width=w*dpr;c.height=h*dpr;ctx.scale(dpr,dpr);ctx.clearRect(0,0,w,h);const pad={l:54,r:14,t:12,b:54};const max=Math.max(1,...series.flatMap(s=>s.values));ctx.strokeStyle="#e1e5ea";ctx.fillStyle="#5f6b7a";ctx.font="12px -apple-system,Segoe UI,sans-serif";for(let i=0;i<=4;i++){let y=pad.t+(h-pad.t-pad.b)*i/4;ctx.beginPath();ctx.moveTo(pad.l,y);ctx.lineTo(w-pad.r,y);ctx.stroke();ctx.fillText(short(max*(1-i/4)),6,y+4)}const groupW=(w-pad.l-pad.r)/Math.max(1,labels.length),barW=Math.max(3,groupW/(series.length+1));labels.forEach((lab,i)=>{series.forEach((s,j)=>{let val=s.values[i]||0,bh=(h-pad.t-pad.b)*val/max,x=pad.l+i*groupW+j*barW+barW*.35,y=h-pad.b-bh;ctx.fillStyle=s.color;ctx.fillRect(x,y,barW*.8,bh)});ctx.save();ctx.translate(pad.l+i*groupW+groupW*.35,h-pad.b+10);ctx.rotate(-Math.PI/5);ctx.fillStyle="#5f6b7a";ctx.fillText(lab,0,0);ctx.restore()})}' +
+        'const daily=DATA.summary.byDay;drawBars("daily",daily.map(x=>x.key),[{color:"#2563eb",values:daily.map(x=>x.readTokens)},{color:"#059669",values:daily.map(x=>x.writeTokens)},{color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}]);' +
+        'const agents=DATA.summary.byAgent.slice().sort((a,b)=>(b.readTokens+b.writeTokens+b.cachedTokens+b.reasoningTokens)-(a.readTokens+a.writeTokens+a.cachedTokens+a.reasoningTokens)).slice(0,12);drawBars("agents",agents.map(x=>x.key),[{color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}]);' +
+        'addEventListener("resize",()=>{drawBars("daily",daily.map(x=>x.key),[{color:"#2563eb",values:daily.map(x=>x.readTokens)},{color:"#059669",values:daily.map(x=>x.writeTokens)},{color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}]);drawBars("agents",agents.map(x=>x.key),[{color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}])});' +
+        '</script>\n</body>\n</html>\n';
+}
+
+function listCompletedRuns(custom) {
+    var workspace = custom.workspace;
+    var repository = custom.repository;
+    var workflowId = custom.workflowId || 'ai-teammate.yml';
+    var statuses = custom.statuses || ['completed'];
+    if (typeof statuses === 'string') statuses = statuses.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
+    var perStatusLimit = custom.perStatusLimit || custom.limit || 50;
+    var seen = {};
+    var runs = [];
+
+    statuses.forEach(function(status) {
+        var raw = github_list_workflow_runs(workspace, repository, status, workflowId, perStatusLimit);
+        asArray(parseJson(raw, raw)).forEach(function(run) {
+            var id = String(run.id || run.databaseId || '');
+            if (!id || seen[id]) return;
+            seen[id] = true;
+            if (run.status && run.status !== 'completed') return;
+            runs.push(run);
+        });
+    });
+
+    runs.sort(function(a, b) {
+        return String(b.created_at || b.createdAt || '').localeCompare(String(a.created_at || a.createdAt || ''));
+    });
+    if (custom.maxRuns && runs.length > custom.maxRuns) runs = runs.slice(0, custom.maxRuns);
+    return runs;
+}
+
+function downloadRunLogs(custom, run) {
+    var runId = String(run.id || run.databaseId);
+    if (typeof github_get_workflow_run_logs === 'function') {
+        return normalizeLogPayload(github_get_workflow_run_logs({
+            workspace: custom.workspace,
+            repository: custom.repository,
+            runId: runId
+        }));
+    }
+
+    var jobsRaw = github_get_workflow_run_jobs({
+        workspace: custom.workspace,
+        repository: custom.repository,
+        runId: runId
+    });
+    var jobs = asArray(parseJson(jobsRaw, jobsRaw));
+    var chunks = [];
+    jobs.forEach(function(job) {
+        var jobId = job.id || job.databaseId;
+        if (!jobId) return;
+        chunks.push(normalizeLogPayload(github_get_job_logs({
+            workspace: custom.workspace,
+            repository: custom.repository,
+            jobId: String(jobId)
+        })));
+    });
+    return chunks.join('\n');
+}
+
+function buildSummary(rows, totalRuns) {
+    var totals = {
+        requests: 0,
+        readTokens: 0,
+        writeTokens: 0,
+        cachedTokens: 0,
+        reasoningTokens: 0
+    };
+    rows.forEach(function(row) {
+        Object.keys(totals).forEach(function(key) {
+            totals[key] += row[key] || 0;
+        });
+    });
+    return {
+        generatedAt: new Date().toISOString(),
+        totalRuns: totalRuns,
+        runsWithTokens: rows.length,
+        runsWithoutTokens: Math.max(0, totalRuns - rows.length),
+        totals: totals,
+        byDay: groupBy(rows, function(row) { return row.day; }),
+        byAgent: groupBy(rows, function(row) { return row.agent; })
+    };
+}
+
+function writeOutput(path, content) {
+    file_write({ path: path, content: content });
+}
+
+function action(params) {
+    var custom = (params && params.jobParams && params.jobParams.customParams) || {};
+    var projectConfig = configLoader.loadProjectConfig(params || {});
+    custom.workspace = custom.workspace || custom.owner;
+    custom.repository = custom.repository || custom.repo;
+    if (!custom.workspace || custom.workspace.indexOf('{') !== -1) {
+        custom.workspace = projectConfig.repository && projectConfig.repository.owner;
+    }
+    if (!custom.repository || custom.repository.indexOf('{') !== -1) {
+        custom.repository = projectConfig.repository && projectConfig.repository.repo;
+    }
+    custom.workflowId = custom.workflowId || 'ai-teammate.yml';
+
+    if (!custom.workspace || !custom.repository) {
+        return { success: false, error: 'customParams.workspace and customParams.repository are required' };
+    }
+
+    var outputDir = custom.outputDir || 'outputs/token_usage';
+    var csvPath = custom.csvPath || (outputDir + '/ai_teammate_token_usage.csv');
+    var jsonPath = custom.jsonPath || (outputDir + '/ai_teammate_token_usage.json');
+    var htmlPath = custom.htmlPath || (outputDir + '/ai_teammate_token_usage.html');
+
+    console.log('AI Teammate Token Usage Reporter — ' + custom.workspace + '/' + custom.repository + ' [' + custom.workflowId + ']');
+    var runs = listCompletedRuns(custom);
+    console.log('Found ' + runs.length + ' completed workflow run(s)');
+
+    var rows = [];
+    for (var i = 0; i < runs.length; i++) {
+        var run = runs[i];
+        var meta = extractAgentAndKey(run);
+        var runId = String(run.id || run.databaseId);
+        console.log('  [' + (i + 1) + '/' + runs.length + '] ' + runId + ' ' + meta.title);
+
+        try {
+            var logs = downloadRunLogs(custom, run);
+            var usage = extractTokenUsage(logs);
+            if (!usage) {
+                console.log('    no token summary found');
+                continue;
+            }
+
+            rows.push({
+                runId: runId,
+                runNumber: run.run_number || run.runNumber || '',
+                createdAt: run.created_at || run.createdAt || '',
+                startedAt: run.run_started_at || run.runStartedAt || '',
+                updatedAt: run.updated_at || run.updatedAt || '',
+                day: isoDay(run.created_at || run.createdAt || run.run_started_at || run.runStartedAt),
+                conclusion: run.conclusion || '',
+                agent: meta.agent,
+                ticketKey: meta.ticketKey,
+                configFile: meta.configFile,
+                title: meta.title,
+                requests: usage.requests || 0,
+                requestTier: usage.requestTier || '',
+                requestDuration: usage.requestDuration || '',
+                readTokens: usage.readTokens || 0,
+                writeTokens: usage.writeTokens || 0,
+                cachedTokens: usage.cachedTokens || 0,
+                reasoningTokens: usage.reasoningTokens || 0,
+                samples: usage.samples || 1,
+                url: run.html_url || run.htmlUrl || ''
+            });
+            console.log('    tokens read=' + usage.readTokens + ' write=' + usage.writeTokens + ' cached=' + usage.cachedTokens + ' reasoning=' + usage.reasoningTokens);
+        } catch (e) {
+            console.warn('    failed to process run ' + runId + ': ' + (e.message || e));
+        }
+    }
+
+    var summary = buildSummary(rows, runs.length);
+    var payload = { summary: summary, rows: rows };
+    writeOutput(csvPath, buildCsv(rows));
+    writeOutput(jsonPath, JSON.stringify(payload, null, 2));
+    writeOutput(htmlPath, buildHtml(rows, summary));
+
+    console.log('Wrote CSV: ' + csvPath);
+    console.log('Wrote JSON: ' + jsonPath);
+    console.log('Wrote HTML: ' + htmlPath);
+    return { success: true, csvPath: csvPath, jsonPath: jsonPath, htmlPath: htmlPath, summary: summary };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        action: action,
+        parseNumberWithSuffix: parseNumberWithSuffix,
+        parseTokensLine: parseTokensLine,
+        extractTokenUsage: extractTokenUsage,
+        extractAgentAndKey: extractAgentAndKey,
+        buildCsv: buildCsv,
+        buildSummary: buildSummary
+    };
+}

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -16,6 +16,7 @@
         "js/unit-tests/test_developTicketAndCreatePR.js",
         "js/unit-tests/test_developBugAndCreatePR.js",
         "js/unit-tests/test_autoStart.js",
+        "js/unit-tests/test_aiTeammateTokenUsageReporter.js",
         "js/unit-tests/test_dfManager.js",
         "js/unit-tests/test_retryMergePR.js",
         "js/unit-tests/test_recoverMergedPRTicket.js",

--- a/js/unit-tests/test_aiTeammateTokenUsageReporter.js
+++ b/js/unit-tests/test_aiTeammateTokenUsageReporter.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for aiTeammateTokenUsageReporter.js
+ */
+
+function loadReporter() {
+    var configLoaderMock = {
+        loadProjectConfig: function() {
+            return { repository: { owner: 'IstiN', repo: 'trackstate' } };
+        }
+    };
+    return loadModule('js/aiTeammateTokenUsageReporter.js', makeRequire({ './configLoader.js': configLoaderMock }), {
+        file_write: function() {},
+        github_list_workflow_runs: function() { return JSON.stringify({ workflow_runs: [] }); }
+    });
+}
+
+suite('aiTeammateTokenUsageReporter parsing', function() {
+
+    test('parses suffixed token counts', function() {
+        var reporter = loadReporter();
+        assert.equal(reporter.parseNumberWithSuffix('2.9m'), 2900000);
+        assert.equal(reporter.parseNumberWithSuffix('9.4k'), 9400);
+        assert.equal(reporter.parseNumberWithSuffix('1700'), 1700);
+    });
+
+    test('parses CommandLineUtils token summary line', function() {
+        var reporter = loadReporter();
+        var parsed = reporter.parseTokensLine('[INFO] CommandLineUtils - Tokens    ↑ 2.9m • ↓ 9.4k • 2.8m (cached) • 1.7k (reasoning)');
+
+        assert.equal(parsed.readTokens, 2900000);
+        assert.equal(parsed.writeTokens, 9400);
+        assert.equal(parsed.cachedTokens, 2800000);
+        assert.equal(parsed.reasoningTokens, 1700);
+    });
+
+    test('extracts the final token usage sample with request metadata', function() {
+        var reporter = loadReporter();
+        var usage = reporter.extractTokenUsage([
+            '[INFO] CommandLineUtils - Requests  1 Premium (27m 2s)',
+            '[INFO] CommandLineUtils - Tokens    ↑ 2.9m • ↓ 9.4k • 2.8m (cached) • 1.7k (reasoning)',
+            '[INFO] CommandLineUtils - Requests  2 Premium (30m 0s)',
+            '[INFO] CommandLineUtils - Tokens    ↑ 3.1m • ↓ 10k • 3m (cached) • 2k (reasoning)'
+        ].join('\n'));
+
+        assert.equal(usage.requests, 2);
+        assert.equal(usage.requestTier, 'Premium');
+        assert.equal(usage.requestDuration, '30m 0s');
+        assert.equal(usage.readTokens, 3100000);
+        assert.equal(usage.writeTokens, 10000);
+        assert.equal(usage.cachedTokens, 3000000);
+        assert.equal(usage.reasoningTokens, 2000);
+        assert.equal(usage.samples, 2);
+    });
+
+    test('extracts agent and ticket key from ai-teammate run title', function() {
+        var reporter = loadReporter();
+        var parsed = reporter.extractAgentAndKey({
+            display_title: 'agents/bug_development.json : TS-1307 : bug_development'
+        });
+
+        assert.equal(parsed.configFile, 'agents/bug_development.json');
+        assert.equal(parsed.agent, 'bug_development');
+        assert.equal(parsed.ticketKey, 'TS-1307');
+    });
+});


### PR DESCRIPTION
Adds a JSRunner reporter that downloads completed ai-teammate workflow logs, extracts CommandLineUtils token summaries, and writes CSV/JSON/static HTML outputs grouped by day and agent.

Outputs default to `outputs/token_usage/ai_teammate_token_usage.{csv,json,html}`.

Tested with `dmtools run js/unit-tests/run_all.json --mini` (331 passed, 0 failed). Also generated a live TrackState report from 50 completed ai-teammate runs.