### PR TITLE
fix: avoid shell fallback in git merge-base commands

### DIFF
--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -99,7 +99,7 @@ function branchContainsBase(runCommand, workingDir, baseBranch) {
     }
 
     try {
-        var mergeBase = lastNonEmptyLine(runCommand('git merge-base ' + baseRef + ' HEAD 2>/dev/null || true', workingDir));
+        var mergeBase = lastNonEmptyLine(runCommand('git merge-base ' + baseRef + ' HEAD', workingDir));
         return mergeBase === baseSha;
     } catch (e) {
         return false;
@@ -111,10 +111,14 @@ function branchHasMergeBase(runCommand, workingDir, baseBranch) {
         throw new Error('Unsafe base branch name: ' + baseBranch);
     }
 
-    var mergeBase = lastNonEmptyLine(
-        runCommand('git merge-base origin/' + baseBranch + ' HEAD 2>/dev/null || true', workingDir)
-    );
-    return !!mergeBase;
+    try {
+        var mergeBase = lastNonEmptyLine(
+            runCommand('git merge-base origin/' + baseBranch + ' HEAD', workingDir)
+        );
+        return !!mergeBase;
+    } catch (e) {
+        return false;
+    }
 }
 
 function buildOriginFetchCommand(refSpec) {

--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -117,7 +117,12 @@ function isAncestor(run, cleanOutput, path, ancestor, descendant) {
         throw new Error('Could not resolve managed submodule ancestor ref for ' + path + ': ' + ancestor);
     }
 
-    var mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant + ' 2>/dev/null || true') || '').trim().split(/\r?\n/).pop();
+    var mergeBase = '';
+    try {
+        mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant) || '').trim().split(/\r?\n/).pop();
+    } catch (e) {
+        return false;
+    }
     return mergeBase === ancestorSha;
 }
 

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -76,12 +76,20 @@ function branchHasUniquePatches(baseBranch) {
 }
 
 function isAncestorRef(ancestor, descendant) {
-    var marker = cleanCommandOutput(runCmd({ command: 'git merge-base --is-ancestor ' + ancestor + ' ' + descendant + ' >/dev/null 2>&1 && echo yes || true' }) || '');
-    return marker.trim() === 'yes';
+    try {
+        runCmd({ command: 'git merge-base --is-ancestor ' + ancestor + ' ' + descendant });
+        return true;
+    } catch (e) {
+        return false;
+    }
 }
 
 function findMergeBase(left, right) {
-    return cleanCommandOutput(runCmd({ command: 'git merge-base ' + left + ' ' + right + ' 2>/dev/null || true' }) || '');
+    try {
+        return cleanCommandOutput(runCmd({ command: 'git merge-base ' + left + ' ' + right }) || '');
+    } catch (e) {
+        return '';
+    }
 }
 
 function alignBranchWithBase(ticketKey, branchName, baseBranch) {

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -116,7 +116,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
                 if (command === 'git rev-parse origin/main') return 'base-sha';
-                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return 'old-sha';
+                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -127,8 +127,8 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
@@ -144,7 +144,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command) {
                 commands.push(command);
                 if (command === 'git rev-parse origin/release') return 'base-sha';
-                if (command === 'git merge-base origin/release HEAD 2>/dev/null || true') return 'base-sha';
+                if (command === 'git merge-base origin/release HEAD') return 'base-sha';
                 return '';
             }
         });
@@ -154,7 +154,7 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             'git -c fetch.recurseSubmodules=no fetch origin release',
             'git rev-parse origin/release',
-            'git merge-base origin/release HEAD 2>/dev/null || true'
+            'git merge-base origin/release HEAD'
         ]);
     });
 
@@ -169,7 +169,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command, workingDir) {
                 commands.push({ command: command, workingDirectory: workingDir || null });
                 if (command === 'git rev-parse origin/main') return 'base-sha';
-                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return 'old-sha';
+                if (command === 'git merge-base origin/main HEAD') return 'old-sha';
                 if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
                 return '';
             }
@@ -180,8 +180,8 @@ suite('pullRequest helper', function() {
         assert.deepEqual(commands, [
             { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
-            { command: 'git merge-base origin/main HEAD 2>/dev/null || true', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
+            { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git status --porcelain --ignore-submodules=dirty', workingDirectory: 'repo' },
             { command: 'git merge --no-edit origin/main', workingDirectory: 'repo' }
         ]);
@@ -197,7 +197,7 @@ suite('pullRequest helper', function() {
             runCommand: function(command) {
                 commands.push(command);
                 if (command === 'git rev-parse origin/main') return 'base-sha';
-                if (command === 'git merge-base origin/main HEAD 2>/dev/null || true') return '';
+                if (command === 'git merge-base origin/main HEAD') return '';
                 return '';
             }
         });

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -98,10 +98,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') {
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true') {
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
                     return 'base-sha';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
@@ -142,10 +142,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') {
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true') {
+                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
                     return 'base-sha';
                 }
                 return '';
@@ -220,7 +220,7 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true') return '';
+                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') return '';
                 return '';
             }
         });

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -198,7 +198,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1306"') return '  ai/TS-1306\n';
-            if (args.command === 'git merge-base --is-ancestor HEAD origin/main >/dev/null 2>&1 && echo yes || true') return 'yes\n';
+            if (args.command === 'git merge-base --is-ancestor HEAD origin/main') return '';
             return '';
         };
 
@@ -261,10 +261,10 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
         var mockCli = function(args) {
             calls.push(args.command);
             if (args.command === 'git branch --list "ai/TS-1307"') return '  ai/TS-1307\n';
-            if (args.command === 'git merge-base --is-ancestor HEAD origin/main >/dev/null 2>&1 && echo yes || true') return '';
+            if (args.command === 'git merge-base --is-ancestor HEAD origin/main') throw new Error('not ancestor');
             if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket work\n';
-            if (args.command === 'git merge-base --is-ancestor origin/main HEAD >/dev/null 2>&1 && echo yes || true') return '';
-            if (args.command === 'git merge-base HEAD origin/main 2>/dev/null || true') return 'base123\n';
+            if (args.command === 'git merge-base --is-ancestor origin/main HEAD') throw new Error('not ancestor');
+            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
             if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (content): Merge conflict in .dmtools/config.js\n';
             return '';
         };


### PR DESCRIPTION
Fix DMTools CLI safety failures caused by shell fallback syntax in generic agent scripts.\n\nChanges:\n- replace `2>/dev/null || true` merge-base checks with plain git commands plus JS try/catch\n- replace `merge-base --is-ancestor ... && echo yes || true` with exit-code based try/catch\n- update unit tests to assert CLI-safe commands\n\nVerification:\n- `dmtools run js/unit-tests/run_all.json --mini` -> 345 passed, 0 failed