### PR TITLE
Clarify bulk bug creation scoped input paths

### DIFF
--- a/bulk_bugs_creation.json
+++ b/bulk_bugs_creation.json
@@ -7,8 +7,8 @@
     "agentParams": {
       "aiRole": "QA Engineer",
       "instructions": [
-        "Read input/failed_tcs.json for the list of failed Test Cases.",
-        "Read input/open_bugs.json for all existing non-Done bugs.",
+        "Read input/failed_tcs.json for the list of failed Test Cases. If it is not present, read input/<trigger-ticket-key>/failed_tcs.json.",
+        "Read input/open_bugs.json for all existing non-Done bugs. If it is not present, read input/<trigger-ticket-key>/open_bugs.json.",
         "Done bugs are intentionally excluded from bug matching.",
         "For each failed TC decide: link to existing non-Done bug, create new bug, or skip (test code issue only).",
         "Group TCs with the same root cause — create ONE new bug for the group.",

--- a/prompts/bulk_bugs_creation_prompt.md
+++ b/prompts/bulk_bugs_creation_prompt.md
@@ -1,10 +1,14 @@
 You are a QA Engineer analyzing a batch of failed Test Cases to create or link bugs efficiently.
 
-**IMPORTANT**: Process ALL test cases in `input/failed_tcs.json`. Group related failures into single bugs.
+**IMPORTANT**: Process ALL test cases in `input/failed_tcs.json`. If the root
+file is not present, use the trigger-ticket scoped input folder, for example
+`input/TS-123/failed_tcs.json`. Group related failures into single bugs.
 
 ## Step 1 — Read the failed Test Cases
 
-Read `input/failed_tcs.json`. It contains an array of failed Test Case objects, each with:
+Read `input/failed_tcs.json`, or `input/<trigger-ticket-key>/failed_tcs.json`
+when the root file is absent. It contains an array of failed Test Case objects,
+each with:
 - `key` — Jira ticket key
 - `summary` — what the TC tests
 - `description` — test case details
@@ -19,7 +23,9 @@ If the latest comment is a PR/test review instead of the raw test run, interpret
 
 ## Step 2 — Read existing non-Done bugs
 
-Read `input/open_bugs.json`. It contains an array of **non-Done** bug objects, each with:
+Read `input/open_bugs.json`, or `input/<trigger-ticket-key>/open_bugs.json`
+when the root file is absent. It contains an array of **non-Done** bug objects,
+each with:
 - `key` — existing bug key
 - `summary` — bug summary
 - `description` — bug description


### PR DESCRIPTION
Bulk bug context is written under the trigger-ticket scoped input folder when the root input files are not present. Tell the agent to read input/<ticket>/failed_tcs.json and input/<ticket>/open_bugs.json directly to avoid unnecessary search/grep recovery.\n\nTests: dmtools run js/unit-tests/run_all.json --mini