### PR TITLE
Remove copilot timeout guard

### DIFF
--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -167,7 +167,6 @@ elif [ "$PROVIDER" = "copilot" ]; then
 
   echo "Copilot Configuration:"
   echo "  Model: ${COPILOT_MODEL:-gpt-5-mini}"
-  echo "  Command timeout: ${COPILOT_COMMAND_TIMEOUT_SECONDS:-1200}s"
   echo "Working directory: $(pwd)"
   echo ""
 
@@ -182,36 +181,16 @@ elif [ "$PROVIDER" = "copilot" ]; then
   fi
   run_copilot_once() {
     local log_file="$1"
-    local timeout_seconds="${COPILOT_COMMAND_TIMEOUT_SECONDS:-1200}"
-    local timeout_cmd=()
-
-    if command -v timeout >/dev/null 2>&1 && [ "${timeout_seconds}" -gt 0 ] 2>/dev/null; then
-      timeout_cmd=(timeout "${timeout_seconds}s")
-    fi
 
     set +e
     if [ -f "${PROMPT_ARG}" ]; then
       echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} (prompt: ${PROMPT_BYTES} bytes via stdin)"
-      if [ "${#timeout_cmd[@]}" -gt 0 ]; then
-        echo "Timeout guard: ${timeout_seconds}s"
-      fi
       echo ""
-      if [ "${#timeout_cmd[@]}" -gt 0 ]; then
-        "${timeout_cmd[@]}" "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
-      else
-        "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
-      fi
+      "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
     else
       echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${COPILOT_MODEL:-gpt-5-mini} ${PASS_ARGS[*]:-} -p <inline prompt>"
-      if [ "${#timeout_cmd[@]}" -gt 0 ]; then
-        echo "Timeout guard: ${timeout_seconds}s"
-      fi
       echo ""
-      if [ "${#timeout_cmd[@]}" -gt 0 ]; then
-        "${timeout_cmd[@]}" "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
-      else
-        "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
-      fi
+      "${COPILOT_CMD[@]}" --allow-all --model "${COPILOT_MODEL:-gpt-5-mini}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
     fi
     local status=${PIPESTATUS[0]}
     return "$status"
@@ -230,14 +209,6 @@ elif [ "$PROVIDER" = "copilot" ]; then
     set -e
 
     if [ "$exit_code" -eq 0 ]; then
-      record_codegraph_usage "$copilot_log"
-      rm -f "$copilot_log"
-      break
-    fi
-
-    if [ "$exit_code" -eq 124 ]; then
-      echo ""
-      echo "Copilot command timed out after ${COPILOT_COMMAND_TIMEOUT_SECONDS:-1200}s; exiting so DMTools post-action can recover/reset the ticket."
       record_codegraph_usage "$copilot_log"
       rm -f "$copilot_log"
       break


### PR DESCRIPTION
Remove the repository-owned timeout wrapper around Copilot execution in agents/scripts/run-agent.sh. The script now invokes copilot directly and no longer enforces COPILOT_COMMAND_TIMEOUT_SECONDS / timeout 1200s.

Validation: bash -n agents/scripts/run-agent.sh; dmtools run js/unit-tests/run_all.json --mini (334 passed, 0 failed).