### PR TITLE
fix: add snapshot markers to timer session output

### DIFF
--- a/js/timerAutoCommitAndSave.js
+++ b/js/timerAutoCommitAndSave.js
@@ -137,8 +137,13 @@ function saveSessionArtefact(customParams, ticketKey, contextId, currentCliOutpu
     // Write to working dir (FileTools blocks /tmp/ paths)
     var outputFile = '.dmtools-session-output.log';
 
+    var snapshotTimestamp = new Date().toISOString();
+    var snapshotHeader = '=== ⏱️ TIMER SESSION SNAPSHOT START (saved at ' + snapshotTimestamp + ') ===\n' +
+                         '=== This is a periodic snapshot of the running agent output, NOT a new agent run ===\n\n';
+    var snapshotFooter = '\n\n=== ⏱️ TIMER SESSION SNAPSHOT END ===\n';
+
     try {
-        file_write({ path: outputFile, content: currentCliOutput });
+        file_write({ path: outputFile, content: snapshotHeader + currentCliOutput + snapshotFooter });
     } catch (e) {
         console.error('⏱️ timer: failed to write CLI output file:', e.toString().substring(0, 100));
         return;


### PR DESCRIPTION
## Problem
When `timerAutoCommitAndSave.js` writes the accumulated CLI output to `.dmtools-session-output.log`, the content includes lines like `Running: copilot ...` and `=== AGENT PROMPT START ===`. In GitHub Actions logs and release assets this looks identical to a real agent invocation, causing confusion.

## Fix
Wrap the snapshot content in clear boundary markers with timestamp:
```
=== ⏱️ TIMER SESSION SNAPSHOT START (saved at 2026-06-05T07:38:25Z) ===
=== This is a periodic snapshot of the running agent output, NOT a new agent run ===

...full accumulated output...

=== ⏱️ TIMER SESSION SNAPSHOT END ===
```

## Related
Companion fix in [epam/dm.ai](https://github.com/epam/dm.ai/pull/new/fix/timer-session-final-snapshot): fires a final timer tick after CLI completes so the **full** session output is always uploaded.