### PR TITLE
fix: avoid shell wrappers in git ancestor checks

### DIFF
--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -71,16 +71,39 @@ function defaultWriteFile(path, content) {
     return file_write(path, content);
 }
 
-function quoteShellArgument(value) {
-    return "'" + String(value || '').replace(/'/g, "'\"'\"'") + "'";
+function isSafeRefName(ref) {
+    return ref &&
+        typeof ref === 'string' &&
+        ref[0] !== '-' &&
+        ref.indexOf('..') === -1 &&
+        /^[A-Za-z0-9._/-]+$/.test(ref);
+}
+
+function lastNonEmptyLine(output) {
+    var lines = cleanCommandOutput(output || '')
+        .split(/\r?\n/)
+        .map(function(line) { return line.trim(); })
+        .filter(function(line) { return line; });
+    return lines[lines.length - 1] || '';
 }
 
 function branchContainsBase(runCommand, workingDir, baseBranch) {
-    var command = 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' +
-        '; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi';
-    var output = cleanCommandOutput(runCommand('bash -lc ' + quoteShellArgument(command), workingDir) || '').trim();
-    var lines = output.split(/\r?\n/).map(function(line) { return line.trim(); }).filter(function(line) { return line; });
-    return lines[lines.length - 1] === 'ancestor';
+    if (!isSafeRefName(baseBranch)) {
+        throw new Error('Unsafe base branch name: ' + baseBranch);
+    }
+
+    var baseRef = 'origin/' + baseBranch;
+    var baseSha = lastNonEmptyLine(runCommand('git rev-parse ' + baseRef, workingDir));
+    if (!baseSha) {
+        throw new Error('Could not resolve ' + baseRef);
+    }
+
+    try {
+        var mergeBase = lastNonEmptyLine(runCommand('git merge-base ' + baseRef + ' HEAD', workingDir));
+        return mergeBase === baseSha;
+    } catch (e) {
+        return false;
+    }
 }
 
 function buildOriginFetchCommand(refSpec) {
@@ -107,6 +130,8 @@ function syncBranchWithBase(options) {
     var runCommand = options.runCommand || defaultRunCommand;
 
     if (!branchName) return { success: false, error: 'branchName is required' };
+    if (!isSafeRefName(branchName)) return { success: false, error: 'Unsafe branch name: ' + branchName };
+    if (!isSafeRefName(baseBranch)) return { success: false, error: 'Unsafe base branch name: ' + baseBranch };
 
     try {
         console.log('Synchronizing ' + branchName + ' with origin/' + baseBranch + ' before publishing...');

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -77,10 +77,6 @@ function quoteCommitMessage(message) {
         .trim() + '"';
 }
 
-function quoteShellArgument(value) {
-    return "'" + String(value || '').replace(/'/g, "'\"'\"'") + "'";
-}
-
 function resolveStashPopConflicts(run, cleanOutput, path) {
     var unmerged = cleanOutput(run('git -C ' + path + ' diff --name-only --diff-filter=U') || '')
         .split('\n')
@@ -109,11 +105,24 @@ function resolveStashPopConflicts(run, cleanOutput, path) {
 }
 
 function isAncestor(run, cleanOutput, path, ancestor, descendant) {
-    var command = 'git -C ' + path + ' merge-base --is-ancestor ' + ancestor + ' ' + descendant +
-        '; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi';
-    var output = cleanOutput(run('bash -lc ' + quoteShellArgument(command)) || '').trim();
-    var lines = output.split(/\r?\n/).map(function(line) { return line.trim(); }).filter(function(line) { return line; });
-    return lines[lines.length - 1] === 'ancestor';
+    if (!isSafeRefName(ancestor)) {
+        throw new Error('Unsafe managed submodule ancestor ref for ' + path + ': ' + ancestor);
+    }
+    if (!isSafeRefName(descendant)) {
+        throw new Error('Unsafe managed submodule descendant ref for ' + path + ': ' + descendant);
+    }
+
+    var ancestorSha = cleanOutput(run('git -C ' + path + ' rev-parse ' + ancestor) || '').trim().split(/\r?\n/).pop();
+    if (!ancestorSha) {
+        throw new Error('Could not resolve managed submodule ancestor ref for ' + path + ': ' + ancestor);
+    }
+
+    try {
+        var mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant) || '').trim().split(/\r?\n/).pop();
+        return mergeBase === ancestorSha;
+    } catch (e) {
+        return false;
+    }
 }
 
 function prepareDirtySubmoduleBranch(run, cleanOutput, path, branch) {
@@ -184,23 +193,26 @@ function pushManagedSubmodules(options) {
         }
 
         var hasDirtyChanges = !!status.trim();
-        var remoteRef = 'origin/' + branch;
-        var localIncludedInRemote = isAncestor(run, cleanOutput, path, 'HEAD', remoteRef);
-        var remoteIncludedInLocal = isAncestor(run, cleanOutput, path, remoteRef, 'HEAD');
 
         if (!hasDirtyChanges && aheadCount === 0) {
             console.log('No managed submodule changes detected in', path);
             return;
         }
 
-        if (!hasDirtyChanges && localIncludedInRemote) {
-            console.log('Managed submodule HEAD is already included in origin/' + branch + ', skipping publish:', path);
-            return;
-        }
+        if (!hasDirtyChanges) {
+            var remoteRef = 'origin/' + branch;
+            var localIncludedInRemote = isAncestor(run, cleanOutput, path, 'HEAD', remoteRef);
+            var remoteIncludedInLocal = isAncestor(run, cleanOutput, path, remoteRef, 'HEAD');
 
-        if (!hasDirtyChanges && aheadCount > 0 && !remoteIncludedInLocal) {
-            console.log('Managed submodule has clean divergent gitlink state; skipping publish to avoid rebasing stale generated commits:', path);
-            return;
+            if (localIncludedInRemote) {
+                console.log('Managed submodule HEAD is already included in origin/' + branch + ', skipping publish:', path);
+                return;
+            }
+
+            if (aheadCount > 0 && !remoteIncludedInLocal) {
+                console.log('Managed submodule has clean divergent gitlink state; skipping publish to avoid rebasing stale generated commits:', path);
+                return;
+            }
         }
 
         console.log('Publishing managed submodule changes:', path, '-> origin/' + branch);

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -115,7 +115,8 @@ suite('pullRequest helper', function() {
             workingDir: 'repo',
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
-                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'not-ancestor';
+                if (command === 'git rev-parse origin/main') return 'base-sha';
+                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -125,7 +126,8 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
-            { command: 'bash -lc \'git merge-base --is-ancestor origin/main HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\'', workingDirectory: 'repo' },
+            { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
@@ -140,7 +142,8 @@ suite('pullRequest helper', function() {
             baseBranch: 'release',
             runCommand: function(command) {
                 commands.push(command);
-                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'ancestor';
+                if (command === 'git rev-parse origin/release') return 'base-sha';
+                if (command === 'git merge-base origin/release HEAD') return 'base-sha';
                 return '';
             }
         });
@@ -149,7 +152,8 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, false);
         assert.deepEqual(commands, [
             'git -c fetch.recurseSubmodules=no fetch origin release',
-            'bash -lc \'git merge-base --is-ancestor origin/release HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\''
+            'git rev-parse origin/release',
+            'git merge-base origin/release HEAD'
         ]);
     });
 
@@ -163,7 +167,8 @@ suite('pullRequest helper', function() {
             workingDir: 'repo',
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
-                if (command.indexOf('git merge-base --is-ancestor') !== -1) return 'not-ancestor';
+                if (command === 'git rev-parse origin/main') return 'base-sha';
+                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -173,7 +178,8 @@ suite('pullRequest helper', function() {
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
-            { command: 'bash -lc \'git merge-base --is-ancestor origin/main HEAD; code=$?; if [ "$code" -eq 0 ]; then echo ancestor; elif [ "$code" -eq 1 ]; then echo not-ancestor; else exit "$code"; fi\'', workingDirectory: 'repo' },
+            { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -92,11 +92,17 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
                     return '2';
                 }
-                if (command.indexOf('merge-base --is-ancestor HEAD origin/main') !== -1) {
-                    return 'not-ancestor';
+                if (command === 'git -C trackstate-setup rev-parse HEAD') {
+                    return 'head-sha';
                 }
-                if (command.indexOf('merge-base --is-ancestor origin/main HEAD') !== -1) {
-                    return 'ancestor';
+                if (command === 'git -C trackstate-setup rev-parse origin/main') {
+                    return 'base-sha';
+                }
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                    return 'old-sha';
+                }
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                    return 'base-sha';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
                     return '2b4b84712bfa';
@@ -130,11 +136,17 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
                     return '2';
                 }
-                if (command.indexOf('merge-base --is-ancestor HEAD origin/main') !== -1) {
-                    return 'not-ancestor';
+                if (command === 'git -C trackstate-setup rev-parse HEAD') {
+                    return 'head-sha';
                 }
-                if (command.indexOf('merge-base --is-ancestor origin/main HEAD') !== -1) {
-                    return 'ancestor';
+                if (command === 'git -C trackstate-setup rev-parse origin/main') {
+                    return 'base-sha';
+                }
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                    return 'old-sha';
+                }
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                    return 'base-sha';
                 }
                 return '';
             }
@@ -202,7 +214,13 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-list --count origin/main..HEAD') {
                     return '1';
                 }
-                if (command.indexOf('git -C trackstate-setup merge-base --is-ancestor') === 0) {
+                if (command === 'git -C trackstate-setup rev-parse HEAD') {
+                    return 'head-sha';
+                }
+                if (command === 'git -C trackstate-setup rev-parse origin/main') {
+                    return 'base-sha';
+                }
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
                     throw new Error('diverged');
                 }
                 return '';


### PR DESCRIPTION
## Summary
- replace shell-wrapped merge-base ancestor checks with safe git rev-parse + merge-base commands
- skip clean-only ancestry checks for dirty managed submodules so dirty publish flow can proceed
- update pull request and submodule helper unit tests

## Validation
- dmtools run js/unit-tests/run_all.json --mini
- rg -n "bash -lc|; code=\$\?|merge-base --is-ancestor" agents/js/common agents/js/pushReworkChanges.js agents/js/developTicketAndCreatePR.js -S