### PR TITLE
Fix merge-base boolean checks

### DIFF
--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -71,6 +71,18 @@ function defaultWriteFile(path, content) {
     return file_write(path, content);
 }
 
+function quoteShellArgument(value) {
+    return "'" + String(value || '').replace(/'/g, "'\"'\"'") + "'";
+}
+
+function branchContainsBase(runCommand, workingDir, baseBranch) {
+    var command = 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' +
+        '; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi';
+    var output = cleanCommandOutput(runCommand('bash -lc ' + quoteShellArgument(command), workingDir) || '').trim();
+    var lines = output.split(/\r?\n/).map(function(line) { return line.trim(); }).filter(function(line) { return line; });
+    return lines[lines.length - 1] === 'ancestor';
+}
+
 function buildOriginFetchCommand(refSpec) {
     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
 }
@@ -100,13 +112,7 @@ function syncBranchWithBase(options) {
         console.log('Synchronizing ' + branchName + ' with origin/' + baseBranch + ' before publishing...');
         runCommand(buildOriginFetchCommand(baseBranch), workingDir);
 
-        var upToDate = false;
-        try {
-            runCommand('git merge-base --is-ancestor origin/' + baseBranch + ' HEAD', workingDir);
-            upToDate = true;
-        } catch (ancestorError) {
-            upToDate = false;
-        }
+        var upToDate = branchContainsBase(runCommand, workingDir, baseBranch);
         if (upToDate) {
             console.log('✅ Branch already contains origin/' + baseBranch);
             return { success: true, updated: false };

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -77,6 +77,10 @@ function quoteCommitMessage(message) {
         .trim() + '"';
 }
 
+function quoteShellArgument(value) {
+    return "'" + String(value || '').replace(/'/g, "'\"'\"'") + "'";
+}
+
 function resolveStashPopConflicts(run, cleanOutput, path) {
     var unmerged = cleanOutput(run('git -C ' + path + ' diff --name-only --diff-filter=U') || '')
         .split('\n')
@@ -104,13 +108,12 @@ function resolveStashPopConflicts(run, cleanOutput, path) {
     return cleanOutput(run('git -C ' + path + ' status --porcelain') || '');
 }
 
-function isAncestor(run, path, ancestor, descendant) {
-    try {
-        run('git -C ' + path + ' merge-base --is-ancestor ' + ancestor + ' ' + descendant);
-        return true;
-    } catch (e) {
-        return false;
-    }
+function isAncestor(run, cleanOutput, path, ancestor, descendant) {
+    var command = 'git -C ' + path + ' merge-base --is-ancestor ' + ancestor + ' ' + descendant +
+        '; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi';
+    var output = cleanOutput(run('bash -lc ' + quoteShellArgument(command)) || '').trim();
+    var lines = output.split(/\r?\n/).map(function(line) { return line.trim(); }).filter(function(line) { return line; });
+    return lines[lines.length - 1] === 'ancestor';
 }
 
 function prepareDirtySubmoduleBranch(run, cleanOutput, path, branch) {
@@ -182,8 +185,8 @@ function pushManagedSubmodules(options) {
 
         var hasDirtyChanges = !!status.trim();
         var remoteRef = 'origin/' + branch;
-        var localIncludedInRemote = isAncestor(run, path, 'HEAD', remoteRef);
-        var remoteIncludedInLocal = isAncestor(run, path, remoteRef, 'HEAD');
+        var localIncludedInRemote = isAncestor(run, cleanOutput, path, 'HEAD', remoteRef);
+        var remoteIncludedInLocal = isAncestor(run, cleanOutput, path, remoteRef, 'HEAD');
 
         if (!hasDirtyChanges && aheadCount === 0) {
             console.log('No managed submodule changes detected in', path);

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -115,7 +115,7 @@ suite('pullRequest helper', function() {
             workingDir: 'repo',
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
-                if (command.indexOf('git merge-base --is-ancestor') === 0) throw new Error('not ancestor');
+                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'not-ancestor';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -125,7 +125,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
-            { command: 'git merge-base --is-ancestor origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'bash -lc \'git merge-base --is-ancestor origin/main HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\'', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
@@ -140,7 +140,7 @@ suite('pullRequest helper', function() {
             baseBranch: 'release',
             runCommand: function(command) {
                 commands.push(command);
-                if (command.indexOf('git merge-base --is-ancestor') === 0) return 'up_to_date';
+                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'ancestor';
                 return '';
             }
         });
@@ -149,7 +149,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, false);
         assert.deepEqual(commands, [
             'git -c fetch.recurseSubmodules=no fetch origin release',
-            'git merge-base --is-ancestor origin/release HEAD'
+            'bash -lc \'git merge-base --is-ancestor origin/release HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\''
         ]);
     });
 
@@ -163,7 +163,7 @@ suite('pullRequest helper', function() {
             workingDir: 'repo',
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
-                if (command.indexOf('git merge-base --is-ancestor') === 0) throw new Error('not ancestor');
+                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'not-ancestor';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -173,7 +173,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
-            { command: 'git merge-base --is-ancestor origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'bash -lc \'git merge-base --is-ancestor origin/main HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\'', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -92,8 +92,11 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
                     return '2';
                 }
-                if (command === 'git -C trackstate-setup merge-base --is-ancestor HEAD origin/main') {
-                    throw new Error('local ahead of remote');
+                if (command.indexOf('merge-base --is-ancestor HEAD origin/main') !== -1) {
+                    return 'not-ancestor';
+                }
+                if (command.indexOf('merge-base --is-ancestor origin/main HEAD') !== -1) {
+                    return 'ancestor';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
                     return '2b4b84712bfa';
@@ -127,8 +130,11 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
                     return '2';
                 }
-                if (command === 'git -C trackstate-setup merge-base --is-ancestor HEAD origin/main') {
-                    throw new Error('local ahead of remote');
+                if (command.indexOf('merge-base --is-ancestor HEAD origin/main') !== -1) {
+                    return 'not-ancestor';
+                }
+                if (command.indexOf('merge-base --is-ancestor origin/main HEAD') !== -1) {
+                    return 'ancestor';
                 }
                 return '';
             }


### PR DESCRIPTION
Suppress noisy DMTools Java stack traces for expected git merge-base --is-ancestor exit code 1. The helpers now map normal ancestor/not-ancestor results to explicit output while preserving failures for real git errors.

Validation: dmtools run js/unit-tests/run_all.json --mini (332 passed, 0 failed).