### PR TITLE
fix: report token loop failures and chart tooltips

### DIFF
--- a/js/aiTeammateTokenUsageReporter.js
+++ b/js/aiTeammateTokenUsageReporter.js
@@ -70,15 +70,33 @@ function extractTokenUsage(logs) {
     var samples = [];
     var resumeDetected = false;
     var resumeStages = [];
+    var feedbackLoopCount = 0;
+    var rateLimitRetryCount = 0;
+    var rateLimitDetected = false;
+    var timeoutCount = 0;
 
     for (var i = 0; i < lines.length; i++) {
         var line = String(lines[i] || '');
+        var lower = line.toLowerCase();
         var resumeMatch = line.match(/Feedback loop: resuming agent for\s+(.+?)\s+attempt\s+([0-9]+)\/([0-9]+)/);
         if (resumeMatch) {
             resumeDetected = true;
+            feedbackLoopCount += 1;
             resumeStages.push((resumeMatch[1] || 'resume') + ' ' + resumeMatch[2] + '/' + resumeMatch[3]);
         } else if (line.indexOf('--resume') !== -1 || line.indexOf('--continue --resume') !== -1) {
             resumeDetected = true;
+        }
+        if (/Copilot rate limit detected; retrying/i.test(line)) {
+            rateLimitRetryCount += 1;
+            rateLimitDetected = true;
+        } else if (/rate limit|limit reset|You've hit your rate limit/i.test(line)) {
+            rateLimitDetected = true;
+        }
+        if (lower.indexOf('exit code 124') !== -1 ||
+            lower.indexOf('timed out') !== -1 ||
+            lower.indexOf('command timeout') !== -1 ||
+            lower.indexOf('timeout guard') !== -1) {
+            timeoutCount += 1;
         }
 
         var request = parseRequestsLine(lines[i]);
@@ -106,6 +124,10 @@ function extractTokenUsage(logs) {
         samples: samples.length,
         resumeDetected: resumeDetected || samples.length > 1,
         resumeStages: resumeStages,
+        feedbackLoopCount: feedbackLoopCount,
+        rateLimitRetryCount: rateLimitRetryCount,
+        rateLimitDetected: rateLimitDetected,
+        timeoutCount: timeoutCount,
         attempts: samples
     };
     samples.forEach(function(sample) {
@@ -193,7 +215,9 @@ function buildCsv(rows) {
         'conclusion', 'agent', 'ticketKey', 'configFile', 'title',
         'requests', 'requestTier', 'requestDuration',
         'readTokens', 'writeTokens', 'cachedTokens', 'reasoningTokens',
-        'samples', 'resumeDetected', 'resumeStages', 'url'
+        'samples', 'resumeDetected', 'resumeStages',
+        'feedbackLoopCount', 'rateLimitRetryCount', 'rateLimitDetected', 'timeoutCount',
+        'url'
     ];
     var out = [headers.join(',')];
     rows.forEach(function(row) {
@@ -206,6 +230,7 @@ function buildAttemptsCsv(attemptRows) {
     var headers = [
         'runId', 'runNumber', 'createdAt', 'day', 'conclusion',
         'agent', 'ticketKey', 'attemptIndex', 'resumeDetected',
+        'feedbackLoopCount', 'rateLimitRetryCount', 'rateLimitDetected', 'timeoutCount',
         'requests', 'requestTier', 'requestDuration',
         'readTokens', 'writeTokens', 'cachedTokens', 'reasoningTokens',
         'rawTokensLine', 'url'
@@ -231,7 +256,12 @@ function groupBy(rows, keyFn) {
                 cachedTokens: 0,
                 reasoningTokens: 0,
                 samples: 0,
-                resumedRuns: 0
+                resumedRuns: 0,
+                feedbackLoopCount: 0,
+                rateLimitRetryCount: 0,
+                rateLimitRuns: 0,
+                timeoutCount: 0,
+                timeoutRuns: 0
             };
         }
         var bucket = map[key];
@@ -243,6 +273,11 @@ function groupBy(rows, keyFn) {
         bucket.reasoningTokens += row.reasoningTokens || 0;
         bucket.samples += row.samples || 0;
         if (row.resumeDetected) bucket.resumedRuns += 1;
+        bucket.feedbackLoopCount += row.feedbackLoopCount || 0;
+        bucket.rateLimitRetryCount += row.rateLimitRetryCount || 0;
+        if (row.rateLimitDetected) bucket.rateLimitRuns += 1;
+        bucket.timeoutCount += row.timeoutCount || 0;
+        if (row.timeoutCount) bucket.timeoutRuns += 1;
     });
     return Object.keys(map).sort().map(function(key) {
         var item = map[key];
@@ -290,17 +325,20 @@ function buildHtml(rows, summary) {
         ':root{color-scheme:light;--bg:#f6f7f9;--panel:#fff;--ink:#18202a;--muted:#5f6b7a;--grid:#e1e5ea;--blue:#2563eb;--green:#059669;--amber:#b7791f;--red:#dc2626;--violet:#7c3aed}' +
         '*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.45 -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}' +
         'header{padding:24px 28px 12px}h1{margin:0 0 6px;font-size:26px;letter-spacing:0}p{margin:0;color:var(--muted)}' +
-        '.wrap{padding:12px 28px 32px;display:grid;gap:16px}.kpis{display:grid;grid-template-columns:repeat(7,minmax(120px,1fr));gap:12px}' +
+        '.wrap{padding:12px 28px 32px;display:grid;gap:16px}.kpis{display:grid;grid-template-columns:repeat(10,minmax(110px,1fr));gap:12px}' +
         '.kpi,.panel{background:var(--panel);border:1px solid var(--grid);border-radius:8px;box-shadow:0 1px 2px rgba(0,0,0,.04)}.kpi{padding:14px}.kpi b{display:block;font-size:22px;margin-top:4px}.kpi span{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}' +
         '.grid{display:grid;grid-template-columns:1.4fr 1fr;gap:16px}.panel{padding:16px}.panel h2{font-size:16px;margin:0 0 12px}.chart{width:100%;height:340px;display:block}.pie{height:300px}' +
         'table{width:100%;border-collapse:collapse}th,td{padding:8px 10px;border-bottom:1px solid var(--grid);text-align:left;white-space:nowrap}th{font-size:12px;color:var(--muted);font-weight:600}th.sortable{cursor:pointer;user-select:none}th.sortable:after{content:"";display:inline-block;margin-left:5px;border-left:4px solid transparent;border-right:4px solid transparent;border-top:5px solid #9aa4b2;vertical-align:middle}th.sortable.desc:after{border-top:0;border-bottom:5px solid #9aa4b2}td.num{text-align:right;font-variant-numeric:tabular-nums}.scroll{overflow:auto;max-height:520px}' +
-        '.legend{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px;color:var(--muted);font-size:12px}.dot{width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:5px}' +
+        '.legend{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px;color:var(--muted);font-size:12px}.dot{width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:5px}.tooltip{position:fixed;z-index:10;display:none;max-width:260px;padding:8px 10px;border:1px solid #cfd6df;border-radius:6px;background:#111827;color:#fff;font-size:12px;line-height:1.4;box-shadow:0 8px 20px rgba(0,0,0,.18);pointer-events:none;white-space:pre-line}' +
         '@media(max-width:900px){.kpis,.grid{grid-template-columns:1fr}.wrap,header{padding-left:16px;padding-right:16px}}\n' +
         '</style>\n</head>\n<body>\n<header><h1>AI Teammate Token Usage</h1><p>Generated ' + htmlEscape(summary.generatedAt) + ' from completed workflow logs.</p></header>\n' +
         '<main class="wrap">\n<section class="kpis">' +
         '<div class="kpi"><span>Runs Parsed</span><b>' + summary.runsWithTokens + '</b></div>' +
         '<div class="kpi"><span>Attempts</span><b>' + summary.totals.samples + '</b></div>' +
         '<div class="kpi"><span>Resume Runs</span><b>' + summary.totals.resumedRuns + '</b></div>' +
+        '<div class="kpi"><span>Loops</span><b>' + summary.totals.feedbackLoopCount + '</b></div>' +
+        '<div class="kpi"><span>Limit Retries</span><b>' + summary.totals.rateLimitRetryCount + '</b></div>' +
+        '<div class="kpi"><span>Timeouts</span><b>' + summary.totals.timeoutCount + '</b></div>' +
         '<div class="kpi"><span>Read Tokens</span><b>' + formatShort(summary.totals.readTokens) + '</b></div>' +
         '<div class="kpi"><span>Write Tokens</span><b>' + formatShort(summary.totals.writeTokens) + '</b></div>' +
         '<div class="kpi"><span>Cached Tokens</span><b>' + formatShort(summary.totals.cachedTokens) + '</b></div>' +
@@ -309,25 +347,27 @@ function buildHtml(rows, summary) {
         '<div class="panel"><h2>Tokens By Agent</h2><canvas id="agents" class="chart"></canvas></div></section>\n' +
         '<section class="grid"><div class="panel"><h2>Agent Token Share</h2><canvas id="agentPie" class="chart pie"></canvas><div id="agentPieLegend" class="legend"></div></div>' +
         '<div class="panel"><h2>Token Type Share</h2><canvas id="tokenPie" class="chart pie"></canvas><div id="tokenPieLegend" class="legend"></div></div></section>\n' +
-        '<section class="panel"><h2>Agent Totals And Averages</h2><div class="scroll"><table id="agentTable"><thead><tr><th class="sortable" data-type="text">Agent</th><th class="sortable" data-type="number">Runs</th><th class="sortable" data-type="number">Attempts</th><th class="sortable" data-type="number">Resume Runs</th><th class="sortable" data-type="number">Read</th><th class="sortable" data-type="number">Avg Read</th><th class="sortable" data-type="number">Write</th><th class="sortable" data-type="number">Avg Write</th><th class="sortable" data-type="number">Cached</th><th class="sortable" data-type="number">Reasoning</th></tr></thead><tbody>' +
+        '<section class="panel"><h2>Agent Totals And Averages</h2><div class="scroll"><table id="agentTable"><thead><tr><th class="sortable" data-type="text">Agent</th><th class="sortable" data-type="number">Runs</th><th class="sortable" data-type="number">Attempts</th><th class="sortable" data-type="number">Resume Runs</th><th class="sortable" data-type="number">Loops</th><th class="sortable" data-type="number">Limit Retries</th><th class="sortable" data-type="number">Timeouts</th><th class="sortable" data-type="number">Read</th><th class="sortable" data-type="number">Avg Read</th><th class="sortable" data-type="number">Write</th><th class="sortable" data-type="number">Avg Write</th><th class="sortable" data-type="number">Cached</th><th class="sortable" data-type="number">Reasoning</th></tr></thead><tbody>' +
         topAgents.map(function(a) {
-            return '<tr><td' + sortAttr(a.key) + '>' + htmlEscape(a.key) + '</td><td class="num"' + sortAttr(a.runs) + '>' + a.runs + '</td><td class="num"' + sortAttr(a.samples) + '>' + a.samples + '</td><td class="num"' + sortAttr(a.resumedRuns) + '>' + a.resumedRuns + '</td><td class="num"' + sortAttr(a.readTokens) + '>' + formatShort(a.readTokens) + '</td><td class="num"' + sortAttr(a.avgReadTokens) + '>' + formatShort(a.avgReadTokens) + '</td><td class="num"' + sortAttr(a.writeTokens) + '>' + formatShort(a.writeTokens) + '</td><td class="num"' + sortAttr(a.avgWriteTokens) + '>' + formatShort(a.avgWriteTokens) + '</td><td class="num"' + sortAttr(a.cachedTokens) + '>' + formatShort(a.cachedTokens) + '</td><td class="num"' + sortAttr(a.reasoningTokens) + '>' + formatShort(a.reasoningTokens) + '</td></tr>';
+            return '<tr><td' + sortAttr(a.key) + '>' + htmlEscape(a.key) + '</td><td class="num"' + sortAttr(a.runs) + '>' + a.runs + '</td><td class="num"' + sortAttr(a.samples) + '>' + a.samples + '</td><td class="num"' + sortAttr(a.resumedRuns) + '>' + a.resumedRuns + '</td><td class="num"' + sortAttr(a.feedbackLoopCount) + '>' + a.feedbackLoopCount + '</td><td class="num"' + sortAttr(a.rateLimitRetryCount) + '>' + a.rateLimitRetryCount + '</td><td class="num"' + sortAttr(a.timeoutCount) + '>' + a.timeoutCount + '</td><td class="num"' + sortAttr(a.readTokens) + '>' + formatShort(a.readTokens) + '</td><td class="num"' + sortAttr(a.avgReadTokens) + '>' + formatShort(a.avgReadTokens) + '</td><td class="num"' + sortAttr(a.writeTokens) + '>' + formatShort(a.writeTokens) + '</td><td class="num"' + sortAttr(a.avgWriteTokens) + '>' + formatShort(a.avgWriteTokens) + '</td><td class="num"' + sortAttr(a.cachedTokens) + '>' + formatShort(a.cachedTokens) + '</td><td class="num"' + sortAttr(a.reasoningTokens) + '>' + formatShort(a.reasoningTokens) + '</td></tr>';
         }).join('') +
         '</tbody></table></div></section>\n' +
-        '<section class="panel"><h2>Recent Runs</h2><div class="scroll"><table id="runsTable"><thead><tr><th class="sortable" data-type="text">Created</th><th class="sortable" data-type="text">Agent</th><th class="sortable" data-type="text">Key</th><th class="sortable" data-type="text">Conclusion</th><th class="sortable" data-type="number">Attempts</th><th class="sortable" data-type="text">Resume</th><th class="sortable" data-type="number">Read</th><th class="sortable" data-type="number">Write</th><th class="sortable" data-type="number">Cached</th><th class="sortable" data-type="number">Reasoning</th><th class="sortable" data-type="number">Run</th></tr></thead><tbody>' +
+        '<section class="panel"><h2>Recent Runs</h2><div class="scroll"><table id="runsTable"><thead><tr><th class="sortable" data-type="text">Created</th><th class="sortable" data-type="text">Agent</th><th class="sortable" data-type="text">Key</th><th class="sortable" data-type="text">Conclusion</th><th class="sortable" data-type="number">Attempts</th><th class="sortable" data-type="text">Resume</th><th class="sortable" data-type="number">Loops</th><th class="sortable" data-type="number">Limit Retries</th><th class="sortable" data-type="number">Timeouts</th><th class="sortable" data-type="number">Read</th><th class="sortable" data-type="number">Write</th><th class="sortable" data-type="number">Cached</th><th class="sortable" data-type="number">Reasoning</th><th class="sortable" data-type="number">Run</th></tr></thead><tbody>' +
         recentRows.map(function(r) {
-            return '<tr><td' + sortAttr(r.createdAt) + '>' + htmlEscape(r.createdAt) + '</td><td' + sortAttr(r.agent) + '>' + htmlEscape(r.agent) + '</td><td' + sortAttr(r.ticketKey) + '>' + htmlEscape(r.ticketKey) + '</td><td' + sortAttr(r.conclusion) + '>' + htmlEscape(r.conclusion) + '</td><td class="num"' + sortAttr(r.samples) + '>' + htmlEscape(r.samples || 1) + '</td><td' + sortAttr(r.resumeDetected ? 'yes' : 'no') + '>' + (r.resumeDetected ? 'yes' : 'no') + '</td><td class="num"' + sortAttr(r.readTokens) + '>' + formatShort(r.readTokens) + '</td><td class="num"' + sortAttr(r.writeTokens) + '>' + formatShort(r.writeTokens) + '</td><td class="num"' + sortAttr(r.cachedTokens) + '>' + formatShort(r.cachedTokens) + '</td><td class="num"' + sortAttr(r.reasoningTokens) + '>' + formatShort(r.reasoningTokens) + '</td><td' + sortAttr(r.runNumber) + '><a href="' + htmlEscape(r.url) + '">#' + htmlEscape(r.runNumber) + '</a></td></tr>';
+            return '<tr><td' + sortAttr(r.createdAt) + '>' + htmlEscape(r.createdAt) + '</td><td' + sortAttr(r.agent) + '>' + htmlEscape(r.agent) + '</td><td' + sortAttr(r.ticketKey) + '>' + htmlEscape(r.ticketKey) + '</td><td' + sortAttr(r.conclusion) + '>' + htmlEscape(r.conclusion) + '</td><td class="num"' + sortAttr(r.samples) + '>' + htmlEscape(r.samples || 1) + '</td><td' + sortAttr(r.resumeDetected ? 'yes' : 'no') + '>' + (r.resumeDetected ? 'yes' : 'no') + '</td><td class="num"' + sortAttr(r.feedbackLoopCount) + '>' + (r.feedbackLoopCount || 0) + '</td><td class="num"' + sortAttr(r.rateLimitRetryCount) + '>' + (r.rateLimitRetryCount || 0) + '</td><td class="num"' + sortAttr(r.timeoutCount) + '>' + (r.timeoutCount || 0) + '</td><td class="num"' + sortAttr(r.readTokens) + '>' + formatShort(r.readTokens) + '</td><td class="num"' + sortAttr(r.writeTokens) + '>' + formatShort(r.writeTokens) + '</td><td class="num"' + sortAttr(r.cachedTokens) + '>' + formatShort(r.cachedTokens) + '</td><td class="num"' + sortAttr(r.reasoningTokens) + '>' + formatShort(r.reasoningTokens) + '</td><td' + sortAttr(r.runNumber) + '><a href="' + htmlEscape(r.url) + '">#' + htmlEscape(r.runNumber) + '</a></td></tr>';
         }).join('') +
-        '</tbody></table></div></section>\n</main>\n<script>const DATA=' + payload.replace(/</g, '\\u003c') + ';\n' +
+        '</tbody></table></div></section>\n</main><div id="chartTooltip" class="tooltip"></div>\n<script>const DATA=' + payload.replace(/</g, '\\u003c') + ';\n' +
         'function short(v){v=v||0;if(v>=1e9)return(v/1e9).toFixed(1).replace(/\\.0$/,"")+"b";if(v>=1e6)return(v/1e6).toFixed(1).replace(/\\.0$/,"")+"m";if(v>=1e3)return(v/1e3).toFixed(1).replace(/\\.0$/,"")+"k";return String(v)}' +
         'function labelLines(label,mode){let text=String(label||"");if(mode==="date")text=text.slice(5);if(mode==="agent"){const chunks=text.split("_");const lines=[];let line="";chunks.forEach(part=>{const next=line?line+"_"+part:part;if(next.length>14&&line){lines.push(line);line=part}else line=next});if(line)lines.push(line);return lines.slice(0,4)}return [text]}' +
-        'function drawBars(id, labels, series, options){options=options||{};const c=document.getElementById(id),ctx=c.getContext("2d"),dpr=devicePixelRatio||1,w=c.clientWidth,h=c.clientHeight;c.width=w*dpr;c.height=h*dpr;ctx.scale(dpr,dpr);ctx.clearRect(0,0,w,h);const pad={l:54,r:18,t:12,b:options.bottom||82};const max=Math.max(1,...series.flatMap(s=>s.values));ctx.strokeStyle="#e1e5ea";ctx.fillStyle="#5f6b7a";ctx.font="12px -apple-system,Segoe UI,sans-serif";for(let i=0;i<=4;i++){let y=pad.t+(h-pad.t-pad.b)*i/4;ctx.beginPath();ctx.moveTo(pad.l,y);ctx.lineTo(w-pad.r,y);ctx.stroke();ctx.fillText(short(max*(1-i/4)),6,y+4)}const groupW=(w-pad.l-pad.r)/Math.max(1,labels.length),barW=Math.max(3,Math.min(18,groupW/(series.length+1)));labels.forEach((lab,i)=>{series.forEach((s,j)=>{let val=s.values[i]||0,bh=(h-pad.t-pad.b)*val/max,x=pad.l+i*groupW+(groupW-series.length*barW)/2+j*barW,y=h-pad.b-bh;ctx.fillStyle=s.color;ctx.fillRect(x,y,barW*.75,bh)});const lines=labelLines(lab,options.labelMode);ctx.fillStyle="#5f6b7a";ctx.textAlign="center";ctx.textBaseline="top";lines.forEach((line,k)=>ctx.fillText(line,pad.l+i*groupW+groupW/2,h-pad.b+10+k*13,Math.max(28,groupW-4)));ctx.textAlign="left";ctx.textBaseline="alphabetic"})}' +
-        'function drawPie(id,legendId,items){const c=document.getElementById(id),ctx=c.getContext("2d"),dpr=devicePixelRatio||1,w=c.clientWidth,h=c.clientHeight;c.width=w*dpr;c.height=h*dpr;ctx.scale(dpr,dpr);ctx.clearRect(0,0,w,h);const total=items.reduce((s,x)=>s+x.value,0)||1,cx=w/2,cy=h/2,r=Math.min(w,h)*.34;let a=-Math.PI/2;items.forEach(x=>{const span=x.value/total*Math.PI*2;ctx.beginPath();ctx.moveTo(cx,cy);ctx.arc(cx,cy,r,a,a+span);ctx.closePath();ctx.fillStyle=x.color;ctx.fill();a+=span});const el=document.getElementById(legendId);el.innerHTML=items.map(x=>"<span><i class=\\"dot\\" style=\\"background:"+x.color+"\\"></i>"+x.label+" "+short(x.value)+"</span>").join("")}' +
+        'function tip(){return document.getElementById("chartTooltip")}function showTip(ev,text){const t=tip();if(!t)return;t.textContent=text;t.style.display="block";const x=Math.min(innerWidth-280,ev.clientX+14),y=Math.min(innerHeight-120,ev.clientY+14);t.style.left=Math.max(8,x)+"px";t.style.top=Math.max(8,y)+"px"}function hideTip(){const t=tip();if(t)t.style.display="none"}' +
+        'function bindTooltip(c,items){c._items=items;c.onmousemove=e=>{const r=c.getBoundingClientRect(),x=e.clientX-r.left,y=e.clientY-r.top,hit=(c._items||[]).find(it=>x>=it.x&&x<=it.x+it.w&&y>=it.y&&y<=it.y+it.h);if(hit)showTip(e,hit.text);else hideTip()};c.onmouseleave=hideTip}' +
+        'function drawBars(id, labels, series, options){options=options||{};const c=document.getElementById(id),ctx=c.getContext("2d"),dpr=devicePixelRatio||1,w=c.clientWidth,h=c.clientHeight,items=[];c.width=w*dpr;c.height=h*dpr;ctx.scale(dpr,dpr);ctx.clearRect(0,0,w,h);const pad={l:54,r:18,t:12,b:options.bottom||82};const max=Math.max(1,...series.flatMap(s=>s.values));ctx.strokeStyle="#e1e5ea";ctx.fillStyle="#5f6b7a";ctx.font="12px -apple-system,Segoe UI,sans-serif";for(let i=0;i<=4;i++){let y=pad.t+(h-pad.t-pad.b)*i/4;ctx.beginPath();ctx.moveTo(pad.l,y);ctx.lineTo(w-pad.r,y);ctx.stroke();ctx.fillText(short(max*(1-i/4)),6,y+4)}const groupW=(w-pad.l-pad.r)/Math.max(1,labels.length),barW=Math.max(3,Math.min(18,groupW/(series.length+1)));labels.forEach((lab,i)=>{series.forEach((s,j)=>{let val=s.values[i]||0,bh=(h-pad.t-pad.b)*val/max,x=pad.l+i*groupW+(groupW-series.length*barW)/2+j*barW,y=h-pad.b-bh;ctx.fillStyle=s.color;ctx.fillRect(x,y,barW*.75,bh);items.push({x:x,y:y,w:barW*.75,h:Math.max(2,bh),text:String(lab)+"\\n"+(s.label||"tokens")+": "+short(val)})});const lines=labelLines(lab,options.labelMode);ctx.fillStyle="#5f6b7a";ctx.textAlign="center";ctx.textBaseline="top";lines.forEach((line,k)=>ctx.fillText(line,pad.l+i*groupW+groupW/2,h-pad.b+10+k*13,Math.max(28,groupW-4)));ctx.textAlign="left";ctx.textBaseline="alphabetic"});bindTooltip(c,items)}' +
+        'function drawPie(id,legendId,items){const c=document.getElementById(id),ctx=c.getContext("2d"),dpr=devicePixelRatio||1,w=c.clientWidth,h=c.clientHeight,hit=[];c.width=w*dpr;c.height=h*dpr;ctx.scale(dpr,dpr);ctx.clearRect(0,0,w,h);const total=items.reduce((s,x)=>s+x.value,0)||1,cx=w/2,cy=h/2,r=Math.min(w,h)*.34;let a=-Math.PI/2;items.forEach(x=>{const start=a,span=x.value/total*Math.PI*2;ctx.beginPath();ctx.moveTo(cx,cy);ctx.arc(cx,cy,r,a,a+span);ctx.closePath();ctx.fillStyle=x.color;ctx.fill();hit.push({start:start,end:start+span,label:x.label,value:x.value});a+=span});c._items=[];c.onmousemove=e=>{const rect=c.getBoundingClientRect(),mx=e.clientX-rect.left-cx,my=e.clientY-rect.top-cy,dist=Math.sqrt(mx*mx+my*my);let ang=Math.atan2(my,mx);if(ang<-Math.PI/2)ang+=Math.PI*2;const found=dist<=r&&hit.find(x=>ang>=x.start&&ang<=x.end);if(found)showTip(e,found.label+": "+short(found.value)+" ("+((found.value/total)*100).toFixed(1)+"%)");else hideTip()};c.onmouseleave=hideTip;const el=document.getElementById(legendId);el.innerHTML=items.map(x=>"<span><i class=\\"dot\\" style=\\"background:"+x.color+"\\"></i>"+x.label+" "+short(x.value)+"</span>").join("")}' +
         'function makeSortable(id){const table=document.getElementById(id);if(!table)return;table.querySelectorAll("th.sortable").forEach((th,idx)=>th.addEventListener("click",()=>{const desc=!th.classList.contains("desc");table.querySelectorAll("th").forEach(h=>h.classList.remove("desc","asc"));th.classList.add(desc?"desc":"asc");const type=th.dataset.type||"text",body=table.tBodies[0],rows=Array.from(body.rows);rows.sort((a,b)=>{let av=a.cells[idx].dataset.sort||a.cells[idx].textContent,bv=b.cells[idx].dataset.sort||b.cells[idx].textContent;if(type==="number"){av=parseFloat(av)||0;bv=parseFloat(bv)||0;return desc?bv-av:av-bv}return desc?String(bv).localeCompare(String(av)):String(av).localeCompare(String(bv))});rows.forEach(r=>body.appendChild(r))}))}' +
-        'const daily=DATA.summary.byDay;drawBars("daily",daily.map(x=>x.key),[{color:"#2563eb",values:daily.map(x=>x.readTokens)},{color:"#059669",values:daily.map(x=>x.writeTokens)},{color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}],{labelMode:"date",bottom:70});' +
-        'const agents=DATA.summary.byAgent.slice().sort((a,b)=>(b.readTokens+b.writeTokens+b.cachedTokens+b.reasoningTokens)-(a.readTokens+a.writeTokens+a.cachedTokens+a.reasoningTokens)).slice(0,12);drawBars("agents",agents.map(x=>x.key),[{color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}],{labelMode:"agent",bottom:112});' +
+        'const daily=DATA.summary.byDay;drawBars("daily",daily.map(x=>x.key),[{label:"read",color:"#2563eb",values:daily.map(x=>x.readTokens)},{label:"write",color:"#059669",values:daily.map(x=>x.writeTokens)},{label:"cached",color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{label:"reasoning",color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}],{labelMode:"date",bottom:70});' +
+        'const agents=DATA.summary.byAgent.slice().sort((a,b)=>(b.readTokens+b.writeTokens+b.cachedTokens+b.reasoningTokens)-(a.readTokens+a.writeTokens+a.cachedTokens+a.reasoningTokens)).slice(0,12);drawBars("agents",agents.map(x=>x.key),[{label:"total",color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}],{labelMode:"agent",bottom:112});' +
         'const colors=["#2563eb","#059669","#b7791f","#dc2626","#7c3aed","#0891b2","#ea580c","#4f46e5","#64748b"];const agentPie=agents.slice(0,8).map((x,i)=>({label:x.key,value:x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens,color:colors[i%colors.length]}));const agentOther=DATA.summary.byAgent.reduce((s,x)=>s+x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens,0)-agentPie.reduce((s,x)=>s+x.value,0);if(agentOther>0)agentPie.push({label:"other",value:agentOther,color:"#94a3b8"});const tokenPie=[{label:"read",value:DATA.summary.totals.readTokens,color:"#2563eb"},{label:"write",value:DATA.summary.totals.writeTokens,color:"#059669"},{label:"cached",value:DATA.summary.totals.cachedTokens,color:"#b7791f"},{label:"reasoning",value:DATA.summary.totals.reasoningTokens,color:"#dc2626"}];drawPie("agentPie","agentPieLegend",agentPie);drawPie("tokenPie","tokenPieLegend",tokenPie);makeSortable("agentTable");makeSortable("runsTable");' +
-        'addEventListener("resize",()=>{drawBars("daily",daily.map(x=>x.key),[{color:"#2563eb",values:daily.map(x=>x.readTokens)},{color:"#059669",values:daily.map(x=>x.writeTokens)},{color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}],{labelMode:"date",bottom:70});drawBars("agents",agents.map(x=>x.key),[{color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}],{labelMode:"agent",bottom:112});drawPie("agentPie","agentPieLegend",agentPie);drawPie("tokenPie","tokenPieLegend",tokenPie)});' +
+        'addEventListener("resize",()=>{drawBars("daily",daily.map(x=>x.key),[{label:"read",color:"#2563eb",values:daily.map(x=>x.readTokens)},{label:"write",color:"#059669",values:daily.map(x=>x.writeTokens)},{label:"cached",color:"#b7791f",values:daily.map(x=>x.cachedTokens)},{label:"reasoning",color:"#dc2626",values:daily.map(x=>x.reasoningTokens)}],{labelMode:"date",bottom:70});drawBars("agents",agents.map(x=>x.key),[{label:"total",color:"#7c3aed",values:agents.map(x=>x.readTokens+x.writeTokens+x.cachedTokens+x.reasoningTokens)}],{labelMode:"agent",bottom:112});drawPie("agentPie","agentPieLegend",agentPie);drawPie("tokenPie","tokenPieLegend",tokenPie)});' +
         '</script>\n</body>\n</html>\n';
 }
 
@@ -444,13 +484,20 @@ function buildSummary(rows, totalRuns) {
         cachedTokens: 0,
         reasoningTokens: 0,
         samples: 0,
-        resumedRuns: 0
+        resumedRuns: 0,
+        feedbackLoopCount: 0,
+        rateLimitRetryCount: 0,
+        rateLimitRuns: 0,
+        timeoutCount: 0,
+        timeoutRuns: 0
     };
     rows.forEach(function(row) {
         Object.keys(totals).forEach(function(key) {
             totals[key] += row[key] || 0;
         });
         if (row.resumeDetected) totals.resumedRuns += 1;
+        if (row.rateLimitDetected) totals.rateLimitRuns += 1;
+        if (row.timeoutCount) totals.timeoutRuns += 1;
     });
     return {
         generatedAt: new Date().toISOString(),
@@ -551,6 +598,10 @@ function action(params) {
                 samples: usage.samples || 1,
                 resumeDetected: usage.resumeDetected === true,
                 resumeStages: (usage.resumeStages || []).join('; '),
+                feedbackLoopCount: usage.feedbackLoopCount || 0,
+                rateLimitRetryCount: usage.rateLimitRetryCount || 0,
+                rateLimitDetected: usage.rateLimitDetected === true,
+                timeoutCount: usage.timeoutCount || 0,
                 url: run.html_url || run.htmlUrl || ''
             });
             (usage.attempts || []).forEach(function(attempt) {
@@ -564,6 +615,10 @@ function action(params) {
                     ticketKey: meta.ticketKey,
                     attemptIndex: attempt.attemptIndex || 1,
                     resumeDetected: usage.resumeDetected === true,
+                    feedbackLoopCount: usage.feedbackLoopCount || 0,
+                    rateLimitRetryCount: usage.rateLimitRetryCount || 0,
+                    rateLimitDetected: usage.rateLimitDetected === true,
+                    timeoutCount: usage.timeoutCount || 0,
                     requests: attempt.requests || 0,
                     requestTier: attempt.requestTier || '',
                     requestDuration: attempt.requestDuration || '',

--- a/js/unit-tests/test_aiTeammateTokenUsageReporter.js
+++ b/js/unit-tests/test_aiTeammateTokenUsageReporter.js
@@ -40,6 +40,8 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
             '[INFO] CommandLineUtils - Requests  1 Premium (27m 2s)',
             '[INFO] CommandLineUtils - Tokens    ↑ 2.9m • ↓ 9.4k • 2.8m (cached) • 1.7k (reasoning)',
             'Feedback loop: resuming agent for rework_missing_outputs attempt 1/2',
+            'Copilot rate limit detected; retrying in 90s (attempt 2/2)',
+            'Command failed (exit code 124): ./agents/scripts/run-agent.sh',
             '[INFO] CommandLineUtils - Requests  2 Premium (30m 0s)',
             '[INFO] CommandLineUtils - Tokens    ↑ 3.1m • ↓ 10k • 3m (cached) • 2k (reasoning)'
         ].join('\n'));
@@ -57,6 +59,10 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
         assert.equal(usage.attempts[0].attemptIndex, 1);
         assert.equal(usage.attempts[1].attemptIndex, 2);
         assert.equal(usage.resumeStages[0], 'rework_missing_outputs 1/2');
+        assert.equal(usage.feedbackLoopCount, 1);
+        assert.equal(usage.rateLimitRetryCount, 1);
+        assert.equal(usage.rateLimitDetected, true);
+        assert.equal(usage.timeoutCount, 1);
     });
 
     test('extracts agent and ticket key from ai-teammate run title', function() {
@@ -125,6 +131,10 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
             samples: 2,
             resumeDetected: true,
             resumeStages: 'rework_missing_outputs 1/2',
+            feedbackLoopCount: 1,
+            rateLimitRetryCount: 1,
+            rateLimitDetected: true,
+            timeoutCount: 1,
             url: 'https://example.test/run/1'
         }]);
         var attemptsCsv = reporter.buildAttemptsCsv([{
@@ -137,6 +147,10 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
             ticketKey: 'TS-1',
             attemptIndex: 2,
             resumeDetected: true,
+            feedbackLoopCount: 1,
+            rateLimitRetryCount: 1,
+            rateLimitDetected: true,
+            timeoutCount: 1,
             requests: 2,
             readTokens: 3100000,
             writeTokens: 10000,
@@ -147,8 +161,53 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
         }]);
 
         assert.contains(aggregateCsv.split('\n')[0], 'resumeDetected');
+        assert.contains(aggregateCsv.split('\n')[0], 'feedbackLoopCount');
+        assert.contains(aggregateCsv.split('\n')[0], 'rateLimitRetryCount');
+        assert.contains(aggregateCsv.split('\n')[0], 'timeoutCount');
         assert.contains(aggregateCsv, 'rework_missing_outputs 1/2');
         assert.contains(attemptsCsv.split('\n')[0], 'attemptIndex');
+        assert.contains(attemptsCsv.split('\n')[0], 'rateLimitDetected');
         assert.contains(attemptsCsv, 'pr_rework,TS-1,2,true');
+    });
+
+    test('builds HTML with loop KPIs and chart tooltips', function() {
+        var reporter = loadReporter();
+        var summary = reporter.buildSummary([{
+            day: '2026-06-01',
+            agent: 'pr_rework',
+            readTokens: 100,
+            writeTokens: 10,
+            cachedTokens: 50,
+            reasoningTokens: 5,
+            samples: 2,
+            resumeDetected: true,
+            feedbackLoopCount: 1,
+            rateLimitRetryCount: 1,
+            rateLimitDetected: true,
+            timeoutCount: 1
+        }], 1);
+        var html = reporter.buildHtml([{
+            createdAt: '2026-06-01T00:00:00Z',
+            agent: 'pr_rework',
+            ticketKey: 'TS-1',
+            conclusion: 'success',
+            samples: 2,
+            resumeDetected: true,
+            feedbackLoopCount: 1,
+            rateLimitRetryCount: 1,
+            timeoutCount: 1,
+            readTokens: 100,
+            writeTokens: 10,
+            cachedTokens: 50,
+            reasoningTokens: 5,
+            runNumber: 10,
+            url: 'https://example.test/run/1'
+        }], summary);
+
+        assert.contains(html, '<span>Loops</span><b>1</b>');
+        assert.contains(html, '<span>Limit Retries</span><b>1</b>');
+        assert.contains(html, '<span>Timeouts</span><b>1</b>');
+        assert.contains(html, 'id="chartTooltip"');
+        assert.contains(html, 'function showTip');
     });
 });


### PR DESCRIPTION
## Summary
- count feedback-loop resumes, Copilot rate-limit retries, rate-limit hits, and timeout markers from workflow logs
- expose loop/limit/timeout counters in CSV, JSON, KPI cards, agent totals, and recent runs
- add hover tooltips for bar and pie charts showing token values and percentages

## Tests
- dmtools run js/unit-tests/run_all.json --mini