### PR TITLE
Fix stale test automation branch alignment

### DIFF
--- a/js/preCliTestAutomationSetup.js
+++ b/js/preCliTestAutomationSetup.js
@@ -25,6 +25,93 @@ function runGit(command, workingDir) {
     return cli_execute_command(args);
 }
 
+function writeBranchConflictGuidance(ticketKey, branchName, baseBranch, details) {
+    try {
+        file_write({
+            path: 'input/' + ticketKey + '/merge_conflicts.md',
+            content: '# Branch Conflict Guidance\n\n' +
+                'Branch `' + branchName + '` has test automation work that is not already merged into `origin/' + baseBranch + '`, ' +
+                'and `origin/' + baseBranch + '` is not an ancestor of this branch.\n\n' +
+                'Before editing tests, sync the branch deliberately with `origin/' + baseBranch + '`. ' +
+                'In most cases, prefer `origin/' + baseBranch + '` for repository setup, generated workflow/config files, ' +
+                'and shared infrastructure, then re-apply only the ticket-specific test automation that is still relevant.\n\n' +
+                'Do not discard test files that are still needed for this ticket. Do not keep stale bootstrap/setup files just because they exist on the old branch.\n\n' +
+                'Details:\n\n```\n' + (details || '(not available)') + '\n```\n'
+        });
+    } catch (e) {
+        console.warn('Could not write branch conflict guidance:', e);
+    }
+}
+
+function branchHasUniquePatches(baseBranch, workingDir) {
+    try {
+        var cherry = cleanCommandOutput(runGit('git cherry origin/' + baseBranch + ' HEAD', workingDir) || '');
+        if (!cherry.trim()) return false;
+        var lines = cherry.split('\n');
+        for (var i = 0; i < lines.length; i++) {
+            if (lines[i].trim().indexOf('+') === 0) return true;
+        }
+        return false;
+    } catch (e) {
+        console.warn('Could not inspect unique test branch patches:', e);
+        return true;
+    }
+}
+
+function isAncestorRef(ancestor, descendant, workingDir) {
+    try {
+        var output = cleanCommandOutput(
+            runGit('git rev-list -1 ' + ancestor + ' --not ' + descendant, workingDir) || ''
+        );
+        return output.trim() === '';
+    } catch (e) {
+        console.warn('Could not inspect branch ancestry for ' + ancestor + ' -> ' + descendant + ':', e);
+        return false;
+    }
+}
+
+function findMergeBase(left, right, workingDir) {
+    try {
+        return cleanCommandOutput(runGit('git merge-base ' + left + ' ' + right + ' || true', workingDir) || '');
+    } catch (e) {
+        return '';
+    }
+}
+
+function alignBranchWithBase(ticketKey, branchName, baseBranch, workingDir) {
+    if (isAncestorRef('HEAD', 'origin/' + baseBranch, workingDir)) {
+        console.log('Test branch changes are already included in origin/' + baseBranch + ', resetting local branch:', branchName);
+        runGit('git reset --hard origin/' + baseBranch, workingDir);
+        return;
+    }
+
+    if (!branchHasUniquePatches(baseBranch, workingDir)) {
+        console.log('Test branch has no unique patches versus origin/' + baseBranch + ', resetting local branch:', branchName);
+        runGit('git reset --hard origin/' + baseBranch, workingDir);
+        return;
+    }
+
+    if (isAncestorRef('origin/' + baseBranch, 'HEAD', workingDir)) {
+        console.log('Test branch already contains origin/' + baseBranch + ':', branchName);
+        return;
+    }
+
+    console.warn('Test branch does not contain origin/' + baseBranch + ':', branchName);
+    var details = '';
+    try {
+        var mergeBase = findMergeBase('HEAD', 'origin/' + baseBranch, workingDir);
+        if (mergeBase) {
+            details = cleanCommandOutput(runGit('git merge-tree ' + mergeBase + ' HEAD origin/' + baseBranch, workingDir) || '');
+        } else {
+            details = 'No merge base found between HEAD and origin/' + baseBranch + '. The branch history may be unrelated to the current base or too shallow.';
+        }
+    } catch (mergeTreeError) {
+        details = mergeTreeError && mergeTreeError.toString ? mergeTreeError.toString() : String(mergeTreeError);
+    }
+    writeBranchConflictGuidance(ticketKey, branchName, baseBranch, details.substring(0, 6000));
+    console.warn('Keeping divergent test branch ' + branchName + '; conflict guidance written for the agent.');
+}
+
 function checkoutBranch(ticketKey, config) {
     var branchName = configLoader.formatBranchName(config.git.branchPrefix.test, ticketKey);
     var workingDir = config.workingDir || null;
@@ -47,56 +134,19 @@ function checkoutBranch(ticketKey, config) {
         runGit('git branch --list "' + branchName + '"', workingDir) || ''
     );
 
-    /**
-     * Bring the current branch up-to-date with main.
-     * Strategy:
-     *   1. Try rebase — if it fails only due to the 'agents' submodule pointer,
-     *      auto-resolve it (main's version always wins for test branches) and continue.
-     *   2. If rebase still fails for any other reason, abort and fall back to
-     *      'git merge origin/main --no-edit' so we keep all existing test code.
-     * NOTE: never do 'git reset --hard origin/main' on an existing branch — that
-     *       diverges the local branch from its remote counterpart and breaks commits.
-     */
-    function syncWithMain() {
-        var base = 'origin/' + config.git.baseBranch;
-        try {
-            runGit('git rebase ' + base, workingDir);
-            console.log('✅ Rebase succeeded');
-        } catch (rebaseErr) {
-            console.warn('Rebase failed, attempting auto-resolve for agents submodule conflict:', rebaseErr);
-            try {
-                // Auto-resolve: take main's agents pointer (test branches never touch agents)
-                runGit('git checkout --ours agents', workingDir);
-                runGit('git add agents', workingDir);
-                runGit('git rebase --continue', workingDir);
-                console.log('✅ Rebase resumed after resolving agents submodule conflict');
-            } catch (continueErr) {
-                console.warn('Rebase --continue also failed, falling back to merge:', continueErr);
-                try { runGit('git rebase --abort', workingDir); } catch (_) {}
-                try {
-                    runGit('git merge ' + base + ' --no-edit', workingDir);
-                    console.log('✅ Merged main into branch instead of rebasing');
-                } catch (mergeErr) {
-                    console.warn('Merge also failed — branch may need manual attention:', mergeErr);
-                    try { runGit('git merge --abort', workingDir); } catch (_) {}
-                }
-            }
-        }
-    }
-
     if (localBranches.trim()) {
-        console.log('Branch exists locally, syncing from main:', branchName);
+        console.log('Branch exists locally, aligning with base:', branchName);
         runGit('git checkout ' + branchName, workingDir);
-        syncWithMain();
+        alignBranchWithBase(ticketKey, branchName, config.git.baseBranch, workingDir);
     } else {
         var remoteBranches = cleanCommandOutput(
             runGit('git ls-remote --heads origin ' + branchName, workingDir) || ''
         );
 
         if (remoteBranches.trim()) {
-            console.log('Branch exists on remote, checking out and syncing from main:', branchName);
+            console.log('Branch exists on remote, checking out and aligning with base:', branchName);
             runGit('git checkout -b ' + branchName + ' origin/' + branchName, workingDir);
-            syncWithMain();
+            alignBranchWithBase(ticketKey, branchName, config.git.baseBranch, workingDir);
         } else {
             console.log('Creating new branch from', config.git.baseBranch + ':', branchName);
             runGit('git checkout ' + config.git.baseBranch, workingDir);

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -408,6 +408,125 @@ suite('preCliTestAutomationSetup > workingDir', function() {
         });
     });
 
+    test('resets test branch that is already included in main without rebasing bootstrap history', function() {
+        var calls = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "test/TS-1324"') return '  test/TS-1324\n';
+            if (args.command === 'git rev-list -1 HEAD --not origin/main') return '';
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        var mod = loadModule(
+            'js/preCliTestAutomationSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchLinkedBugsToInput.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function() {},
+                jira_move_to_status: function() {}
+            }
+        );
+
+        mod.action({
+            inputFolderPath: 'input/TS-1324',
+            jobParams: {}
+        });
+
+        assert.equal(
+            calls.some(function(c) { return c.indexOf('git rebase origin/') === 0; }),
+            false,
+            'already included test branches must not be rebased through stale bootstrap history'
+        );
+        assert.ok(
+            calls.indexOf('git reset --hard origin/main') !== -1,
+            'already included test branch should be reset to base'
+        );
+    });
+
+    test('keeps divergent test branch and writes conflict guidance without rebase or merge attempts', function() {
+        var calls = [];
+        var writes = [];
+        var mockCli = function(args) {
+            calls.push(args.command);
+            if (args.command === 'git branch --list "test/TS-1325"') return '  test/TS-1325\n';
+            if (args.command === 'git rev-list -1 HEAD --not origin/main') return 'head-sha\n';
+            if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket test work\n';
+            if (args.command === 'git rev-list -1 origin/main --not HEAD') return 'base-sha\n';
+            if (args.command === 'git merge-base HEAD origin/main || true') return 'base123\n';
+            if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (add/add): Merge conflict in .github/workflows/unit-tests.yml\n';
+            return '';
+        };
+
+        var freshConfigLoader = loadModule(
+            'js/configLoader.js',
+            makeRequire({ './config.js': configModule }),
+            { file_read: function(opts) {
+                try { return file_read(opts); } catch (e) { return null; }
+            } }
+        );
+
+        var mod = loadModule(
+            'js/preCliTestAutomationSetup.js',
+            makeRequire({
+                './configLoader.js': freshConfigLoader,
+                './config.js': configModule,
+                './common/pullRequest.js': {
+                    buildOriginFetchCommand: function(refSpec) {
+                        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    }
+                },
+                './fetchLinkedBugsToInput.js': { action: function() {} }
+            }),
+            {
+                cli_execute_command: mockCli,
+                file_read: function(opts) {
+                    try { return file_read(opts); } catch (e) { return null; }
+                },
+                file_write: function(args) { writes.push(args); },
+                jira_move_to_status: function() {}
+            }
+        );
+
+        mod.action({
+            inputFolderPath: 'input/TS-1325',
+            jobParams: {}
+        });
+
+        assert.equal(
+            calls.some(function(c) { return c.indexOf('git rebase origin/') === 0; }),
+            false,
+            'divergent test branches should not trigger noisy automatic rebase'
+        );
+        assert.equal(
+            calls.some(function(c) { return c.indexOf('git merge origin/') === 0; }),
+            false,
+            'divergent test branches should not trigger noisy automatic merge'
+        );
+        assert.equal(writes.length, 1, 'conflict guidance should be written');
+        assert.equal(writes[0].path, 'input/TS-1325/merge_conflicts.md');
+        assert.contains(writes[0].content, 'prefer `origin/main`');
+    });
+
 });
 
 // ── postTestAutomationResults: workingDir + testFilesGlob ────────────────────

--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -12,6 +12,8 @@ User request is in the 'input' folder. Read all files there.
 
 The feature code is **already implemented** in the `main` branch and **deployed**. Your job is to automate this test case — not to implement features.
 
+If `merge_conflicts.md` is present in the input folder, the test branch could not be safely auto-aligned with `origin/main` before you started. Resolve this first: inspect the guidance, sync the branch deliberately with `origin/main`, prefer `origin/main` for setup/config/workflow/shared infrastructure conflicts, and keep only ticket-specific test automation that is still relevant. Do not open or leave a PR that is still dirty/conflicting with the base branch.
+
 ## Your task
 
 0. Before inspecting `testing/` or any source file, run a targeted CodeGraph command such as `codegraph context "<ticket key> test automation existing tests and reusable helpers"`. Use CodeGraph for code investigation before `grep`, `find`, `cat`, `sed`, or opening files directly.


### PR DESCRIPTION
## Summary
- replace test automation pre-CLI rebase/merge with branch alignment checks
- reset stale/already-included test branches to base
- write merge_conflicts.md guidance for genuinely divergent branches
- tell test automation agents to resolve branch conflicts before opening PRs

## Validation
- dmtools run js/unit-tests/run_all.json (357 passed, 0 failed)