### PR TITLE
Prefer root project config discovery

### DIFF
--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -6,8 +6,9 @@
  *
  * Discovery order:
  *   1. customParams.configPath (explicit path)
- *   2. ../.dmtools/config.js   (relative to agents dir — submodule layout)
- *   3. Built-in defaults       (backward compatible)
+ *   2. .dmtools/config.js      (target repo root layout)
+ *   3. ../.dmtools/config.js   (when running directly from agents submodule)
+ *   4. Built-in defaults       (backward compatible)
  *
  * Merge strategy:
  *   - jira.statuses, jira.issueTypes, jira.questions, labels: FULL REPLACEMENT when provided
@@ -254,8 +255,8 @@ function loadConfigFile(path) {
  *   1. params.configPath          — top-level param (e.g. jobParams.configPath in sm.json)
  *   2. params.customParams.configPath — explicit path from agent customParams
  *   3. params.agentConfigsDir + "/.dmtools/config.js" — when agentConfigsDir is passed
- *   4. ../.dmtools/config.js       — submodule layout (agents/ is a submodule)
- *   5. .dmtools/config.js          — co-located layout (agents/ in same repo)
+ *   4. .dmtools/config.js          — target repo root layout
+ *   5. ../.dmtools/config.js       — running directly from agents submodule
  *   6. Defaults                    — built-in defaults from config.js
  *
  * @param {Object} params - Agent params (jobParams or top-level params)
@@ -295,23 +296,23 @@ function loadProjectConfig(params) {
         }
     }
 
-    // 4. Relative discovery: ../.dmtools/config.js (submodule layout)
-    if (!loaded) {
-        var relativePath = '../.dmtools/config.js';
-        loaded = loadConfigFile(relativePath);
-        if (loaded) {
-            resolvedPath = relativePath;
-            console.log('configLoader: Loaded config from ' + relativePath);
-        }
-    }
-
-    // 5. Co-located: .dmtools/config.js (same repo layout)
+    // 4. Co-located/target-root discovery: .dmtools/config.js
     if (!loaded) {
         var absolutePath = '.dmtools/config.js';
         loaded = loadConfigFile(absolutePath);
         if (loaded) {
             resolvedPath = absolutePath;
             console.log('configLoader: Loaded config from ' + absolutePath);
+        }
+    }
+
+    // 5. Relative discovery: ../.dmtools/config.js (when running from agents/)
+    if (!loaded) {
+        var relativePath = '../.dmtools/config.js';
+        loaded = loadConfigFile(relativePath);
+        if (loaded) {
+            resolvedPath = relativePath;
+            console.log('configLoader: Loaded config from ' + relativePath);
         }
     }
 

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -214,10 +214,12 @@ suite('configLoader.loadProjectConfig', function() {
         assert.equal(config.repository.owner, '');
     });
 
-    test('loads config from ../.dmtools/config.js', function() {
+    test('loads config from .dmtools/config.js before relative fallback', function() {
         var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { jira: { project: "PROJ", parentTicket: "PROJ-1" }, repository: { owner: "my-org", repo: "my-repo" } };',
             '../.dmtools/config.js':
-                'module.exports = { jira: { project: "PROJ", parentTicket: "PROJ-1" }, repository: { owner: "my-org", repo: "my-repo" } };'
+                'module.exports = { jira: { project: "REL" } };'
         });
         var config = cl.loadProjectConfig({});
         assert.equal(config.jira.project, 'PROJ');
@@ -225,16 +227,54 @@ suite('configLoader.loadProjectConfig', function() {
         assert.equal(config.repository.owner, 'my-org');
         assert.equal(config.repository.repo, 'my-repo');
         assert.equal(config.git.baseBranch, 'main', 'defaults preserved');
+        assert.equal(config._configPath, '.dmtools/config.js');
     });
 
-    test('falls back to .dmtools/config.js if relative path not found', function() {
+    test('falls back to ../.dmtools/config.js when root config not found', function() {
         var cl = makeLoader({
-            '../.dmtools/config.js': null,
-            '.dmtools/config.js':
-                'module.exports = { jira: { project: "FALLBACK" } };'
+            '.dmtools/config.js': null,
+            '../.dmtools/config.js':
+                'module.exports = { jira: { project: "REL", parentTicket: "REL-1" }, repository: { owner: "rel-org", repo: "rel-repo" } };'
         });
         var config = cl.loadProjectConfig({});
-        assert.equal(config.jira.project, 'FALLBACK');
+        assert.equal(config.jira.project, 'REL');
+        assert.equal(config.jira.parentTicket, 'REL-1');
+        assert.equal(config.repository.owner, 'rel-org');
+        assert.equal(config.repository.repo, 'rel-repo');
+        assert.equal(config.git.baseBranch, 'main', 'defaults preserved');
+        assert.equal(config._configPath, '../.dmtools/config.js');
+    });
+
+    test('does not probe relative config when root config is present', function() {
+        var paths = [];
+        var loader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            {
+                file_read: function(opts) {
+                    paths.push(opts.path);
+                    if (opts.path === '.dmtools/config.js') {
+                        return 'module.exports = { jira: { project: "ROOT" } };';
+                    }
+                    if (opts.path === '../.dmtools/config.js') {
+                        throw new Error('relative path should not be read');
+                    }
+                    return null;
+                }
+            }
+        );
+        var config = loader.loadProjectConfig({});
+        assert.equal(config.jira.project, 'ROOT');
+        assert.equal(paths.indexOf('../.dmtools/config.js'), -1, 'relative fallback skipped');
+    });
+
+    test('falls back to defaults if both discovered configs are missing', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js': null,
+            '../.dmtools/config.js': null
+        });
+        var config = cl.loadProjectConfig({});
+        assert.equal(config.jira.project, '');
     });
 
     test('uses customParams.configPath when provided', function() {
@@ -491,7 +531,7 @@ suite('configLoader.loadProjectConfig top-level configPath', function() {
 
     test('_configPath is stored for discovered paths (not just explicit)', function() {
         var mockRead = function(opts) {
-            if (opts.path === '../.dmtools/config.js') {
+            if (opts.path === '.dmtools/config.js') {
                 return 'module.exports = { jira: { project: "DISC" } };';
             }
             return null;
@@ -503,7 +543,7 @@ suite('configLoader.loadProjectConfig top-level configPath', function() {
 
         var config = loader.loadProjectConfig({});
         assert.equal(config.jira.project, 'DISC', 'discovered config loaded');
-        assert.equal(config._configPath, '../.dmtools/config.js', '_configPath set for discovered path');
+        assert.equal(config._configPath, '.dmtools/config.js', '_configPath set for discovered path');
     });
 
     test('_configPath is undefined when using defaults (no config file found)', function() {


### PR DESCRIPTION
Avoids noisy DMTools file security errors when agents run from the target repository root.

The loader now checks .dmtools/config.js before falling back to ../.dmtools/config.js. This keeps direct agents-submodule runs working while avoiding forbidden path traversal probes in root-run SM cycles.

Validation:
- dmtools run js/unit-tests/run_configLoader.json --mini
- dmtools run js/unit-tests/run_all.json --mini