### PR TITLE
Prevalidate test review inline comment lines

### DIFF
--- a/js/postTestReviewComments.js
+++ b/js/postTestReviewComments.js
@@ -119,6 +119,79 @@ function resolveApprovedThreads(repoInfo, prNumber, resolvedThreadIds) {
     });
 }
 
+function getPrDiff(repoInfo, prNumber) {
+    try {
+        return github_get_pr_diff({
+            workspace: repoInfo.owner,
+            repository: repoInfo.repo,
+            pullRequestId: String(prNumber)
+        }) || '';
+    } catch (e) {
+        console.warn('Could not fetch PR diff for inline comment validation:', e.message || e);
+        return null;
+    }
+}
+
+function isLinePresentInDiff(diffText, filePath, targetLine) {
+    if (!diffText || !filePath || !targetLine) return true;
+
+    var lineNumber = parseInt(targetLine, 10);
+    if (!lineNumber) return true;
+
+    var currentFile = null;
+    var newLine = null;
+    var lines = String(diffText).split(/\r?\n/);
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+
+        if (line.indexOf('diff --git ') === 0) {
+            currentFile = null;
+            newLine = null;
+            continue;
+        }
+
+        if (line.indexOf('+++ b/') === 0) {
+            currentFile = line.substring('+++ b/'.length);
+            continue;
+        }
+
+        if (currentFile !== filePath) continue;
+
+        var hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+        if (hunk) {
+            newLine = parseInt(hunk[1], 10);
+            continue;
+        }
+
+        if (newLine === null) continue;
+
+        if (line.indexOf('+') === 0 || line.indexOf(' ') === 0) {
+            if (newLine === lineNumber) return true;
+            newLine++;
+        } else if (line.indexOf('-') === 0) {
+            continue;
+        } else if (line === '\\ No newline at end of file') {
+            continue;
+        } else {
+            newLine++;
+        }
+    }
+
+    return false;
+}
+
+function postFallbackInlineComment(repoInfo, prNumber, filePath, line, commentText) {
+    var lineRef = filePath + (line ? ':' + line : '');
+    github_add_pr_comment({
+        workspace: repoInfo.owner,
+        repository: repoInfo.repo,
+        pullRequestId: String(prNumber),
+        text: '📍 **`' + lineRef + '`**\n\n' + commentText
+    });
+    console.log('✅ Posted fallback PR comment for ' + lineRef);
+}
+
 function postInlineComment(repoInfo, prNumber, inlineComment) {
     const filePath = inlineComment.path || inlineComment.file;
     const commentText = inlineComment.body || readFile(inlineComment.comment);
@@ -144,20 +217,20 @@ function postInlineComment(repoInfo, prNumber, inlineComment) {
         if (inlineComment.startLine) params.startLine = String(inlineComment.startLine);
         if (inlineComment.side) params.side = inlineComment.side;
 
+        var diffText = getPrDiff(repoInfo, prNumber);
+        if (diffText !== null && !isLinePresentInDiff(diffText, filePath, inlineComment.line)) {
+            console.warn('Inline comment line is not present in PR diff; falling back to PR comment on ' + filePath + ':' + inlineComment.line);
+            postFallbackInlineComment(repoInfo, prNumber, filePath, inlineComment.line, commentText);
+            return true;
+        }
+
         github_add_inline_comment(params);
         console.log('✅ Inline comment on ' + filePath + ':' + inlineComment.line);
         return true;
     } catch (e) {
         console.warn('Inline comment failed (line not in diff?), falling back to PR comment on ' + filePath + ':' + inlineComment.line);
         try {
-            var lineRef = filePath + (inlineComment.line ? ':' + inlineComment.line : '');
-            github_add_pr_comment({
-                workspace: repoInfo.owner,
-                repository: repoInfo.repo,
-                pullRequestId: String(prNumber),
-                text: '📍 **`' + lineRef + '`**\n\n' + commentText
-            });
-            console.log('✅ Posted fallback PR comment for ' + lineRef);
+            postFallbackInlineComment(repoInfo, prNumber, filePath, inlineComment.line, commentText);
             return true;
         } catch (fallbackError) {
             console.warn('Failed to post fallback PR comment:', fallbackError);

--- a/js/unit-tests/test_postTestReviewComments.js
+++ b/js/unit-tests/test_postTestReviewComments.js
@@ -18,6 +18,7 @@ function loadPostTestReviewComments(mocks) {
         github_list_prs: function() { return []; },
         github_add_pr_comment: function() {},
         github_add_inline_comment: function() {},
+        github_get_pr_diff: function() { return null; },
         github_add_pr_label: function() {},
         github_resolve_pr_thread: function() {},
         cli_execute_command: function() { return ''; }
@@ -196,5 +197,63 @@ suite('postTestReviewComments: inline comments', function() {
         assert.equal(prComments.length, 2, 'general comment plus fallback inline comment');
         assert.contains(prComments[1].text, 'testing/tests/TS-250/test_ts_250.py:99');
         assert.contains(prComments[1].text, 'Fallback inline finding');
+    });
+
+    test('falls back without calling inline API when line is not in PR diff', function() {
+        var inlineCalls = [];
+        var prComments = [];
+        var module = loadPostTestReviewComments({
+            file_read: function(opts) {
+                if (opts.path && opts.path.indexOf('.dmtools/config') !== -1) return null;
+                if (opts.path === 'outputs/pr_review.json') {
+                    return JSON.stringify({
+                        recommendation: 'REQUEST_CHANGES',
+                        generalComment: 'outputs/pr_review_general.md',
+                        inlineComments: [
+                            {
+                                path: 'testing/tests/TS-250/config.yaml',
+                                line: 59,
+                                body: 'Line is outside the diff.'
+                            }
+                        ]
+                    });
+                }
+                if (opts.path === 'outputs/pr_review_general.md') return 'General comment';
+                return null;
+            },
+            github_list_prs: function() {
+                return [{ number: 255, html_url: 'https://github.com/org/repo/pull/255', head: { ref: 'test/DMC-1104' } }];
+            },
+            cli_execute_command: function() {
+                return 'https://github.com/IstiN/trackstate';
+            },
+            github_get_pr_diff: function() {
+                return [
+                    'diff --git a/testing/tests/TS-250/config.yaml b/testing/tests/TS-250/config.yaml',
+                    '--- a/testing/tests/TS-250/config.yaml',
+                    '+++ b/testing/tests/TS-250/config.yaml',
+                    '@@ -1,3 +1,3 @@',
+                    ' name: TS-250',
+                    '+enabled: true',
+                    ' owner: qa'
+                ].join('\n');
+            },
+            github_add_inline_comment: function(args) {
+                inlineCalls.push(args);
+            },
+            github_add_pr_comment: function(args) {
+                prComments.push(args);
+            }
+        });
+
+        var result = module.action({
+            ticket: { key: 'DMC-1104', fields: { summary: 'Inline diff prevalidation' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(inlineCalls.length, 0, 'inline API should not be called for a line outside the PR diff');
+        assert.equal(prComments.length, 2, 'general comment plus fallback inline comment');
+        assert.contains(prComments[1].text, 'testing/tests/TS-250/config.yaml:59');
+        assert.contains(prComments[1].text, 'Line is outside the diff');
     });
 });


### PR DESCRIPTION
Avoids GitHub 422 stacktraces when a test-review inline comment points to a line outside the PR diff.\n\nThe test review post-action now checks the PR diff hunk first. If the requested line is not present in the diff, it posts the finding as a normal PR comment with file:line instead of calling github_add_inline_comment and triggering a validation error.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini