### PR TITLE
Guard interrupted rework outputs

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -323,6 +323,41 @@ function postJiraComment(ticketKey, prUrl, branchName, prCommentPosted, codeChan
     }
 }
 
+function isInterruptedReworkResponse(response) {
+    var text = String(response || '');
+    return text.indexOf('CLI command executed but did not produce output file') !== -1 ||
+        text.indexOf('Command failed (exit code 124)') !== -1 ||
+        text.indexOf('Copilot command timed out') !== -1 ||
+        text.indexOf('outputs/response.md missing') !== -1 ||
+        text.indexOf('"path":"interrupted"') !== -1 ||
+        text.indexOf('"path": "interrupted"') !== -1;
+}
+
+function handleInterruptedRework(ticketKey, branchName, customParams, statuses) {
+    console.warn('Rework CLI was interrupted before writing required outputs; leaving PR conversations open and resetting ticket for retry.');
+    try {
+        jira_post_comment({
+            key: ticketKey,
+            comment: 'h3. ⏸️ Rework Interrupted\n\nThe AI agent pushed any staged partial changes, but it was interrupted before writing {code}outputs/response.md{code} and {code}outputs/review_replies.json{code}. PR conversations were left open. The ticket was moved back to *' + statuses.IN_REWORK + '* for retry.\n\n*Branch*: {code}' + branchName + '{code}'
+        });
+    } catch (e) {
+        console.warn('Failed to post interrupted rework Jira comment:', e.message || e);
+    }
+    try {
+        jira_move_to_status({ key: ticketKey, statusName: statuses.IN_REWORK });
+        console.log('✅ Moved', ticketKey, 'back to', statuses.IN_REWORK, 'for retry');
+    } catch (e) {
+        console.warn('Failed to move ticket back to ' + statuses.IN_REWORK + ':', e.message || e);
+    }
+    removeConfiguredLabels(ticketKey, customParams || {});
+    return {
+        success: true,
+        path: 'rework-interrupted',
+        ticketKey: ticketKey,
+        branchName: branchName
+    };
+}
+
 function action(params) {
     try {
         const actualParams = params.ticket ? params : (params.jobParams || params);
@@ -402,6 +437,10 @@ function action(params) {
                 });
             } catch (e) {}
             return { success: false, error: gateError };
+        }
+
+        if (isInterruptedReworkResponse(fixSummary)) {
+            return handleInterruptedRework(ticketKey, branchName, _customParams, statuses);
         }
 
         // Find PR to post comment — prefer targetRepository from config over git remote
@@ -545,5 +584,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, resolveCustomParams };
+    module.exports = { action, resolveCustomParams, isInterruptedReworkResponse };
 }

--- a/js/unit-tests/test_reworkCustomParams.js
+++ b/js/unit-tests/test_reworkCustomParams.js
@@ -19,6 +19,63 @@ function loadPushReworkChanges() {
     );
 }
 
+function loadPushReworkChangesForAction(mocks) {
+    mocks = mocks || {};
+    return loadModule(
+        'js/pushReworkChanges.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': configLoaderModule,
+            './common/scm.js': {
+                createScm: function() {
+                    return {
+                        getRemoteRepoInfo: function() { return { owner: 'IstiN', repo: 'trackstate' }; },
+                        listPrs: function() { return [{ number: 1571, title: 'TS-1293 Fix', html_url: 'https://github.com/IstiN/trackstate/pull/1571', head: { ref: 'ai/TS-1293' } }]; },
+                        addComment: function() { mocks.prComments = (mocks.prComments || 0) + 1; },
+                        replyToThread: function() { mocks.threadReplies = (mocks.threadReplies || 0) + 1; },
+                        resolveThread: function() { mocks.resolvedThreads = (mocks.resolvedThreads || 0) + 1; }
+                    };
+                }
+            },
+            './common/submodules.js': { pushManagedSubmodules: function() {} },
+            './common/pullRequest.js': {
+                readStagedDiffStat: function() { return 'lib/app.dart | 1 +'; },
+                syncBranchWithBase: function() { return { success: true }; }
+            },
+            './common/feedbackLoop.js': {
+                runQualityGates: function() { return { success: true }; },
+                runPolicyGates: function() { return { success: true }; },
+                runPostPublishGates: function() { return { success: true }; },
+                resumeAgent: function() { return { attempted: false }; }
+            },
+            './common/autoStart.js': {
+                triggerConfiguredWorkflowForTicket: function() { mocks.autoStartReview = true; return true; },
+                triggerSmIfIdle: function() { mocks.triggerSm = true; return true; }
+            },
+            './cacheToReleases.js': { action: function() {} }
+        }),
+        {
+            file_read: function(args) {
+                if (args.path === 'input/TS-1293/pr_info.md') {
+                    return '**Branch**: `ai/TS-1293` → `main`';
+                }
+                throw new Error('missing ' + args.path);
+            },
+            cli_execute_command: function(args) {
+                mocks.commands = mocks.commands || [];
+                mocks.commands.push(args.command);
+                if (args.command === 'git branch --show-current') return 'ai/TS-1293';
+                if (args.command.indexOf('git ls-remote --heads origin ai/TS-1293') === 0) return 'abc123\trefs/heads/ai/TS-1293';
+                return '';
+            },
+            jira_post_comment: function(args) { mocks.jiraComments = (mocks.jiraComments || []).concat([args.comment]); },
+            jira_move_to_status: function(args) { mocks.moves = (mocks.moves || []).concat([args.statusName]); },
+            jira_remove_label: function(args) { mocks.removedLabels = (mocks.removedLabels || []).concat([args.label]); },
+            jira_assign_ticket_to: function() {}
+        }
+    );
+}
+
 function loadPostTestReworkResults() {
     return loadModule(
         'js/postTestReworkResults.js',
@@ -64,6 +121,40 @@ suite('rework custom params', function() {
         assert.equal(customParams.autoStartReviewConfigFile, 'agents/pr_review.json');
         assert.equal(customParams.removeLabel, 'sm_story_rework_triggered');
         assert.deepEqual(customParams.targetRepository, { owner: 'IstiN', repo: 'trackstate' });
+    });
+
+    test('detects interrupted pr_rework responses', function() {
+        var mod = loadPushReworkChanges();
+
+        assert.equal(mod.isInterruptedReworkResponse('CLI command executed but did not produce output file'), true);
+        assert.equal(mod.isInterruptedReworkResponse('Command failed (exit code 124): ./agents/scripts/run-agent.sh'), true);
+        assert.equal(mod.isInterruptedReworkResponse('Implemented fix and wrote outputs/response.md'), false);
+    });
+
+    test('interrupted pr_rework keeps PR conversations open and resets ticket for retry', function() {
+        var mocks = {};
+        var mod = loadPushReworkChangesForAction(mocks);
+
+        var result = mod.action({
+            jobParams: {
+                ticket: { key: 'TS-1293', fields: { labels: [] } },
+                response: 'CLI command executed but did not produce output file:\nCommand failed (exit code 124): ./agents/scripts/run-agent.sh',
+                customParams: {
+                    removeLabels: ['sm_story_rework_triggered'],
+                    autoStartReview: true,
+                    autoStartReviewConfigFile: 'agents/pr_review.json'
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'rework-interrupted');
+        assert.deepEqual(mocks.moves, ['In Rework']);
+        assert.deepEqual(mocks.removedLabels, ['sm_story_rework_triggered']);
+        assert.equal(mocks.prComments || 0, 0, 'must not post Rework Complete PR comment');
+        assert.equal(mocks.threadReplies || 0, 0, 'must not reply to conversations without review_replies.json');
+        assert.equal(mocks.resolvedThreads || 0, 0, 'must not resolve conversations without review_replies.json');
+        assert.equal(!!mocks.autoStartReview, false, 'must not start review after interrupted rework');
     });
 
     test('merges pr_test_automation_rework jobParamPatches into runtime customParams', function() {


### PR DESCRIPTION
Treat interrupted pr_rework output as incomplete instead of successful rework. If the CLI times out before writing outputs/response.md or outputs/review_replies.json, the post-action leaves PR conversations open, moves the ticket back to In Rework, removes the SM label for retry, and skips auto-starting review.

Validation: dmtools run js/unit-tests/run_all.json --mini (334 passed, 0 failed).