### PR TITLE
Harden test automation branch recovery

### DIFF
--- a/instructions/development/bug_implementation_instructions.md
+++ b/instructions/development/bug_implementation_instructions.md
@@ -45,6 +45,7 @@ Before claiming "already fixed" on any bug (returned or not):
 3. Write a unit test that exercises the exact failure scenario from the ticket. Run it.
    - If the test **FAILS** → the bug is real, proceed to fix.
    - If the test **PASSES** against current code → the bug may genuinely be fixed. Before writing `already_fixed.json`:
+     - Run a targeted CodeGraph command for the RCA code path, for example `codegraph context "<ticket key> already fixed validation <failing flow or symbol>"`. Do not write `already_fixed.json` until the conversation contains an actual executed `codegraph ...` command.
      - Re-read the latest comments — has QA confirmed the fix, or are they still reporting it broken?
      - Check the platform / build / environment the reporter mentioned — maybe it's only broken on one platform.
      - If the failure is only in the deployed artifact, trigger the appropriate deploy/sync workflow yourself with `SOURCE_GITHUB_TOKEN`, rerun the linked test on the refreshed deployment, and only then decide whether `already_fixed.json` is correct.
@@ -74,6 +75,7 @@ Otherwise, after RCA, check recent commits and the current codebase:
 - Run `git log --oneline -20` to see recent commits
 - Check if the code path identified in RCA already has the correct logic
 - Run the reproduction test from Step 0.2 — it must FAIL before you can claim the bug exists
+- Run a targeted CodeGraph command for the current code path and include the validated symbol/flow in `outputs/rca.md`; `already_fixed.json` is invalid without an actual executed `codegraph ...` command in the session.
 - If the reproduction test PASSES on current code AND no QA comment disputes this:
   - Write `outputs/already_fixed.json`:
     ```json

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -197,6 +197,42 @@ function createPullRequest(title, branchName, baseBranch, workingDir) {
     });
 }
 
+function hasBranchConflictGuidance(ticketKey, workingDir) {
+    var relativePath = 'input/' + ticketKey + '/merge_conflicts.md';
+    if (readFile(relativePath)) return true;
+    if (workingDir && readFile(workingDir + '/' + relativePath)) return true;
+    return false;
+}
+
+function getPrMergeability(prUrl, workingDir) {
+    try {
+        var raw = cleanCommandOutput(runInRepo('gh pr view ' + prUrl + ' --json mergeable', workingDir) || '');
+        if (!raw) return '';
+        var parsed = JSON.parse(raw);
+        return parsed && parsed.mergeable ? String(parsed.mergeable) : '';
+    } catch (e) {
+        console.warn('Could not read PR mergeability:', e);
+        return '';
+    }
+}
+
+function removeAutomationLabels(ticketKey, params) {
+    try {
+        const wipLabel = params.metadata && params.metadata.contextId
+            ? params.metadata.contextId + '_wip'
+            : 'test_case_automation_wip';
+        jira_remove_label({ key: ticketKey, label: wipLabel });
+    } catch (e) {}
+
+    try {
+        const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
+        if (smTriggerLabel) {
+            jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+            console.log('✅ Removed SM trigger label:', smTriggerLabel);
+        }
+    } catch (e) {}
+}
+
 function autoStartTestReview(ticketKey, config, customParams, noCodeChanges) {
     if (noCodeChanges) {
         console.log('ℹ️ autoStartReview: skipped — no test code changes to review');
@@ -343,6 +379,34 @@ function action(params) {
                         }
                     } catch (e) { console.warn('Could not remove SM trigger label:', e); }
                     return { success: false, error: 'PR creation failed: ' + (prResult.error || 'no URL returned') };
+                }
+
+                if (hasBranchConflictGuidance(ticketKey, workingDir)) {
+                    var mergeable = getPrMergeability(prUrl, workingDir);
+                    console.log('PR mergeability after branch conflict guidance:', mergeable || '(unknown)');
+                    if (mergeable === 'CONFLICTING') {
+                        var conflictComment = 'h3. 🚫 Test Automation Blocked — PR Conflicts With Main\n\n' +
+                            'The test automation branch {code}' + branchName + '{code} still conflicts with {code}' + config.git.baseBranch + '{code} after the agent run.\n\n' +
+                            '*Pull Request:* ' + prUrl + '\n\n' +
+                            'A {code}merge_conflicts.md{code} guidance file was present for this run, which means the existing test branch could not be safely auto-aligned with {code}origin/' + config.git.baseBranch + '{code}. ' +
+                            'Do not send this PR into automated review until the branch is deliberately synced with main and only ticket-specific test automation changes remain.\n\n' +
+                            'Ticket moved to *Blocked* for human conflict resolution.';
+                        try { jira_post_comment({ key: ticketKey, comment: conflictComment }); } catch (e) {}
+                        try {
+                            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
+                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', STATUSES.BLOCKED);
+                        } catch (e) {
+                            console.warn('Failed to move conflicting PR ticket to Blocked:', e);
+                        }
+                        removeAutomationLabels(ticketKey, params);
+                        return {
+                            success: true,
+                            status: 'blocked_by_human',
+                            ticketKey: ticketKey,
+                            prUrl: prUrl,
+                            blockedReason: 'pr_conflicts_with_main'
+                        };
+                    }
                 }
             } else if (gitResult.noNewCommit) {
                 noCodeChanges = true;

--- a/js/preCliTestAutomationSetup.js
+++ b/js/preCliTestAutomationSetup.js
@@ -72,7 +72,7 @@ function isAncestorRef(ancestor, descendant, workingDir) {
 
 function findMergeBase(left, right, workingDir) {
     try {
-        return cleanCommandOutput(runGit('git merge-base ' + left + ' ' + right + ' || true', workingDir) || '');
+        return cleanCommandOutput(runGit('git merge-base ' + left + ' ' + right, workingDir) || '');
     } catch (e) {
         return '';
     }

--- a/js/unit-tests/test_postTestAutomationResults.js
+++ b/js/unit-tests/test_postTestAutomationResults.js
@@ -90,6 +90,66 @@ suite('postTestAutomationResults: PR creation', function() {
         assert.notOk(commands.some(function(command) { return command === 'pwd'; }), 'pwd command not used');
     });
 
+    test('blocks conflicting PR when merge conflict guidance was present', function() {
+        var commands = [];
+        var statuses = [];
+        var removedLabels = [];
+        var comments = [];
+        var module = loadPostTestAutomation({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/test_automation_result.json') {
+                    return JSON.stringify({ status: 'blocked_by_human', summary: 'Needs browser auth' });
+                }
+                if (opts.path === 'outputs/pr_body.md') return 'PR body';
+                if (opts.path === 'input/DMC-909/merge_conflicts.md') return '# Branch Conflict Guidance';
+                if (opts.path && opts.path.indexOf('.dmtools/config') !== -1) return null;
+                return null;
+            },
+            jira_move_to_status: function(args) {
+                statuses.push(args.statusName);
+            },
+            jira_remove_label: function(args) {
+                removedLabels.push(args.label);
+            },
+            jira_post_comment: function(args) {
+                comments.push(args.comment);
+            },
+            cli_execute_command: function(opts) {
+                var command = opts.command;
+                commands.push(command);
+                if (command === 'git branch --show-current') return 'test/DMC-909';
+                if (command === 'git status --short -- testing') return ' M testing/tests/DMC-909/test_dmc_909.py';
+                if (command === 'git diff --cached --stat') return ' testing/tests/DMC-909/test_dmc_909.py | 1 +';
+                if (command.indexOf('git ls-remote --heads origin test/DMC-909') === 0) return 'abc\trefs/heads/test/DMC-909';
+                if (command.indexOf('gh pr list --head test/DMC-909') === 0) return '';
+                if (command.indexOf('gh pr create') === 0) return 'https://github.com/epam/dm.ai/pull/909';
+                if (command.indexOf('gh pr view https://github.com/epam/dm.ai/pull/909 --json mergeable') === 0) {
+                    return '{"mergeable":"CONFLICTING"}';
+                }
+                return '';
+            }
+        });
+
+        var result = module.action({
+            ticket: { key: 'DMC-909', fields: { summary: 'Conflicting test automation branch' } },
+            metadata: { contextId: 'test_case_automation' },
+            jobParams: { customParams: { removeLabel: 'sm_test_automation_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.status, 'blocked_by_human');
+        assert.equal(result.blockedReason, 'pr_conflicts_with_main');
+        assert.equal(result.prUrl, 'https://github.com/epam/dm.ai/pull/909');
+        assert.ok(statuses.indexOf('Blocked') !== -1, 'moved ticket to Blocked');
+        assert.ok(removedLabels.indexOf('sm_test_automation_triggered') !== -1, 'removed SM trigger label');
+        assert.ok(removedLabels.indexOf('test_case_automation_wip') !== -1, 'removed WIP label');
+        assert.ok(commands.some(function(command) {
+            return command.indexOf('gh pr view https://github.com/epam/dm.ai/pull/909 --json mergeable') === 0;
+        }), 'checked PR mergeability');
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0], 'PR Conflicts With Main');
+    });
+
     test('pushes synced existing branch before moving directly to Passed when there are no new test changes', function() {
         var commands = [];
         var statuses = [];

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -472,7 +472,7 @@ suite('preCliTestAutomationSetup > workingDir', function() {
             if (args.command === 'git rev-list -1 HEAD --not origin/main') return 'head-sha\n';
             if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket test work\n';
             if (args.command === 'git rev-list -1 origin/main --not HEAD') return 'base-sha\n';
-            if (args.command === 'git merge-base HEAD origin/main || true') return 'base123\n';
+            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
             if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (add/add): Merge conflict in .github/workflows/unit-tests.yml\n';
             return '';
         };


### PR DESCRIPTION
## Summary
- block conflicting test automation PRs when merge conflict guidance was present
- avoid shell metacharacters in test automation merge-base lookup
- require CodeGraph validation before bug agents write already_fixed output

## Validation
- dmtools run js/unit-tests/run_all.json