### PR TITLE
Prefer CodeGraph in investigation instructions

### DIFF
--- a/instructions/common/investigate_before_answer.md
+++ b/instructions/common/investigate_before_answer.md
@@ -2,9 +2,9 @@
 
 **Before providing any answer, recommendation, or content, investigate the relevant context.**
 
-Use CLI tools (`find`, `ls`, `cat`, `grep`) and dmtools commands to:
+Use CodeGraph first for source-code investigation (`codegraph context "<topic>"`, `codegraph query`, `codegraph callers`, `codegraph impact`) and dmtools commands to:
 1. Read the full ticket (`request.md`) and its comment history (`comments.md`).
 2. Fetch the parent story for complete business context (run `dmtools jira_get_ticket PARENT-KEY` if needed).
-3. Explore the existing codebase or documentation relevant to the question — do not rely solely on the ticket text.
+3. Explore the existing codebase or documentation relevant to the question — do not rely solely on the ticket text. Use `grep`, `find`, `cat`, or `sed` only after CodeGraph when you need literal text, file listing, or a specific file excerpt.
 
 Ground your answer in **verified facts** from the investigation. If the codebase or documentation contains an authoritative answer, cite it explicitly. Only state assumptions when information is genuinely absent.

--- a/instructions/common/investigate_before_questioning.md
+++ b/instructions/common/investigate_before_questioning.md
@@ -2,6 +2,6 @@
 
 **Before raising any question, verify whether it can be answered by reading the codebase.**
 
-Use CLI tools (`find`, `ls`, `cat`, `grep`) to investigate relevant files. If the answer is discoverable from the code, note your finding and **skip the question entirely**.
+Use CodeGraph first for source-code investigation (`codegraph context "<topic>"`, `codegraph query`, `codegraph callers`, `codegraph impact`). Use `grep`, `find`, `cat`, or `sed` only after CodeGraph when you need literal text, file listing, or a specific file excerpt. If the answer is discoverable from the code, note your finding and **skip the question entirely**.
 
 Only raise a question when the information is genuinely absent from the codebase and requires a human decision or confirmation.

--- a/instructions/common/investigate_before_solution.md
+++ b/instructions/common/investigate_before_solution.md
@@ -2,9 +2,11 @@
 
 **Before writing any solution design, investigate the existing codebase.**
 
-Use CLI tools (`find`, `ls`, `cat`, `grep`) to:
+Use CodeGraph first for source-code investigation (`codegraph context "<solution area>"`, `codegraph query`, `codegraph callers`, `codegraph impact`) to:
 1. Locate components (classes, services, modules, UI) related to the story domain.
 2. Understand the current data model and integration patterns.
 3. Identify existing automation and test coverage that may be affected.
+
+Use `grep`, `find`, `cat`, or `sed` only after CodeGraph when you need literal text, file listing, or a specific file excerpt.
 
 Only propose new components or patterns when the existing codebase genuinely does not satisfy the requirement. Where existing code can be extended or reused, prefer that approach and justify the decision explicitly in the solution.

--- a/instructions/rework/rework_instructions.md
+++ b/instructions/rework/rework_instructions.md
@@ -19,7 +19,7 @@ Do NOT run `git commit` or `git merge --abort` — the commit is handled automat
 ## Approach
 
 1. **Read `pr_discussions.md` first** — list all review comments and threads before touching any code
-2. **Be surgical but thorough** — fix the exact issue the reviewer flagged, then **search the entire codebase for the same pattern** and fix all similar occurrences. For example, if the reviewer flags a hardcoded `accessibilityRole="button"` string literal, `grep -r 'accessibilityRole="' src/ --include="*.tsx"` and fix ALL matching files — not just the one the reviewer pointed out. This prevents the same issue from being raised in the next review cycle. Do not refactor unrelated code or add unrequested features.
+2. **Be surgical but thorough** — fix the exact issue the reviewer flagged, then use CodeGraph to find the same structural pattern across the codebase and fix all similar occurrences. Start with `codegraph context "<review issue and affected area>"`; use `codegraph query`, `codegraph callers`, or `codegraph impact` when you know a symbol. Use `grep` only after CodeGraph when you need a literal string search. This prevents the same issue from being raised in the next review cycle. Do not refactor unrelated code or add unrequested features.
 3. **Address BLOCKING issues first** (security, critical bugs), then IMPORTANT, then SUGGESTIONS
 4. **If a SUGGESTION is minor and time-consuming**, you may skip it but explicitly note it in `outputs/response.md`
 

--- a/prompts/pr_rework_prompt.md
+++ b/prompts/pr_rework_prompt.md
@@ -64,7 +64,7 @@ For each thread:
 1. Understand the issue described by the reviewer
 2. Locate the relevant code in the codebase
 3. Apply the required fix
-4. **Search the entire codebase for the same pattern** and fix ALL similar occurrences — not just the exact line the reviewer flagged. For example, if the reviewer flags a missing `accessibilityLabel`, search all similar components for the same omission and fix them too. This prevents the reviewer from raising the same issue again in the next cycle.
+4. **Use CodeGraph to inspect the same pattern across the codebase** and fix ALL similar occurrences — not just the exact line the reviewer flagged. Start source-code navigation with `codegraph context "<review issue and affected area>"`, then use `codegraph query`, `codegraph callers`, or `codegraph impact` for related symbols. Use grep only after CodeGraph when you need a literal string match. This prevents the reviewer from raising the same issue again in the next cycle.
 5. Write a reply entry in `outputs/review_replies.json` — mention all files you fixed (both the flagged one and the similar ones found by search)
 
 **Every human review thread in `pr_discussions.md` must have exactly one matching entry in `review_replies.json`. Do not skip any thread.**


### PR DESCRIPTION
Strengthens CodeGraph-first behavior for source-code agents.\n\nWhy:\n- TrackState rework logs showed source-code rework completing without recorded CodeGraph usage even though codegraph_tools.md is globally injected.\n- Some older instructions still explicitly suggested grep/find/cat first, which can conflict with the global CodeGraph rule.\n\nChanges:\n- Rework instructions now say to use CodeGraph to find structural patterns, with grep only for literal search after CodeGraph.\n- Common investigate-before-* instructions now say CodeGraph first for source-code investigation.\n\nVerification:\n- dmtools run js/unit-tests/run_all.json --mini