### PR TITLE
Avoid noisy merge-base failures in git sync

### DIFF
--- a/js/common/feedbackLoop.js
+++ b/js/common/feedbackLoop.js
@@ -59,7 +59,9 @@ function isNonRecoverable(errorText, config) {
         'Bad credentials',
         'Resource not accessible by integration',
         'could not read Username',
-        'Authentication failed'
+        'Authentication failed',
+        'refusing to merge unrelated histories',
+        'No merge base found between HEAD and origin/'
     ];
     return patterns.some(function(pattern) {
         return text.indexOf(pattern) !== -1;

--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -99,11 +99,22 @@ function branchContainsBase(runCommand, workingDir, baseBranch) {
     }
 
     try {
-        var mergeBase = lastNonEmptyLine(runCommand('git merge-base ' + baseRef + ' HEAD', workingDir));
+        var mergeBase = lastNonEmptyLine(runCommand('git merge-base ' + baseRef + ' HEAD 2>/dev/null || true', workingDir));
         return mergeBase === baseSha;
     } catch (e) {
         return false;
     }
+}
+
+function branchHasMergeBase(runCommand, workingDir, baseBranch) {
+    if (!isSafeRefName(baseBranch)) {
+        throw new Error('Unsafe base branch name: ' + baseBranch);
+    }
+
+    var mergeBase = lastNonEmptyLine(
+        runCommand('git merge-base origin/' + baseBranch + ' HEAD 2>/dev/null || true', workingDir)
+    );
+    return !!mergeBase;
 }
 
 function buildOriginFetchCommand(refSpec) {
@@ -141,6 +152,14 @@ function syncBranchWithBase(options) {
         if (upToDate) {
             console.log('✅ Branch already contains origin/' + baseBranch);
             return { success: true, updated: false };
+        }
+
+        if (!branchHasMergeBase(runCommand, workingDir, baseBranch)) {
+            return {
+                success: false,
+                unrecoverableByAgent: true,
+                error: 'No merge base found between HEAD and origin/' + baseBranch + '; refusing to merge unrelated histories. Fetch full branch history or recreate the branch from origin/' + baseBranch + ' before publishing.'
+            };
         }
 
         var status = readTrackedStatus(runCommand, workingDir);

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -117,12 +117,8 @@ function isAncestor(run, cleanOutput, path, ancestor, descendant) {
         throw new Error('Could not resolve managed submodule ancestor ref for ' + path + ': ' + ancestor);
     }
 
-    try {
-        var mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant) || '').trim().split(/\r?\n/).pop();
-        return mergeBase === ancestorSha;
-    } catch (e) {
-        return false;
-    }
+    var mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant + ' 2>/dev/null || true') || '').trim().split(/\r?\n/).pop();
+    return mergeBase === ancestorSha;
 }
 
 function prepareDirtySubmoduleBranch(run, cleanOutput, path, branch) {

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -75,14 +75,20 @@ function branchHasUniquePatches(baseBranch) {
     }
 }
 
+function isAncestorRef(ancestor, descendant) {
+    var marker = cleanCommandOutput(runCmd({ command: 'git merge-base --is-ancestor ' + ancestor + ' ' + descendant + ' >/dev/null 2>&1 && echo yes || true' }) || '');
+    return marker.trim() === 'yes';
+}
+
+function findMergeBase(left, right) {
+    return cleanCommandOutput(runCmd({ command: 'git merge-base ' + left + ' ' + right + ' 2>/dev/null || true' }) || '');
+}
+
 function alignBranchWithBase(ticketKey, branchName, baseBranch) {
-    try {
-        runCmd({ command: 'git merge-base --is-ancestor HEAD origin/' + baseBranch });
+    if (isAncestorRef('HEAD', 'origin/' + baseBranch)) {
         console.log('Branch changes are already included in origin/' + baseBranch + ', resetting local branch:', branchName);
         runCmd({ command: 'git reset --hard origin/' + baseBranch });
         return;
-    } catch (mergedError) {
-        // Branch has work that is not trivially reachable from origin/base.
     }
 
     if (!branchHasUniquePatches(baseBranch)) {
@@ -91,19 +97,19 @@ function alignBranchWithBase(ticketKey, branchName, baseBranch) {
         return;
     }
 
-    try {
-        runCmd({ command: 'git merge-base --is-ancestor origin/' + baseBranch + ' HEAD' });
+    if (isAncestorRef('origin/' + baseBranch, 'HEAD')) {
         console.log('Branch already contains origin/' + baseBranch + ':', branchName);
         return;
-    } catch (ancestorError) {
-        console.warn('Branch does not contain origin/' + baseBranch + ':', branchName);
     }
+    console.warn('Branch does not contain origin/' + baseBranch + ':', branchName);
 
     var details = '';
     try {
-        var mergeBase = cleanCommandOutput(runCmd({ command: 'git merge-base HEAD origin/' + baseBranch }) || '');
+        var mergeBase = findMergeBase('HEAD', 'origin/' + baseBranch);
         if (mergeBase) {
             details = cleanCommandOutput(runCmd({ command: 'git merge-tree ' + mergeBase + ' HEAD origin/' + baseBranch }) || '');
+        } else {
+            details = 'No merge base found between HEAD and origin/' + baseBranch + '. The local checkout is likely shallow or the branch history is unrelated to the current base.';
         }
     } catch (mergeTreeError) {
         details = mergeTreeError && mergeTreeError.toString ? mergeTreeError.toString() : String(mergeTreeError);

--- a/js/unit-tests/test_feedbackLoop.js
+++ b/js/unit-tests/test_feedbackLoop.js
@@ -46,6 +46,21 @@ suite('feedbackLoop helper', function() {
         assert.deepEqual(loaded.commands, []);
     });
 
+    test('does not resume unrelated-history git infrastructure failures', function() {
+        var loaded = loadFeedbackLoop();
+        var result = loaded.mod.resumeAgent({
+            ticketKey: 'TS-1',
+            customParams: { feedbackLoop: { postAction: { enabled: true, maxAttempts: 1 } } },
+            section: 'postAction',
+            stage: 'git_operations',
+            error: 'fatal: refusing to merge unrelated histories'
+        });
+
+        assert.equal(result.attempted, false);
+        assert.equal(result.reason, 'non-recoverable');
+        assert.deepEqual(loaded.commands, []);
+    });
+
     test('writes feedback prompt and resumes agent once when enabled', function() {
         var loaded = loadFeedbackLoop();
         var result = loaded.mod.resumeAgent({

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -116,7 +116,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
                 if (command === 'git rev-parse origin/main') return 'base-sha';
-                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
+                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -127,7 +127,8 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
@@ -143,7 +144,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command) {
                 commands.push(command);
                 if (command === 'git rev-parse origin/release') return 'base-sha';
-                if (command === 'git merge-base origin/release HEAD') return 'base-sha';
+                if (command === 'git merge-base origin/release HEAD 2>/dev/null || true') return 'base-sha';
                 return '';
             }
         });
@@ -153,7 +154,7 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             'git -c fetch.recurseSubmodules=no fetch origin release',
             'git rev-parse origin/release',
-            'git merge-base origin/release HEAD'
+            'git merge-base origin/release HEAD 2>/dev/null || true'
         ]);
     });
 
@@ -168,7 +169,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
                 if (command === 'git rev-parse origin/main') return 'base-sha';
-                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
+                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -179,10 +180,32 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
+    });
+
+    test('refuses to merge unrelated histories during branch sync', function() {
+        var commands = [];
+        var pr = loadPullRequestHelper();
+
+        var result = pr.syncBranchWithBase({
+            branchName: 'feature/DMC-7',
+            baseBranch: 'main',
+            runCommand: function(command) {
+                commands.push(command);
+                if (command === 'git rev-parse origin/main') return 'base-sha';
+                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return '';
+                return '';
+            }
+        });
+
+        assert.equal(result.success, false);
+        assert.equal(result.unrecoverableByAgent, true);
+        assert.contains(result.error, 'No merge base found');
+        assert.equal(commands.indexOf('git merge --no-edit origin/main'), -1);
     });
 
 });

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -98,10 +98,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true') {
                     return 'base-sha';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
@@ -142,10 +142,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true') {
                     return 'base-sha';
                 }
                 return '';
@@ -220,9 +220,7 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
-                    throw new Error('diverged');
-                }
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') return '';
                 return '';
             }
         });

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -198,6 +198,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1306"') return '  ai/TS-1306\n';
+            if (args.command === 'git merge-base --is-ancestor HEAD origin/main >/dev/null 2>&1 && echo yes || true') return 'yes\n';
             return '';
         };
 
@@ -260,14 +261,10 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1307"') return '  ai/TS-1307\n';
-            if (args.command === 'git merge-base --is-ancestor HEAD origin/main') {
-                throw new Error('not merged');
-            }
+            if (args.command === 'git merge-base --is-ancestor HEAD origin/main >/dev/null 2>&1 && echo yes || true') return '';
             if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket work\n';
-            if (args.command === 'git merge-base --is-ancestor origin/main HEAD') {
-                throw new Error('not ancestor');
-            }
-            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
+            if (args.command === 'git merge-base --is-ancestor origin/main HEAD >/dev/null 2>&1 && echo yes || true') return '';
+            if (args.command === 'git merge-base HEAD origin/main 2>/dev/null || true') return 'base123\n';
             if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (content): Merge conflict in .dmtools/config.js\n';
             return '';
         };


### PR DESCRIPTION
Changes expected git ancestry probes to no-error commands, refuses unrelated-history merges before publishing, and prevents feedback loops from sending unrelated-history infrastructure failures back to Copilot.

Tested with `dmtools run js/unit-tests/run_all.json --mini`.