### PR TITLE
Fix token usage cache-only reporting

### DIFF
--- a/js/aiTeammateTokenUsageReporter.js
+++ b/js/aiTeammateTokenUsageReporter.js
@@ -583,6 +583,26 @@ function writeUsageCache(path, cache) {
     writeOutput(path, JSON.stringify(cache, null, 2));
 }
 
+function buildRowsFromCache(cache) {
+    var rows = [];
+    var attemptRows = [];
+    Object.keys(cache.entries || {}).forEach(function(runId) {
+        var entry = cache.entries[runId];
+        if (!entry || !entry.row) return;
+        rows.push(entry.row);
+        (entry.attemptRows || []).forEach(function(attemptRow) { attemptRows.push(attemptRow); });
+    });
+    rows.sort(function(a, b) {
+        return String(b.createdAt || '').localeCompare(String(a.createdAt || ''));
+    });
+    attemptRows.sort(function(a, b) {
+        var byDate = String(b.createdAt || '').localeCompare(String(a.createdAt || ''));
+        if (byDate !== 0) return byDate;
+        return (a.attemptIndex || 0) - (b.attemptIndex || 0);
+    });
+    return { rows: rows, attemptRows: attemptRows };
+}
+
 function action(params) {
     var custom = (params && params.jobParams && params.jobParams.customParams) || {};
     var projectConfig = configLoader.loadProjectConfig(params || {});
@@ -609,9 +629,10 @@ function action(params) {
     var useCache = custom.useCache !== false && custom.useCache !== 'false';
     var cacheWriteEvery = Math.max(1, parseInt(custom.cacheWriteEvery || 25, 10) || 25);
     var logDownloadSleepMs = parseInt(custom.logDownloadSleepMs || 0, 10) || 0;
+    var parsedMaxLogDownloads = parseInt(custom.maxLogDownloads, 10);
     var maxLogDownloads = custom.maxLogDownloads == null || custom.maxLogDownloads === ''
         ? null
-        : Math.max(0, parseInt(custom.maxLogDownloads, 10) || 0);
+        : Math.max(0, isNaN(parsedMaxLogDownloads) ? 0 : parsedMaxLogDownloads);
 
     if (custom.renderOnly === true || custom.renderOnly === 'true') {
         var inputJsonPath = custom.inputJsonPath || jsonPath;
@@ -622,6 +643,34 @@ function action(params) {
         writeOutput(htmlPath, buildHtml(existing.rows, existing.summary));
         console.log('Wrote HTML: ' + htmlPath);
         return { success: true, renderOnly: true, jsonPath: inputJsonPath, htmlPath: htmlPath, summary: existing.summary };
+    }
+
+    if (custom.cacheOnly === true || custom.cacheOnly === 'true') {
+        var cacheOnly = loadUsageCache(cachePath);
+        var cached = buildRowsFromCache(cacheOnly);
+        var cachedTotalRuns = Object.keys(cacheOnly.entries || {}).length;
+        var summaryFromCache = buildSummary(cached.rows, cachedTotalRuns);
+        summaryFromCache.cache = {
+            enabled: true,
+            path: cachePath,
+            cacheOnly: true,
+            hits: cached.rows.length,
+            logDownloads: 0,
+            maxLogDownloads: 0,
+            stoppedByDownloadLimit: false,
+            logDownloadSleepMs: 0
+        };
+        var cachedPayload = { summary: summaryFromCache, rows: cached.rows, attempts: cached.attemptRows };
+        writeOutput(csvPath, buildCsv(cached.rows));
+        writeOutput(attemptsCsvPath, buildAttemptsCsv(cached.attemptRows));
+        writeOutput(jsonPath, JSON.stringify(cachedPayload, null, 2));
+        writeOutput(htmlPath, buildHtml(cached.rows, summaryFromCache));
+        console.log('Wrote CSV: ' + csvPath);
+        console.log('Wrote attempts CSV: ' + attemptsCsvPath);
+        console.log('Wrote JSON: ' + jsonPath);
+        console.log('Wrote HTML: ' + htmlPath);
+        console.log('Cache-only report rows=' + cached.rows.length + ', log downloads=0');
+        return { success: true, cacheOnly: true, csvPath: csvPath, attemptsCsvPath: attemptsCsvPath, jsonPath: jsonPath, htmlPath: htmlPath, summary: summaryFromCache };
     }
 
     console.log('AI Teammate Token Usage Reporter — ' + custom.workspace + '/' + custom.repository + ' [' + custom.workflowId + ']');

--- a/js/unit-tests/test_aiTeammateTokenUsageReporter.js
+++ b/js/unit-tests/test_aiTeammateTokenUsageReporter.js
@@ -302,4 +302,109 @@ suite('aiTeammateTokenUsageReporter parsing', function() {
         assert.equal(result.summary.cache.hits, 1);
         assert.equal(result.summary.cache.logDownloads, 1);
     });
+
+    test('maxLogDownloads zero skips uncached log downloads', function() {
+        var logDownloads = [];
+        var reporter = loadReporter({
+            file_read: function() {
+                return JSON.stringify({ version: 1, entries: {} });
+            },
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [
+                    { id: 1, status: 'completed', conclusion: 'success', run_number: 10, created_at: '2026-06-01T00:00:00Z', run_started_at: '2026-06-01T00:00:00Z', updated_at: '2026-06-01T00:01:00Z', display_title: 'agents/pr_review.json : TS-1 : TS-1', html_url: 'https://example.test/run/1' }
+                ] });
+            },
+            github_get_workflow_run_logs: function(args) {
+                logDownloads.push(args.runId);
+                return '[INFO] CommandLineUtils - Tokens    ↑ 2k • ↓ 20 • 1k (cached) • 3 (reasoning)';
+            }
+        });
+
+        var result = reporter.action({
+            jobParams: {
+                customParams: {
+                    workspace: 'IstiN',
+                    repository: 'trackstate',
+                    outputDir: 'outputs/token_usage',
+                    maxPages: 1,
+                    maxLogDownloads: 0
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(logDownloads.length, 0);
+        assert.equal(result.summary.cache.logDownloads, 0);
+        assert.equal(result.summary.cache.stoppedByDownloadLimit, true);
+    });
+
+    test('cacheOnly writes report from cache without listing or downloading logs', function() {
+        var writes = {};
+        var listCalls = 0;
+        var logDownloads = [];
+        var cachedRow = {
+            runId: '1',
+            runNumber: 10,
+            createdAt: '2026-06-01T00:00:00Z',
+            startedAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T00:01:00Z',
+            day: '2026-06-01',
+            conclusion: 'success',
+            agent: 'pr_review',
+            ticketKey: 'TS-1',
+            configFile: 'agents/pr_review.json',
+            title: 'agents/pr_review.json : TS-1 : TS-1',
+            durationSeconds: 60,
+            duration: '1m 0s',
+            requests: 0,
+            readTokens: 100,
+            writeTokens: 10,
+            cachedTokens: 90,
+            reasoningTokens: 5,
+            samples: 1,
+            resumeDetected: false,
+            resumeStages: '',
+            feedbackLoopCount: 0,
+            rateLimitRetryCount: 0,
+            rateLimitDetected: false,
+            timeoutCount: 0,
+            url: 'https://example.test/run/1'
+        };
+        var reporter = loadReporter({
+            file_read: function(args) {
+                if (args.path === 'outputs/token_usage/ai_teammate_token_usage_cache.json') {
+                    return JSON.stringify({ version: 1, entries: { '1': { row: cachedRow, attemptRows: [] }, '2': { noUsage: true } } });
+                }
+                return '';
+            },
+            file_write: function(args) { writes[args.path] = args.content; },
+            github_list_workflow_runs: function() {
+                listCalls += 1;
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_get_workflow_run_logs: function(args) {
+                logDownloads.push(args.runId);
+                return '';
+            }
+        });
+
+        var result = reporter.action({
+            jobParams: {
+                customParams: {
+                    workspace: 'IstiN',
+                    repository: 'trackstate',
+                    outputDir: 'outputs/token_usage',
+                    cacheOnly: true
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.cacheOnly, true);
+        assert.equal(listCalls, 0);
+        assert.equal(logDownloads.length, 0);
+        assert.equal(result.summary.totalRuns, 2);
+        assert.equal(result.summary.runsWithTokens, 1);
+        assert.contains(writes['outputs/token_usage/ai_teammate_token_usage.html'], 'Daily Token Trend');
+    });
 });


### PR DESCRIPTION
## Summary
- preserve maxLogDownloads=0 as an explicit no-download mode
- add cacheOnly report generation from the token usage cache without listing workflow runs or downloading logs
- cover cache-only and zero-download behavior in unit tests

## Tests
- dmtools run js/unit-tests/run_all.json --mini