### PR TITLE
Prevent Copilot session cache from being committed

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -229,7 +229,7 @@ function action(params) {
 
         let hasGitChanges = false;
         try {
-            cli_execute_command({ command: 'git add .' });
+            cli_execute_command({ command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"' });
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {
                 return l.trim() &&

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -204,7 +204,7 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
         // Stage all changes
         console.log('Staging changes...');
         runCmd({
-            command: 'git add .'
+            command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"'
         });
 
         // Check if there are changes to commit

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -176,7 +176,7 @@ function commitAndPush(ticketKey, config, customParams) {
         ticketKey: ticketKey
     });
 
-    cmd('git add .');
+    cmd('git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"');
 
     const status = prHelper.readStagedDiffStat(cmd, workingDir);
 

--- a/js/timerAutoCommitAndSave.js
+++ b/js/timerAutoCommitAndSave.js
@@ -68,7 +68,7 @@ function autoCommitAndPush(customParams, ticketKey) {
 
     try {
         cli_execute_command({
-            command: 'git add -A',
+            command: 'git add -A -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"',
             workingDirectory: workingDir
         });
     } catch (e) {

--- a/setup/copilot-session.sh
+++ b/setup/copilot-session.sh
@@ -78,6 +78,24 @@ _session_group_for_config() {
   esac
 }
 
+exclude_copilot_session_from_git() {
+  local workspace="$1"
+  local git_dir
+
+  git_dir="$(git -C "${workspace}" rev-parse --git-dir 2>/dev/null || true)"
+  if [ -z "${git_dir}" ]; then
+    return 0
+  fi
+
+  mkdir -p "${git_dir}/info"
+  touch "${git_dir}/info/exclude"
+
+  grep -qxF ".dmtools/copilot-sessions/" "${git_dir}/info/exclude" 2>/dev/null \
+    || echo ".dmtools/copilot-sessions/" >> "${git_dir}/info/exclude"
+  grep -qxF ".dmtools/copilot-sessions/**" "${git_dir}/info/exclude" 2>/dev/null \
+    || echo ".dmtools/copilot-sessions/**" >> "${git_dir}/info/exclude"
+}
+
 configure_copilot_session() {
   local workspace="${GITHUB_WORKSPACE:-${PWD}}"
   local repo="${GITHUB_REPOSITORY:-$(basename "${workspace}")}"
@@ -104,6 +122,7 @@ configure_copilot_session() {
   local cache_run_id="${GITHUB_RUN_ID:-local}"
 
   mkdir -p "${session_root}"
+  exclude_copilot_session_from_git "${workspace}"
 
   export_var "COPILOT_HOME" "${session_root}"
   export_var "COPILOT_SESSION_ID" "${session_id}"


### PR DESCRIPTION
Fixes AI teammate runtime session cache leaking into target PR diffs.\n\nChanges:\n- Add .dmtools/copilot-sessions to local git info/exclude during Copilot session setup.\n- Exclude .dmtools/copilot-sessions from broad git add commands in development/rework/timer flows.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini -> 345 passed, 0 failed.