### PR TITLE
Tighten CodeGraph requirement for rework agents

### DIFF
--- a/instructions/rework/rework_instructions.md
+++ b/instructions/rework/rework_instructions.md
@@ -19,7 +19,7 @@ Do NOT run `git commit` or `git merge --abort` — the commit is handled automat
 ## Approach
 
 1. **Read `pr_discussions.md` first** — list all review comments and threads before touching any code
-2. **Be surgical but thorough** — fix the exact issue the reviewer flagged, then use CodeGraph to find the same structural pattern across the codebase and fix all similar occurrences. Start with `codegraph context "<review issue and affected area>"`; use `codegraph query`, `codegraph callers`, or `codegraph impact` when you know a symbol. Use `grep` only after CodeGraph when you need a literal string search. This prevents the same issue from being raised in the next review cycle. Do not refactor unrelated code or add unrequested features.
+2. **Be surgical but thorough** — before opening or editing any source file, run `codegraph context "<ticket key> <review issue and affected area>"`, even if the review already names an exact file, line, failing assertion, or test. Then fix the exact issue the reviewer flagged and use CodeGraph to find the same structural pattern across the codebase. Use `codegraph query`, `codegraph callers`, or `codegraph impact` when you know a symbol. Use `grep` only after CodeGraph when you need a literal string search. This prevents the same issue from being raised in the next review cycle. Do not refactor unrelated code or add unrequested features.
 3. **Address BLOCKING issues first** (security, critical bugs), then IMPORTANT, then SUGGESTIONS
 4. **If a SUGGESTION is minor and time-consuming**, you may skip it but explicitly note it in `outputs/response.md`
 

--- a/prompts/codegraph_tools.md
+++ b/prompts/codegraph_tools.md
@@ -22,7 +22,7 @@ Use `codegraph context "<task description>"` by default. Use `codegraph query "<
 
 After editing code, run `codegraph sync` before any further CodeGraph query.
 
-Only skip CodeGraph when the task does not involve source-code navigation (for example, a pure Jira/status update or a known single-file text edit). If you skip it, state the reason in the final response.
+Only skip CodeGraph when the task does not involve source-code navigation at all (for example, a pure Jira/status update). Source-code agents such as development, rework, review, and test automation must still run at least one CodeGraph command even when the requested fix names an exact file, line, failing test, or review comment. In that case use a short targeted command such as `codegraph context "<ticket key> <file or failing test> <issue summary>"`.
 
 **Prefer CodeGraph over `grep` or `cat` for code understanding** — it uses the pre-built semantic index and returns only relevant, structured results.
 


### PR DESCRIPTION
## Summary\n- remove the single-file source edit CodeGraph skip loophole\n- require pr_rework to run targeted CodeGraph context before opening or editing source files\n\n## Tests\n- dmtools run js/unit-tests/run_all.json --mini