### PR TITLE
Add Copilot session cache support

### DIFF
--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -167,9 +167,34 @@ elif [ "$PROVIDER" = "copilot" ]; then
 
   COPILOT_DEFAULT_MODEL="${COPILOT_DEFAULT_MODEL:-gpt-5-mini}"
   COPILOT_MODEL_VALUE="${COPILOT_MODEL:-$COPILOT_DEFAULT_MODEL}"
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ "${COPILOT_SESSION_ENABLED:-true}" != "false" ] && [ -f "${SCRIPT_DIR}/../setup/copilot-session.sh" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/../setup/copilot-session.sh" env
+  fi
+
+  COPILOT_SESSION_ARGS=()
+  COPILOT_HAS_RESUME_ARG=false
+  for pass_arg in "${PASS_ARGS[@]:-}"; do
+    case "${pass_arg}" in
+      --continue|--resume|--resume=*|--session-id|--session-id=*)
+        COPILOT_HAS_RESUME_ARG=true
+        ;;
+    esac
+  done
+  if [ "${COPILOT_SESSION_ENABLED:-true}" != "false" ] && [ "${COPILOT_HAS_RESUME_ARG}" = "false" ] && [ -n "${COPILOT_SESSION_ID:-}" ]; then
+    COPILOT_SESSION_ARGS=(--session-id "${COPILOT_SESSION_ID}")
+    if [ -n "${COPILOT_SESSION_NAME:-}" ]; then
+      COPILOT_SESSION_ARGS+=(--name "${COPILOT_SESSION_NAME}")
+    fi
+  fi
 
   echo "Copilot Configuration:"
   echo "  Model: ${COPILOT_MODEL_VALUE}"
+  if [ -n "${COPILOT_SESSION_ID:-}" ]; then
+    echo "  Session: ${COPILOT_SESSION_NAME:-${COPILOT_SESSION_ID}} (${COPILOT_SESSION_GROUP:-default})"
+    echo "  COPILOT_HOME: ${COPILOT_HOME:-}"
+  fi
   echo "Working directory: $(pwd)"
   echo ""
 
@@ -188,13 +213,13 @@ elif [ "$PROVIDER" = "copilot" ]; then
 
     set +e
     if [ -f "${PROMPT_ARG}" ]; then
-      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${model} ${PASS_ARGS[*]:-} (prompt: ${PROMPT_BYTES} bytes via stdin)"
+      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${model} ${COPILOT_SESSION_ARGS[*]:-} ${PASS_ARGS[*]:-} (prompt: ${PROMPT_BYTES} bytes via stdin)"
       echo ""
-      "${COPILOT_CMD[@]}" --allow-all --model "${model}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
+      "${COPILOT_CMD[@]}" --allow-all --model "${model}" ${COPILOT_SESSION_ARGS[@]+"${COPILOT_SESSION_ARGS[@]}"} ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} < "${PROMPT_ARG}" 2>&1 | tee "$log_file"
     else
-      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${model} ${PASS_ARGS[*]:-} -p <inline prompt>"
+      echo "Running: ${COPILOT_CMD[*]} --allow-all --model ${model} ${COPILOT_SESSION_ARGS[*]:-} ${PASS_ARGS[*]:-} -p <inline prompt>"
       echo ""
-      "${COPILOT_CMD[@]}" --allow-all --model "${model}" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
+      "${COPILOT_CMD[@]}" --allow-all --model "${model}" ${COPILOT_SESSION_ARGS[@]+"${COPILOT_SESSION_ARGS[@]}"} ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} -p "${PROMPT}" 2>&1 | tee "$log_file"
     fi
     local status=${PIPESTATUS[0]}
     return "$status"

--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -58,6 +58,11 @@ _cache_copilot() {
   export_var "COPILOT_CACHE_KEY"  "npm-global-copilot-${version}-${OS_TAG}"
 }
 
+_cache_copilot_session() {
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/copilot-session.sh" env
+}
+
 _cache_codegraph() {
   local version="${1:-${CODEGRAPH_VERSION:-latest}}"
   # Binary cache (~/.npm-global)
@@ -91,6 +96,7 @@ _dispatch_tool() {
     node)     _cache_node     "${version}" ;;
     maestro)  _cache_maestro  "${version}" ;;
     copilot)  _cache_copilot  "${version}" ;;
+    copilot-session) _cache_copilot_session ;;
     codegraph) _cache_codegraph "${version}" ;;
     playwright) _cache_playwright "${version}" ;;
     codemie)  _cache_codemie  "${version}" ;;
@@ -130,7 +136,7 @@ _print_info() {
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-ALL_TOOLS="java node dmtools maestro copilot codemie codegraph playwright"  # cursor has no cache
+ALL_TOOLS="java node dmtools maestro copilot copilot-session codemie codegraph playwright"  # cursor has no cache
 
 MODE="${1:-info}"
 shift || true
@@ -191,7 +197,7 @@ for arg in ${TOOL_LIST}; do
 
   _dispatch_tool "${TOOL_NAME}" "${TOOL_VERSION}"
 
-  VAR_PREFIX="$(echo "${TOOL_NAME}" | tr '[:lower:]' '[:upper:]')"
+  VAR_PREFIX="$(echo "${TOOL_NAME}" | tr '[:lower:]-' '[:upper:]_')"
   PATH_VAR="${VAR_PREFIX}_CACHE_PATH"
   KEY_VAR="${VAR_PREFIX}_CACHE_KEY"
   echo "📦 ${TOOL_NAME}: key=${!KEY_VAR:-?}  path=${!PATH_VAR:-?}"

--- a/setup/copilot-session.sh
+++ b/setup/copilot-session.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Configure a stable, cacheable GitHub Copilot CLI session for AI Teammate runs.
+#
+# Usage:
+#   copilot-session.sh env
+#   copilot-session.sh info
+#
+# Inputs:
+#   AI_TEAMMATE_CONFIG_FILE       e.g. agents/story_development.json
+#   AI_TEAMMATE_CONCURRENCY_KEY   workflow concurrency key
+#   AI_TEAMMATE_DISPLAY_KEY       user-visible ticket key, preferred when set
+#   GITHUB_WORKSPACE              workspace root
+#
+# Outputs:
+#   COPILOT_HOME                  isolated home to cache for this work stream
+#   COPILOT_SESSION_ID            stable UUID derived from repo/key/group
+#   COPILOT_SESSION_NAME          stable human-readable session name
+#   COPILOT_SESSION_GROUP         logical group (dev-write, test-write, review...)
+#   COPILOT_SESSION_CACHE_PATH    path for CI cache restore/save
+#   COPILOT_SESSION_CACHE_KEY     immutable cache key for this run
+#   COPILOT_SESSION_CACHE_RESTORE_KEY prefix for previous runs of the same stream
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+_uuid_from_seed() {
+  local hash="$(_sha256 "$1")"
+  # Build a deterministic UUID-looking value. Copilot only requires a UUID;
+  # the seed keeps the same ticket/group on the same session across CI runs.
+  printf '%s-%s-5%s-a%s-%s' \
+    "${hash:0:8}" \
+    "${hash:8:4}" \
+    "${hash:13:3}" \
+    "${hash:17:3}" \
+    "${hash:20:12}"
+}
+
+_config_slug() {
+  local config="${AI_TEAMMATE_CONFIG_FILE:-${CONFIG_FILE:-}}"
+  config="${config##*/}"
+  config="${config%.json}"
+  _slug "${config:-unknown}"
+}
+
+_session_group_for_config() {
+  local config="$1"
+  case "${config}" in
+    story_development|bug_development|pr_rework)
+      echo "dev-write"
+      ;;
+    pr_review)
+      echo "dev-review"
+      ;;
+    test_case_automation|pr_test_automation_rework)
+      echo "test-write"
+      ;;
+    pr_test_automation_review)
+      echo "test-review"
+      ;;
+    *)
+      echo "${config}"
+      ;;
+  esac
+}
+
+configure_copilot_session() {
+  local workspace="${GITHUB_WORKSPACE:-${PWD}}"
+  local repo="${GITHUB_REPOSITORY:-$(basename "${workspace}")}"
+  local config="$(_config_slug)"
+  local group="$(_session_group_for_config "${config}")"
+  local key="${AI_TEAMMATE_DISPLAY_KEY:-${DISPLAY_KEY:-}}"
+
+  if [ -z "${key}" ]; then
+    key="${AI_TEAMMATE_CONCURRENCY_KEY:-${CONCURRENCY_KEY:-}}"
+  fi
+  if [ -z "${key}" ]; then
+    key="$(git -C "${workspace}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)"
+  fi
+
+  local repo_slug="$(_slug "${repo}")"
+  local key_slug="$(_slug "${key}")"
+  local group_slug="$(_slug "${group}")"
+  local session_seed="${repo_slug}:${key_slug}:${group_slug}"
+  local session_id="$(_uuid_from_seed "${session_seed}")"
+  local session_name="${repo_slug}-${key_slug}-${group_slug}"
+  local session_root="${workspace}/.dmtools/copilot-sessions/${repo_slug}/${key_slug}/${group_slug}"
+  local cache_prefix="copilot-session-${repo_slug}-${key_slug}-${group_slug}-"
+  local cache_version="${COPILOT_SESSION_CACHE_VERSION:-v1}"
+  local cache_run_id="${GITHUB_RUN_ID:-local}"
+
+  mkdir -p "${session_root}"
+
+  export_var "COPILOT_HOME" "${session_root}"
+  export_var "COPILOT_SESSION_ID" "${session_id}"
+  export_var "COPILOT_SESSION_NAME" "${session_name}"
+  export_var "COPILOT_SESSION_GROUP" "${group_slug}"
+  export_var "COPILOT_SESSION_CACHE_PATH" "${session_root}"
+  export_var "COPILOT_SESSION_CACHE_RESTORE_KEY" "${cache_prefix}${cache_version}-"
+  export_var "COPILOT_SESSION_CACHE_KEY" "${cache_prefix}${cache_version}-${cache_run_id}"
+}
+
+MODE="${1:-env}"
+case "${MODE}" in
+  env|restore|save|info)
+    configure_copilot_session
+    echo "🤖 Copilot session: group=${COPILOT_SESSION_GROUP} name=${COPILOT_SESSION_NAME}"
+    echo "📦 Copilot session cache: key=${COPILOT_SESSION_CACHE_KEY} path=${COPILOT_SESSION_CACHE_PATH}"
+    ;;
+  *)
+    echo "Usage: copilot-session.sh env|restore|save|info" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Adds boxed Copilot session restore/cache support for AI Teammate runs.

- computes stable Copilot session groups in agents/setup
- shares development + rework sessions while keeping review sessions separate
- exposes copilot-session cache keys through setup/cache.sh
- passes stable --session-id only for normal Copilot runs and preserves existing --continue/--resume behavior

Validation:
- bash -n setup/copilot-session.sh setup/cache.sh scripts/run-agent.sh
- fake Copilot run-agent smoke for normal and resume paths
- dmtools run js/unit-tests/run_all.json --mini