### PR TITLE
Avoid racing active test automation recovery

### DIFF
--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -207,6 +207,22 @@ suite('sm.json rule ordering', function() {
         assert.equal(bugDevelopment.limit, 1, 'bug development should retry one ticket per SM cycle to avoid Copilot rate-limit bursts');
         assert.equal(bugDevelopment.concurrencyKey, 'bug_development', 'bug development should use shared active-run detection across SM cycles');
     });
+
+    test('stuck test case recovery has a cooldown to avoid racing active automation', function() {
+        var config = JSON.parse(file_read({ path: 'sm.json' }));
+        var rules = config.params.jobParams.rules;
+        var stuckRecovery = null;
+
+        rules.forEach(function(rule) {
+            if (rule.description === 'Stuck In Development Test Cases → recover (check PR, route to Rework/Review/Backlog)') {
+                stuckRecovery = rule;
+            }
+        });
+
+        assert.ok(stuckRecovery, 'stuck test case recovery rule exists');
+        assert.contains(stuckRecovery.jql, 'updated <= -15m');
+        assert.equal(stuckRecovery.localExecution, true, 'recovery should stay local execution');
+    });
 });
 
 // ── JQL interpolation ─────────────────────────────────────────────────────────

--- a/prompts/codegraph_tools.md
+++ b/prompts/codegraph_tools.md
@@ -12,6 +12,16 @@ codegraph context "<ticket key> <agent role> <short task summary>"
 
 Do this even when the prompt already includes a PR diff, file path, failing test, or review comment. PR diffs are not enough context; CodeGraph provides surrounding symbols and call paths that plain file reads miss.
 
+## Completion check
+
+Before you finish a source-code agent run, verify that the conversation contains an actual executed `codegraph ...` command, not only this instruction text or example commands. If no CodeGraph command has been executed yet, run a targeted command before writing the final result:
+
+```bash
+codegraph context "<ticket key> <changed file or tested flow> <decision you are validating>"
+```
+
+Do not approve, request changes, report a passed test, report a failed test, or publish implementation results until this check is satisfied.
+
 ## When to use CodeGraph vs other tools
 
 | Situation | Use |

--- a/sm.json
+++ b/sm.json
@@ -170,7 +170,7 @@
         },
         {
           "description": "Stuck In Development Test Cases → recover (check PR, route to Rework/Review/Backlog)",
-          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Development')",
+          "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Development') AND updated <= -15m",
           "configFile": "agents/recover_stuck_test_case.json",
           "localExecution": true
         },


### PR DESCRIPTION
## Summary
- add a 15 minute cooldown to stuck In Development Test Case recovery
- prevent recovery from moving freshly started test automation back to Backlog before it can create a PR
- strengthen CodeGraph prompt completion check so source-code agents execute a real codegraph command before publishing results

## Validation
- dmtools run js/unit-tests/run_all.json (358 passed, 0 failed)

## Context
Observed in TrackState after smMaxWorkflows=2: SM dispatched TS-1319 test automation, then another SM run recovered the same freshly updated In Development Test Case as stuck because no PR existed yet.