### PR TITLE
Use force-with-lease for rework push fallback

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -213,8 +213,8 @@ function commitAndPush(ticketKey, config, customParams) {
     try {
         cmd('git push -u origin ' + branchName);
     } catch (pushError) {
-        console.log('Normal push failed, force pushing...');
-        cmd('git push -u origin ' + branchName + ' --force');
+        console.log('Normal push failed, retrying with --force-with-lease...');
+        cmd('git push -u origin ' + branchName + ' --force-with-lease');
     }
 
     const remoteCheck = cleanCommandOutput(cmd('git ls-remote --heads origin ' + branchName) || '');


### PR DESCRIPTION
Avoid unsafe bare force pushes from pr_rework post-action.\n\nObserved on trackstate TS-1293: normal push was rejected as non-fast-forward, then the post-action retried with bare --force. This can overwrite a concurrently advanced PR branch.\n\nChange:\n- Retry with --force-with-lease instead of --force in pushReworkChanges.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini