### PR TITLE
Strictly match merged PR recovery

### DIFF
--- a/js/recoverMergedPRTicket.js
+++ b/js/recoverMergedPRTicket.js
@@ -11,8 +11,7 @@ function prMatchesTicket(pr, ticketKey) {
     if (!pr || !ticketKey) return false;
     var titleMatch = pr.title && pr.title.indexOf(ticketKey) !== -1;
     var branchMatch = pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1;
-    var bodyMatch = pr.body && pr.body.indexOf(ticketKey) !== -1;
-    return !!(titleMatch || branchMatch || bodyMatch);
+    return !!(titleMatch || branchMatch);
 }
 
 function isMergedPR(pr) {
@@ -23,6 +22,19 @@ function isMergedPR(pr) {
 }
 
 function findMergedPRForTicket(scm, ticketKey) {
+    try {
+        var open = scm.listPrs('open') || [];
+        for (var openIndex = 0; openIndex < open.length; openIndex++) {
+            if (prMatchesTicket(open[openIndex], ticketKey)) {
+                console.log('Open PR still exists for ' + ticketKey + ', skipping merged-PR recovery: #' + open[openIndex].number);
+                return null;
+            }
+        }
+    } catch (openError) {
+        console.warn('Could not list open PRs for merged recovery guard:', openError.message || openError);
+        return null;
+    }
+
     var closed = [];
     try {
         closed = scm.listPrs('closed') || [];

--- a/js/unit-tests/test_recoverMergedPRTicket.js
+++ b/js/unit-tests/test_recoverMergedPRTicket.js
@@ -43,6 +43,7 @@ suite('recoverMergedPRTicket', function() {
         var loaded = loadRecoverMergedPRTicket({
             scm: {
                 listPrs: function(state) {
+                    if (state === 'open') return [];
                     assert.equal(state, 'closed');
                     return [{
                         number: 1512,
@@ -71,10 +72,67 @@ suite('recoverMergedPRTicket', function() {
         assert.contains(loaded.comments[0].comment, 'Merged PR Recovered');
     });
 
+    test('does nothing when a matching open PR still exists', function() {
+        var loaded = loadRecoverMergedPRTicket({
+            scm: {
+                listPrs: function(state) {
+                    if (state === 'open') {
+                        return [{
+                            number: 1571,
+                            title: 'TS-1293 Busy-startup retry does not restore active local workspace as Local Git',
+                            head: { ref: 'ai/TS-1293' }
+                        }];
+                    }
+                    if (state === 'closed') {
+                        throw new Error('closed PRs should not be inspected while a matching open PR exists');
+                    }
+                    return [];
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-1293' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'none');
+        assert.deepEqual(loaded.statusMoves, []);
+        assert.deepEqual(loaded.removedLabels, []);
+        assert.deepEqual(loaded.comments, []);
+    });
+
+    test('does not match unrelated merged PR that only mentions ticket in body', function() {
+        var loaded = loadRecoverMergedPRTicket({
+            scm: {
+                listPrs: function(state) {
+                    if (state === 'open') return [];
+                    if (state === 'closed') {
+                        return [{
+                            number: 1623,
+                            title: 'Fail AI teammate when JS action reports failure',
+                            body: 'TS-1293 pr_rework posted a push failure comment.',
+                            head: { ref: 'fix/fail-ai-teammate-on-js-false' },
+                            merged_at: '2026-06-01T07:48:14Z'
+                        }];
+                    }
+                    return [];
+                }
+            }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'TS-1293' }, jobParams: {} });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'none');
+        assert.deepEqual(loaded.statusMoves, []);
+        assert.deepEqual(loaded.removedLabels, []);
+        assert.deepEqual(loaded.comments, []);
+    });
+
     test('does nothing when matching PR is closed but not merged', function() {
         var loaded = loadRecoverMergedPRTicket({
             scm: {
-                listPrs: function() {
+                listPrs: function(state) {
+                    if (state === 'open') return [];
                     return [{
                         number: 9,
                         title: 'TS-1272 attempted fix',


### PR DESCRIPTION
Fixes a false recovery case where a merged infra PR that only mentioned a ticket key in the PR body could move the ticket to Merged while the real ticket PR was still open.\n\nChanges:\n- Do not match recovery PRs by body text.\n- Guard recovery by checking for an open title/branch match first.\n- Fail closed if open PR listing is unavailable.\n- Add unit coverage for TS-1293/#1623 style false positives.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini