### PR TITLE
Avoid noisy merge-base failures in setup

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -86,7 +86,7 @@ function isAncestorRef(ancestor, descendant) {
 
 function findMergeBase(left, right) {
     try {
-        return cleanCommandOutput(runCmd({ command: 'git merge-base ' + left + ' ' + right }) || '');
+        return cleanCommandOutput(runCmd({ command: 'bash agents/scripts/git-merge-base-or-empty.sh ' + left + ' ' + right }) || '');
     } catch (e) {
         return '';
     }

--- a/js/preCliTestAutomationSetup.js
+++ b/js/preCliTestAutomationSetup.js
@@ -72,7 +72,7 @@ function isAncestorRef(ancestor, descendant, workingDir) {
 
 function findMergeBase(left, right, workingDir) {
     try {
-        return cleanCommandOutput(runGit('git merge-base ' + left + ' ' + right, workingDir) || '');
+        return cleanCommandOutput(runGit('bash agents/scripts/git-merge-base-or-empty.sh ' + left + ' ' + right, workingDir) || '');
     } catch (e) {
         return '';
     }

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -264,7 +264,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
             if (args.command === 'git merge-base --is-ancestor HEAD origin/main') throw new Error('not ancestor');
             if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket work\n';
             if (args.command === 'git merge-base --is-ancestor origin/main HEAD') throw new Error('not ancestor');
-            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
+            if (args.command === 'bash agents/scripts/git-merge-base-or-empty.sh HEAD origin/main') return 'base123\n';
             if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (content): Merge conflict in .dmtools/config.js\n';
             return '';
         };
@@ -472,7 +472,7 @@ suite('preCliTestAutomationSetup > workingDir', function() {
             if (args.command === 'git rev-list -1 HEAD --not origin/main') return 'head-sha\n';
             if (args.command === 'git cherry origin/main HEAD') return '+ abc123 ticket test work\n';
             if (args.command === 'git rev-list -1 origin/main --not HEAD') return 'base-sha\n';
-            if (args.command === 'git merge-base HEAD origin/main') return 'base123\n';
+            if (args.command === 'bash agents/scripts/git-merge-base-or-empty.sh HEAD origin/main') return 'base123\n';
             if (args.command === 'git merge-tree base123 HEAD origin/main') return 'CONFLICT (add/add): Merge conflict in .github/workflows/unit-tests.yml\n';
             return '';
         };

--- a/scripts/git-merge-base-or-empty.sh
+++ b/scripts/git-merge-base-or-empty.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git merge-base "$1" "$2" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- route merge-base lookup through a small helper that returns empty output instead of non-zero when no merge base exists
- use the helper from development and test automation pre-cli setup
- update unit expectations

## Tests
- dmtools run js/unit-tests/run_all.json