### PR TITLE
Fix PR sync merge-base on shallow checkouts

### DIFF
--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -121,6 +121,33 @@ function branchHasMergeBase(runCommand, workingDir, baseBranch) {
     }
 }
 
+function fetchAdditionalHistoryForMergeBase(runCommand, workingDir, baseBranch, branchName) {
+    var refSpecs = [
+        '+refs/heads/' + baseBranch + ':refs/remotes/origin/' + baseBranch
+    ];
+    if (branchName && isSafeRefName(branchName)) {
+        refSpecs.push('+refs/heads/' + branchName + ':refs/remotes/origin/' + branchName);
+    }
+
+    var deepenCommands = [];
+    for (var i = 0; i < refSpecs.length; i++) {
+        deepenCommands.push('git -c fetch.recurseSubmodules=no fetch --deepen=100 origin ' + refSpecs[i]);
+    }
+    deepenCommands.push('git -c fetch.recurseSubmodules=no fetch --unshallow origin');
+
+    for (var j = 0; j < deepenCommands.length; j++) {
+        try {
+            runCommand(deepenCommands[j], workingDir);
+        } catch (e) {
+            console.warn('Could not deepen git history for merge-base lookup:', e.message || e);
+        }
+        if (branchHasMergeBase(runCommand, workingDir, baseBranch)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function buildOriginFetchCommand(refSpec) {
     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
 }
@@ -158,7 +185,8 @@ function syncBranchWithBase(options) {
             return { success: true, updated: false };
         }
 
-        if (!branchHasMergeBase(runCommand, workingDir, baseBranch)) {
+        if (!branchHasMergeBase(runCommand, workingDir, baseBranch) &&
+                !fetchAdditionalHistoryForMergeBase(runCommand, workingDir, baseBranch, branchName)) {
             return {
                 success: false,
                 unrecoverableByAgent: true,

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -206,6 +206,41 @@ suite('pullRequest helper', function() {
         assert.equal(result.unrecoverableByAgent, true);
         assert.contains(result.error, 'No merge base found');
         assert.equal(commands.indexOf('git merge --no-edit origin/main'), -1);
+        assert.ok(commands.indexOf('git -c fetch.recurseSubmodules=no fetch --deepen=100 origin +refs/heads/main:refs/remotes/origin/main') !== -1,
+            'should deepen base history before declaring histories unrelated');
+        assert.ok(commands.indexOf('git -c fetch.recurseSubmodules=no fetch --deepen=100 origin +refs/heads/feature/DMC-7:refs/remotes/origin/feature/DMC-7') !== -1,
+            'should deepen head branch history before declaring histories unrelated');
+    });
+
+    test('deepens shallow history before merge-base refusal', function() {
+        var commands = [];
+        var mergeBaseAttempts = 0;
+        var pr = loadPullRequestHelper();
+
+        var result = pr.syncBranchWithBase({
+            branchName: 'feature/DMC-8',
+            baseBranch: 'main',
+            workingDir: 'repo',
+            runCommand: function(command, workingDir) {
+                commands.push({ command: command, workingDirectory: workingDir || null });
+                if (command === 'git rev-parse origin/main') return 'base-sha';
+                if (command === 'git merge-base origin/main HEAD') {
+                    mergeBaseAttempts += 1;
+                    return mergeBaseAttempts < 3 ? '' : 'old-sha';
+                }
+                if (command === 'git status --porcelain --ignore-submodules=dirty') return '';
+                return '';
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.updated, true);
+        assert.ok(commands.some(function(call) {
+            return call.command === 'git -c fetch.recurseSubmodules=no fetch --deepen=100 origin +refs/heads/main:refs/remotes/origin/main';
+        }), 'expected base history deepen fetch');
+        assert.ok(commands.some(function(call) {
+            return call.command === 'git merge --no-edit origin/main';
+        }), 'expected merge after merge-base is found');
     });
 
 });


### PR DESCRIPTION
Fixes PR publishing when a runner has shallow history and an existing remote AI branch.

Changes:
- before treating missing merge-base as unrelated histories, deepen origin/base and origin/head branch refs
- keep the final unrelated-history refusal when merge-base still cannot be found
- add unit coverage for shallow-history recovery and the true unrelated-history path

Validation:
- dmtools run js/unit-tests/run_all.json -> 350 passed, 0 failed