### PR TITLE
fix: keep PR diff context small

### DIFF
--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -12,7 +12,7 @@
 const { GIT_CONFIG } = require('../config.js');
 const prHelper = require('./pullRequest.js');
 
-var MAX_PR_DIFF_CONTEXT_CHARS = 80000;
+var MAX_PR_DIFF_CONTEXT_CHARS = 12000;
 
 function cleanCommandOutput(output) {
     if (!output) return '';


### PR DESCRIPTION
## Summary\n- reduce generated pr_diff.txt input context to 12k chars\n- keep full diff available from checked-out PR branch via git diff/CodeGraph\n\n## Tests\n- dmtools run js/unit-tests/run_all.json --mini