### PR TITLE
Guard PR review rework loops

### DIFF
--- a/instructions/rework/rework_instructions.md
+++ b/instructions/rework/rework_instructions.md
@@ -23,6 +23,16 @@ Do NOT run `git commit` or `git merge --abort` — the commit is handled automat
 3. **Address BLOCKING issues first** (security, critical bugs), then IMPORTANT, then SUGGESTIONS
 4. **If a SUGGESTION is minor and time-consuming**, you may skip it but explicitly note it in `outputs/response.md`
 
+## Scope-Creep Review Loop Guard
+
+If a reviewer blocks the PR because `pr_diff.txt` contains an unrelated deleted file, generated/cache artifact, tooling file, or other out-of-scope path, this is an actionable blocking issue even if it appears as a general PR comment instead of an inline thread.
+
+Before writing a no-action response:
+- Re-read `pr_diff.txt` and confirm the blocked path is no longer present.
+- For deleted unrelated files, restore the file from the base branch or otherwise remove that deletion from the PR diff.
+- Do not write "No open review comments" or "No new actionable items" while the blocked path remains in `pr_diff.txt`.
+- If the same path appears in repeated review cycles, fix that path first to stop the loop.
+
 ## Rework Decision Flow
 
 Use this flow before changing code so approved PRs that are only waiting for CI or merge checks do not enter a stale rework loop:

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -290,6 +290,62 @@ function postGeneralComment(scm, pullRequestId, commentPath) {
     }
 }
 
+function isLinePresentInDiff(diffText, filePath, targetLine) {
+    if (!diffText || !filePath || !targetLine) return true;
+
+    var lineNumber = parseInt(targetLine, 10);
+    if (!lineNumber) return true;
+
+    var currentFile = null;
+    var newLine = null;
+    var lines = String(diffText).split(/\r?\n/);
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+
+        if (line.indexOf('diff --git ') === 0) {
+            currentFile = null;
+            newLine = null;
+            continue;
+        }
+
+        if (line.indexOf('+++ b/') === 0) {
+            currentFile = line.substring('+++ b/'.length);
+            if (currentFile === '/dev/null') currentFile = null;
+            continue;
+        }
+
+        if (currentFile !== filePath) continue;
+
+        var hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+        if (hunk) {
+            newLine = parseInt(hunk[1], 10);
+            continue;
+        }
+
+        if (newLine === null) continue;
+
+        if (line.indexOf('+') === 0 || line.indexOf(' ') === 0) {
+            if (newLine === lineNumber) return true;
+            newLine++;
+        } else if (line.indexOf('-') === 0) {
+            continue;
+        } else if (line === '\\ No newline at end of file') {
+            continue;
+        } else {
+            newLine++;
+        }
+    }
+
+    return false;
+}
+
+function postFallbackInlineComment(scm, pullRequestId, filePath, line, commentText) {
+    var lineRef = filePath + (line ? ':' + line : '');
+    scm.addComment(pullRequestId, '📍 **`' + lineRef + '`**\n\n' + commentText);
+    console.log('✅ Posted fallback PR comment for ' + lineRef);
+}
+
 function postInlineComment(scm, pullRequestId, inlineComment) {
     // Accept both spec formats:
     //   old spec: { file, comment: "path/to/file.md" }
@@ -309,6 +365,17 @@ function postInlineComment(scm, pullRequestId, inlineComment) {
 
         console.log('Posting inline comment on ' + filePath + ':' + inlineComment.line);
 
+        try {
+            var diffText = scm.getPrDiff(pullRequestId);
+            if (diffText !== null && !isLinePresentInDiff(diffText, filePath, inlineComment.line)) {
+                console.warn('Inline comment line is not present in PR diff; falling back to PR comment on ' + filePath + ':' + inlineComment.line);
+                postFallbackInlineComment(scm, pullRequestId, filePath, inlineComment.line, commentText);
+                return true;
+            }
+        } catch (diffError) {
+            console.warn('Could not fetch PR diff for inline comment validation:', diffError.message || diffError);
+        }
+
         scm.addInlineComment(
             pullRequestId, filePath, inlineComment.line, commentText,
             inlineComment.startLine || null, inlineComment.side || null
@@ -321,9 +388,7 @@ function postInlineComment(scm, pullRequestId, inlineComment) {
         // 422 = line not in diff hunk — fall back to a regular PR comment so nothing is lost
         console.warn('Inline comment failed (line not in diff?), falling back to PR comment on ' + filePath + ':' + inlineComment.line);
         try {
-            var lineRef = filePath + (inlineComment.line ? ':' + inlineComment.line : '');
-            scm.addComment(pullRequestId, '📍 **`' + lineRef + '`**\n\n' + commentText);
-            console.log('✅ Posted fallback PR comment for ' + lineRef);
+            postFallbackInlineComment(scm, pullRequestId, filePath, inlineComment.line, commentText);
             return true;
         } catch (fallbackError) {
             console.error('Failed to post fallback PR comment for ' + filePath + ':', fallbackError);
@@ -780,5 +845,5 @@ function action(params) {
 
 // Export for dmtools standalone execution
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, resolveCustomParams };
+    module.exports = { action, resolveCustomParams, isLinePresentInDiff };
 }

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -48,4 +48,35 @@ suite('postPRReviewComments', function() {
         assert.equal(customParams.removeLabel, 'sm_story_review_triggered');
         assert.deepEqual(customParams.targetRepository, { owner: 'IstiN', repo: 'trackstate' });
     });
+
+    test('detects line present in added side of PR diff', function() {
+        var mod = loadPostPRReviewComments();
+        var diff =
+            'diff --git a/lib/example.dart b/lib/example.dart\n' +
+            'index 1111111..2222222 100644\n' +
+            '--- a/lib/example.dart\n' +
+            '+++ b/lib/example.dart\n' +
+            '@@ -10,2 +10,3 @@ class Example {\n' +
+            ' context line\n' +
+            '+new line\n' +
+            ' another context\n';
+
+        assert.equal(mod.isLinePresentInDiff(diff, 'lib/example.dart', 11), true);
+        assert.equal(mod.isLinePresentInDiff(diff, 'lib/example.dart', 99), false);
+    });
+
+    test('treats deleted file lines as unavailable for inline comments', function() {
+        var mod = loadPostPRReviewComments();
+        var diff =
+            'diff --git a/.codegraph/.gitignore b/.codegraph/.gitignore\n' +
+            'deleted file mode 100644\n' +
+            'index 1111111..0000000\n' +
+            '--- a/.codegraph/.gitignore\n' +
+            '+++ /dev/null\n' +
+            '@@ -1,2 +0,0 @@\n' +
+            '-index\n' +
+            '-cache\n';
+
+        assert.equal(mod.isLinePresentInDiff(diff, '.codegraph/.gitignore', 1), false);
+    });
 });

--- a/prompts/pr_rework_prompt.md
+++ b/prompts/pr_rework_prompt.md
@@ -27,6 +27,16 @@ Your mission is to address every issue raised in `pr_discussions.md`. This inclu
 
 **Ignore only**: bot ticket-link comments (e.g. "TICKET-123 ...link..."), previous rework summary comments, and automated code review APPROVE comments — these are informational and require no action.
 
+### 🚫 SCOPE-CREEP REVIEW LOOP GUARD
+
+If a review blocks the PR for an unrelated, deleted, generated, cache, tooling, or scope-creep file:
+
+- Treat it as an actionable blocking issue even when the comment is posted as a general PR comment rather than an inline thread.
+- Re-read the current `pr_diff.txt` and verify the path is gone from the PR diff before writing `outputs/response.md`.
+- For deleted unrelated files, restore the file from the base branch or remove the deletion from the PR so the diff no longer contains that path.
+- Do NOT answer "No new actionable items" while `pr_diff.txt` still contains the blocked path.
+- If the same blocking path was mentioned in a previous review cycle, prioritize removing that diff before any other cleanup.
+
 ### 🛑 STALE AUTOMATION LOOP — DO NOT REPEAT YOURSELF
 
 If the only "blocker" is the reviewer asking for fresh post-fix automation, and you have ALREADY explained in a previous rework cycle that the code addresses the failure:


### PR DESCRIPTION
## Summary
- validate PR review inline comment lines against the current diff before calling the GitHub inline comment API
- fall back directly to a PR-level comment for deleted/out-of-diff paths
- strengthen PR rework instructions so blocking scope-creep/deleted-file comments cannot be treated as no-action while the path remains in pr_diff.txt

## Tests
- dmtools run js/unit-tests/run_all.json (354 passed, 0 failed)