### PR TITLE
Move Copilot session cache outside worktree

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -229,6 +229,11 @@ function action(params) {
 
         let hasGitChanges = false;
         try {
+            try {
+                cli_execute_command({ command: 'git rm -r --ignore-unmatch .dmtools/copilot-sessions' });
+            } catch (cleanupErr) {
+                console.warn('Could not remove tracked Copilot session cache before checking status:', cleanupErr);
+            }
             cli_execute_command({ command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"' });
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -201,6 +201,14 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
             ticketKey: ticketKey
         });
 
+        try {
+            runCmd({
+                command: 'git rm -r --ignore-unmatch .dmtools/copilot-sessions'
+            });
+        } catch (cleanupErr) {
+            console.warn('Could not remove tracked Copilot session cache before staging:', cleanupErr);
+        }
+
         // Stage all changes
         console.log('Staging changes...');
         runCmd({

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -176,6 +176,12 @@ function commitAndPush(ticketKey, config, customParams) {
         ticketKey: ticketKey
     });
 
+    try {
+        cmd('git rm -r --ignore-unmatch .dmtools/copilot-sessions');
+    } catch (cleanupErr) {
+        console.warn('Could not remove tracked Copilot session cache before staging:', cleanupErr);
+    }
+
     cmd('git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"');
 
     const status = prHelper.readStagedDiffStat(cmd, workingDir);

--- a/js/timerAutoCommitAndSave.js
+++ b/js/timerAutoCommitAndSave.js
@@ -68,6 +68,15 @@ function autoCommitAndPush(customParams, ticketKey) {
 
     try {
         cli_execute_command({
+            command: 'git rm -r --ignore-unmatch .dmtools/copilot-sessions',
+            workingDirectory: workingDir
+        });
+    } catch (cleanupErr) {
+        console.log('⏱️ timer: session cache cleanup skipped:', cleanupErr.toString().substring(0, 100));
+    }
+
+    try {
+        cli_execute_command({
             command: 'git add -A -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"',
             workingDirectory: workingDir
         });

--- a/js/unit-tests/test_timerAutoCommitAndSave.js
+++ b/js/unit-tests/test_timerAutoCommitAndSave.js
@@ -96,10 +96,11 @@ suite('timerAutoCommitAndSave — autoCommitAndPush', function() {
             currentCliOutput: ''
         });
         assert.ok(cliCalls.length >= 4, 'should call status, add, commit, push');
-        assert.contains(cliCalls[1], 'git add -A');
-        assert.contains(cliCalls[2], 'git commit');
-        assert.contains(cliCalls[2], 'PROJ-123');
-        assert.contains(cliCalls[3], 'git push');
+        assert.contains(cliCalls[1], 'git rm -r --ignore-unmatch .dmtools/copilot-sessions');
+        assert.contains(cliCalls[2], 'git add -A');
+        assert.contains(cliCalls[3], 'git commit');
+        assert.contains(cliCalls[3], 'PROJ-123');
+        assert.contains(cliCalls[4], 'git push');
     });
 });
 

--- a/setup/copilot-session.sh
+++ b/setup/copilot-session.sh
@@ -116,9 +116,10 @@ configure_copilot_session() {
   local session_seed="${repo_slug}:${key_slug}:${group_slug}"
   local session_id="$(_uuid_from_seed "${session_seed}")"
   local session_name="${repo_slug}-${key_slug}-${group_slug}"
-  local session_root="${workspace}/.dmtools/copilot-sessions/${repo_slug}/${key_slug}/${group_slug}"
+  local session_base="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/dmtools-copilot-sessions"
+  local session_root="${session_base}/${repo_slug}/${key_slug}/${group_slug}"
   local cache_prefix="copilot-session-${repo_slug}-${key_slug}-${group_slug}-"
-  local cache_version="${COPILOT_SESSION_CACHE_VERSION:-v1}"
+  local cache_version="${COPILOT_SESSION_CACHE_VERSION:-v2}"
   local cache_run_id="${GITHUB_RUN_ID:-local}"
 
   mkdir -p "${session_root}"


### PR DESCRIPTION
Prevents Copilot session cache from conflicting with target branch checkouts or leaking into PR diffs.\n\nChanges:\n- Move COPILOT_HOME to RUNNER_TEMP-backed cache path outside the git worktree.\n- Bump Copilot session cache key to v2 so old in-worktree caches are not restored.\n- Remove tracked .dmtools/copilot-sessions before broad staging in dev/rework/timer flows.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini -> 345 passed, 0 failed.\n- Local setup check shows COPILOT_HOME under /tmp/runner-temp/dmtools-copilot-sessions.