### PR TITLE
Sync rework branch before retry push

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -213,8 +213,18 @@ function commitAndPush(ticketKey, config, customParams) {
     try {
         cmd('git push -u origin ' + branchName);
     } catch (pushError) {
-        console.log('Normal push failed, retrying with --force-with-lease...');
-        cmd('git push -u origin ' + branchName + ' --force-with-lease');
+        console.warn('Normal push failed; synchronizing with origin/' + branchName + ' before retry:', pushError.message || pushError);
+        try {
+            cmd('git -c fetch.recurseSubmodules=no fetch origin ' + branchName + ':refs/remotes/origin/' + branchName);
+            cmd('git merge --no-edit origin/' + branchName);
+            cmd('git push -u origin ' + branchName);
+        } catch (syncPushError) {
+            throw new Error(
+                'Could not push rework branch after synchronizing with origin/' + branchName +
+                '. Refusing to force-push over remote updates. Error: ' +
+                (syncPushError.message || syncPushError)
+            );
+        }
     }
 
     const remoteCheck = cleanCommandOutput(cmd('git ls-remote --heads origin ' + branchName) || '');

--- a/js/unit-tests/test_reworkCustomParams.js
+++ b/js/unit-tests/test_reworkCustomParams.js
@@ -69,6 +69,10 @@ function loadPushReworkChangesForAction(mocks) {
                 mocks.commands = mocks.commands || [];
                 mocks.commands.push(args.command);
                 if (args.command === 'git branch --show-current') return 'ai/TS-1293';
+                if (args.command === 'git push -u origin ai/TS-1293' && mocks.failFirstPush) {
+                    mocks.failFirstPush = false;
+                    throw new Error('rejected non-fast-forward');
+                }
                 if (args.command.indexOf('git ls-remote --heads origin ai/TS-1293') === 0) return 'abc123\trefs/heads/ai/TS-1293';
                 return '';
             },
@@ -187,6 +191,36 @@ suite('rework custom params', function() {
         assert.equal(result.success, true);
         assert.equal(result.message, 'TS-1293 rework pushed, PR commented, moved to In Review');
         assert.deepEqual(mocks.moves, ['In Review']);
+    });
+
+    test('pr_rework syncs remote branch before retrying a rejected push', function() {
+        var mocks = { failFirstPush: true };
+        var mod = loadPushReworkChangesForAction(mocks);
+
+        var result = mod.action({
+            jobParams: {
+                ticket: { key: 'TS-1293', fields: { labels: [] } },
+                response: 'Implemented fix and wrote outputs/response.md',
+                customParams: {
+                    removeLabels: ['sm_story_rework_triggered']
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(
+            mocks.commands.indexOf('git -c fetch.recurseSubmodules=no fetch origin ai/TS-1293:refs/remotes/origin/ai/TS-1293') !== -1,
+            'expected fetch of remote PR branch after rejected push'
+        );
+        assert.ok(
+            mocks.commands.indexOf('git merge --no-edit origin/ai/TS-1293') !== -1,
+            'expected merge of remote PR branch before retry push'
+        );
+        assert.equal(
+            mocks.commands.indexOf('git push -u origin ai/TS-1293 --force-with-lease'),
+            -1,
+            'must not force-push over remote PR updates'
+        );
     });
 
     test('merges pr_test_automation_rework jobParamPatches into runtime customParams', function() {


### PR DESCRIPTION
## Summary
- replace blind rework force-with-lease retry with fetch+merge of the remote PR branch before retrying push
- prevents rework post-action from overwriting main-sync/auto-update commits on the PR branch

## Tests
- dmtools run js/unit-tests/run_reworkCustomParams.json (9 passed, 0 failed)
- dmtools run js/unit-tests/run_all.json (355 passed, 0 failed)