### PR TITLE
Quiet managed submodule merge-base checks

### DIFF
--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -117,12 +117,10 @@ function isAncestor(run, cleanOutput, path, ancestor, descendant) {
         throw new Error('Could not resolve managed submodule ancestor ref for ' + path + ': ' + ancestor);
     }
 
-    var mergeBase = '';
-    try {
-        mergeBase = cleanOutput(run('git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant) || '').trim().split(/\r?\n/).pop();
-    } catch (e) {
-        return false;
-    }
+    var mergeBase = cleanOutput(run('bash -lc "git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant + ' 2>/dev/null || true"') || '')
+        .trim()
+        .split(/\r?\n/)
+        .pop();
     return mergeBase === ancestorSha;
 }
 

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -98,10 +98,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                if (command === 'bash -lc "git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true"') {
                     return 'base-sha';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
@@ -142,10 +142,10 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') {
+                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') {
                     return 'old-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base origin/main HEAD') {
+                if (command === 'bash -lc "git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true"') {
                     return 'base-sha';
                 }
                 return '';
@@ -220,7 +220,7 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'git -C trackstate-setup merge-base HEAD origin/main') return '';
+                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') return '';
                 return '';
             }
         });
@@ -228,6 +228,7 @@ suite('submodule helper', function() {
         assert.ok(commands.indexOf('git -C trackstate-setup rebase origin/main') === -1, 'divergent stale gitlink should not be rebased');
         assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') === -1, 'divergent clean gitlink should not be pushed');
         assert.ok(commands.indexOf('git -C trackstate-setup checkout -B main HEAD') === -1, 'divergent clean gitlink should not rewrite branch');
+        assert.ok(commands.indexOf('git -C trackstate-setup merge-base HEAD origin/main') === -1, 'expected non-ancestor checks must not call raw merge-base through error-logging command executor');
     });
 
     test('restores stashed dirty changes when branch alignment fails', function() {


### PR DESCRIPTION
This keeps managed-submodule ancestor checks from logging expected non-ancestor states as command failures.\n\nThe previous raw git merge-base call returned exit 1 for normal divergent/stale cases, and DMTools logged it as ERROR before the JS helper handled it. The check now captures an empty merge-base result with exit 0 and keeps the existing skip behavior.\n\nVerification:\n- dmtools run js/unit-tests/run_submodules.json --mini\n- dmtools run js/unit-tests/run_all.json --mini