### PR TITLE
Require CodeGraph first in test automation prompt

### DIFF
--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -14,6 +14,7 @@ The feature code is **already implemented** in the `main` branch and **deployed*
 
 ## Your task
 
+0. Before inspecting `testing/` or any source file, run a targeted CodeGraph command such as `codegraph context "<ticket key> test automation existing tests and reusable helpers"`. Use CodeGraph for code investigation before `grep`, `find`, `cat`, `sed`, or opening files directly.
 1. Analyze the Test Case: understand what needs to be verified, what type it is (web, mobile, API), and which framework fits best.
 2. Check `testing/` for existing components (pages, screens, services) and core utilities you can reuse.
 3. **Check if test already exists** in `testing/tests/{TICKET-KEY}/`. If it does, reuse and update it rather than rewriting from scratch. Only modify what is necessary.


### PR DESCRIPTION
## Summary\n- add an explicit Step 0 to the test automation prompt requiring CodeGraph before inspecting testing/ or source files\n- make the existing generic CodeGraph rule harder to miss for test automation agents\n\n## Verification\n- prompt-only change