### PR TITLE
feat: report AI teammate token usage across all runs

### DIFF
--- a/ai_teammate_token_usage_reporter.json
+++ b/ai_teammate_token_usage_reporter.json
@@ -10,8 +10,8 @@
         "statuses": [
           "completed"
         ],
-        "perStatusLimit": 50,
-        "maxRuns": 50,
+        "perStatusLimit": 100,
+        "maxPages": 100,
         "outputDir": "outputs/token_usage"
       }
     }

--- a/js/aiTeammateTokenUsageReporter.js
+++ b/js/aiTeammateTokenUsageReporter.js
@@ -124,6 +124,32 @@ function isoDay(value) {
     return String(value).substring(0, 10);
 }
 
+function todayIsoDay() {
+    return new Date().toISOString().substring(0, 10);
+}
+
+function toWindowStart(value) {
+    var text = String(value || todayIsoDay());
+    return text.length === 10 ? text + 'T00:00:00Z' : text;
+}
+
+function toWindowEnd(value) {
+    var text = String(value || todayIsoDay());
+    return text.length === 10 ? text + 'T23:59:59Z' : text;
+}
+
+function formatWindowTime(ms) {
+    return new Date(ms).toISOString().replace('.000Z', 'Z');
+}
+
+function addMilliseconds(iso, count) {
+    return formatWindowTime(Date.parse(iso) + count);
+}
+
+function midpointTime(startIso, endIso) {
+    return formatWindowTime(Math.floor((Date.parse(startIso) + Date.parse(endIso)) / 2));
+}
+
 function toCsvValue(value) {
     if (value == null) return '';
     var text = String(value);
@@ -244,25 +270,73 @@ function buildHtml(rows, summary) {
         '</script>\n</body>\n</html>\n';
 }
 
-function listCompletedRuns(custom) {
-    var workspace = custom.workspace;
-    var repository = custom.repository;
-    var workflowId = custom.workflowId || 'ai-teammate.yml';
-    var statuses = custom.statuses || ['completed'];
-    if (typeof statuses === 'string') statuses = statuses.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
-    var perStatusLimit = custom.perStatusLimit || custom.limit || 50;
-    var seen = {};
-    var runs = [];
+function fetchWorkflowRunsPage(custom, status, created, page) {
+    var raw = github_list_workflow_runs(
+        custom.workspace,
+        custom.repository,
+        status,
+        custom.workflowId || 'ai-teammate.yml',
+        custom.perStatusLimit || custom.limit || 100,
+        page,
+        created
+    );
+    var parsed = parseJson(raw, raw);
+    return {
+        total: parsed && typeof parsed.total_count === 'number' ? parsed.total_count : null,
+        runs: asArray(parsed)
+    };
+}
 
-    statuses.forEach(function(status) {
-        var raw = github_list_workflow_runs(workspace, repository, status, workflowId, perStatusLimit);
-        asArray(parseJson(raw, raw)).forEach(function(run) {
+function collectRunsForWindow(custom, status, startDay, endDay, seen, runs, depth) {
+    var created = startDay + '..' + endDay;
+    var firstPage = fetchWorkflowRunsPage(custom, status, created, 1);
+    var total = firstPage.total;
+    var windowMs = Date.parse(endDay) - Date.parse(startDay);
+
+    if (total != null && total >= 1000 && windowMs > 60000) {
+        var mid = midpointTime(startDay, endDay);
+        collectRunsForWindow(custom, status, startDay, mid, seen, runs, depth + 1);
+        collectRunsForWindow(custom, status, addMilliseconds(mid, 1000), endDay, seen, runs, depth + 1);
+        return;
+    }
+
+    var pageRuns = firstPage.runs;
+    var page = 1;
+    while (pageRuns.length) {
+        pageRuns.forEach(function(run) {
             var id = String(run.id || run.databaseId || '');
             if (!id || seen[id]) return;
             seen[id] = true;
             if (run.status && run.status !== 'completed') return;
             runs.push(run);
         });
+        if (custom.maxRuns && runs.length >= custom.maxRuns) return;
+        if (pageRuns.length < (custom.perStatusLimit || custom.limit || 100)) return;
+        page++;
+        if (page > (custom.maxPages || 100)) return;
+        pageRuns = fetchWorkflowRunsPage(custom, status, created, page).runs;
+    }
+}
+
+function listCompletedRuns(custom) {
+    var workspace = custom.workspace;
+    var repository = custom.repository;
+    var workflowId = custom.workflowId || 'ai-teammate.yml';
+    var statuses = custom.statuses || ['completed'];
+    if (typeof statuses === 'string') statuses = statuses.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
+    var perStatusLimit = custom.perStatusLimit || custom.limit || 100;
+    var maxPages = custom.maxPages || 100;
+    var seen = {};
+    var runs = [];
+
+    statuses.forEach(function(status) {
+        custom.perStatusLimit = perStatusLimit;
+        custom.maxPages = maxPages;
+        if (custom.created === false || custom.created === 'false') {
+            collectRunsForWindow(custom, status, '1970-01-01T00:00:00Z', toWindowEnd(todayIsoDay()), seen, runs, 0);
+        } else {
+            collectRunsForWindow(custom, status, toWindowStart(custom.createdStart || custom.since || '2020-01-01'), toWindowEnd(custom.createdEnd || todayIsoDay()), seen, runs, 0);
+        }
     });
 
     runs.sort(function(a, b) {
@@ -356,17 +430,21 @@ function action(params) {
     console.log('Found ' + runs.length + ' completed workflow run(s)');
 
     var rows = [];
+    var logEvery = custom.logEvery || 50;
+    var verbose = custom.verbose === true || custom.verbose === 'true';
     for (var i = 0; i < runs.length; i++) {
         var run = runs[i];
         var meta = extractAgentAndKey(run);
         var runId = String(run.id || run.databaseId);
-        console.log('  [' + (i + 1) + '/' + runs.length + '] ' + runId + ' ' + meta.title);
+        if (verbose || i === 0 || (i + 1) % logEvery === 0 || i === runs.length - 1) {
+            console.log('  [' + (i + 1) + '/' + runs.length + '] ' + runId + ' ' + meta.title);
+        }
 
         try {
             var logs = downloadRunLogs(custom, run);
             var usage = extractTokenUsage(logs);
             if (!usage) {
-                console.log('    no token summary found');
+                if (verbose) console.log('    no token summary found');
                 continue;
             }
 
@@ -392,7 +470,9 @@ function action(params) {
                 samples: usage.samples || 1,
                 url: run.html_url || run.htmlUrl || ''
             });
-            console.log('    tokens read=' + usage.readTokens + ' write=' + usage.writeTokens + ' cached=' + usage.cachedTokens + ' reasoning=' + usage.reasoningTokens);
+            if (verbose) {
+                console.log('    tokens read=' + usage.readTokens + ' write=' + usage.writeTokens + ' cached=' + usage.cachedTokens + ' reasoning=' + usage.reasoningTokens);
+            }
         } catch (e) {
             console.warn('    failed to process run ' + runId + ': ' + (e.message || e));
         }
@@ -417,6 +497,7 @@ if (typeof module !== 'undefined' && module.exports) {
         parseTokensLine: parseTokensLine,
         extractTokenUsage: extractTokenUsage,
         extractAgentAndKey: extractAgentAndKey,
+        listCompletedRuns: listCompletedRuns,
         buildCsv: buildCsv,
         buildSummary: buildSummary
     };

--- a/js/unit-tests/test_aiTeammateTokenUsageReporter.js
+++ b/js/unit-tests/test_aiTeammateTokenUsageReporter.js
@@ -2,16 +2,17 @@
  * Unit tests for aiTeammateTokenUsageReporter.js
  */
 
-function loadReporter() {
+function loadReporter(overrides) {
     var configLoaderMock = {
         loadProjectConfig: function() {
             return { repository: { owner: 'IstiN', repo: 'trackstate' } };
         }
     };
-    return loadModule('js/aiTeammateTokenUsageReporter.js', makeRequire({ './configLoader.js': configLoaderMock }), {
+    var globals = Object.assign({
         file_write: function() {},
         github_list_workflow_runs: function() { return JSON.stringify({ workflow_runs: [] }); }
-    });
+    }, overrides || {});
+    return loadModule('js/aiTeammateTokenUsageReporter.js', makeRequire({ './configLoader.js': configLoaderMock }), globals);
 }
 
 suite('aiTeammateTokenUsageReporter parsing', function() {
@@ -61,5 +62,40 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
         assert.equal(parsed.configFile, 'agents/bug_development.json');
         assert.equal(parsed.agent, 'bug_development');
         assert.equal(parsed.ticketKey, 'TS-1307');
+    });
+
+    test('lists completed workflow runs across MCP pages', function() {
+        var calls = [];
+        var reporter = loadReporter({
+            github_list_workflow_runs: function(workspace, repository, status, workflowId, perPage, page) {
+                calls.push({ workspace: workspace, repository: repository, status: status, workflowId: workflowId, perPage: perPage, page: page });
+                if (page === 1) {
+                    return JSON.stringify({ workflow_runs: [
+                        { id: 1, status: 'completed', created_at: '2026-06-01T00:00:00Z' },
+                        { id: 2, status: 'completed', created_at: '2026-05-31T00:00:00Z' }
+                    ] });
+                }
+                if (page === 2) {
+                    return JSON.stringify({ workflow_runs: [
+                        { id: 3, status: 'completed', created_at: '2026-05-30T00:00:00Z' }
+                    ] });
+                }
+                return JSON.stringify({ workflow_runs: [] });
+            }
+        });
+
+        var runs = reporter.listCompletedRuns({
+            workspace: 'IstiN',
+            repository: 'trackstate',
+            workflowId: 'ai-teammate.yml',
+            statuses: ['completed'],
+            perStatusLimit: 2,
+            maxPages: 10
+        });
+
+        assert.equal(runs.length, 3);
+        assert.equal(calls.length, 2);
+        assert.equal(calls[0].page, 1);
+        assert.equal(calls[1].page, 2);
     });
 });


### PR DESCRIPTION
Adds a JSRunner reporter for AI teammate token usage that paginates workflow runs across created-time windows, parses CommandLineUtils token summaries, and writes CSV/JSON/static HTML outputs.\n\nValidation:\n- dmtools run js/unit-tests/run_all.json --mini