### PR TITLE
Avoid unsafe CLI metacharacter commands

### DIFF
--- a/js/common/submodules.js
+++ b/js/common/submodules.js
@@ -117,11 +117,13 @@ function isAncestor(run, cleanOutput, path, ancestor, descendant) {
         throw new Error('Could not resolve managed submodule ancestor ref for ' + path + ': ' + ancestor);
     }
 
-    var mergeBase = cleanOutput(run('bash -lc "git -C ' + path + ' merge-base ' + ancestor + ' ' + descendant + ' 2>/dev/null || true"') || '')
-        .trim()
-        .split(/\r?\n/)
-        .pop();
-    return mergeBase === ancestorSha;
+    var descendantSha = cleanOutput(run('git -C ' + path + ' rev-parse ' + descendant) || '').trim().split(/\r?\n/).pop();
+    if (!descendantSha) {
+        throw new Error('Could not resolve managed submodule descendant ref for ' + path + ': ' + descendant);
+    }
+
+    var notReachable = cleanOutput(run('git -C ' + path + ' rev-list -1 ' + ancestorSha + ' --not ' + descendantSha) || '').trim();
+    return !notReachable;
 }
 
 function prepareDirtySubmoduleBranch(run, cleanOutput, path, branch) {

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -104,8 +104,8 @@ function performGitOperations(branchName, commitMessage, workingDir, testFilesPa
     try {
         // Diagnostic: list test files before staging
         try {
-            var lsOutput = runInRepo('find ' + inspectPath + ' -type f 2>/dev/null | head -20', workingDir) || '';
-            console.log('Files in ' + inspectPath + ':', cleanCommandOutput(lsOutput) || '(empty)');
+            var lsOutput = runInRepo('git status --short -- ' + inspectPath, workingDir) || '';
+            console.log('Git status for ' + inspectPath + ':', cleanCommandOutput(lsOutput) || '(empty)');
         } catch (e) {
             console.warn('Could not list ' + inspectPath + ':', e);
         }

--- a/js/unit-tests/test_postTestAutomationResults.js
+++ b/js/unit-tests/test_postTestAutomationResults.js
@@ -69,7 +69,7 @@ suite('postTestAutomationResults: PR creation', function() {
                 commands.push(command);
                 if (command === 'pwd') throw new Error('pwd must not be called');
                 if (command === 'git branch --show-current') return 'test/DMC-898';
-                if (command.indexOf('find testing') === 0) return 'testing/tests/DMC-898/test_dmc_898.py';
+                if (command === 'git status --short -- testing') return '?? testing/tests/DMC-898/test_dmc_898.py';
                 if (command === 'git diff --cached --stat') return ' testing/tests/DMC-898/test_dmc_898.py | 1 +';
                 if (command.indexOf('git ls-remote --heads origin test/DMC-898') === 0) return 'abc\trefs/heads/test/DMC-898';
                 if (command.indexOf('gh pr list --head test/DMC-898') === 0) return '';
@@ -113,7 +113,7 @@ suite('postTestAutomationResults: PR creation', function() {
                 var command = opts.command;
                 commands.push(command);
                 if (command === 'git branch --show-current') return 'test/DMC-968';
-                if (command.indexOf('find testing') === 0) return 'testing/tests/DMC-968/test_dmc_968.py';
+                if (command === 'git status --short -- testing') return '?? testing/tests/DMC-968/test_dmc_968.py';
                 if (command === 'git diff --cached --stat') return '';
                 if (command.indexOf('git ls-remote --heads origin test/DMC-968') === 0) return 'abc\trefs/heads/test/DMC-968';
                 if (command.indexOf('gh pr create') === 0) throw new Error('gh pr create must not be called without branch diff');

--- a/js/unit-tests/test_submodules.js
+++ b/js/unit-tests/test_submodules.js
@@ -98,11 +98,11 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') {
-                    return 'old-sha';
+                if (command === 'git -C trackstate-setup rev-list -1 head-sha --not base-sha') {
+                    return 'head-sha';
                 }
-                if (command === 'bash -lc "git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true"') {
-                    return 'base-sha';
+                if (command === 'git -C trackstate-setup rev-list -1 base-sha --not head-sha') {
+                    return '';
                 }
                 if (command === 'git -C trackstate-setup rev-parse --short=12 HEAD') {
                     return '2b4b84712bfa';
@@ -142,11 +142,11 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') {
-                    return 'old-sha';
+                if (command === 'git -C trackstate-setup rev-list -1 head-sha --not base-sha') {
+                    return 'head-sha';
                 }
-                if (command === 'bash -lc "git -C trackstate-setup merge-base origin/main HEAD 2>/dev/null || true"') {
-                    return 'base-sha';
+                if (command === 'git -C trackstate-setup rev-list -1 base-sha --not head-sha') {
+                    return '';
                 }
                 return '';
             }
@@ -220,7 +220,8 @@ suite('submodule helper', function() {
                 if (command === 'git -C trackstate-setup rev-parse origin/main') {
                     return 'base-sha';
                 }
-                if (command === 'bash -lc "git -C trackstate-setup merge-base HEAD origin/main 2>/dev/null || true"') return '';
+                if (command === 'git -C trackstate-setup rev-list -1 head-sha --not base-sha') return 'head-sha';
+                if (command === 'git -C trackstate-setup rev-list -1 base-sha --not head-sha') return 'base-sha';
                 return '';
             }
         });
@@ -229,6 +230,7 @@ suite('submodule helper', function() {
         assert.ok(commands.indexOf('git -C trackstate-setup push origin HEAD:main') === -1, 'divergent clean gitlink should not be pushed');
         assert.ok(commands.indexOf('git -C trackstate-setup checkout -B main HEAD') === -1, 'divergent clean gitlink should not rewrite branch');
         assert.ok(commands.indexOf('git -C trackstate-setup merge-base HEAD origin/main') === -1, 'expected non-ancestor checks must not call raw merge-base through error-logging command executor');
+        assert.ok(commands.indexOf('git -C trackstate-setup rev-list -1 head-sha --not base-sha') !== -1, 'expected non-ancestor checks should use exit-zero rev-list containment check');
     });
 
     test('restores stashed dirty changes when branch alignment fails', function() {


### PR DESCRIPTION
Removes shell-metacharacter commands from shared agents JS so DMTools command validation does not log avoidable errors.\n\nChanges:\n- managed submodule ancestor checks now use an exit-zero git rev-list containment query instead of shell-wrapped merge-base\n- test automation post-processing now uses git status --short -- <path> instead of find with redirect and pipe\n\nVerification:\n- dmtools run js/unit-tests/run_submodules.json --mini\n- dmtools run js/unit-tests/run_all.json --mini