### PR TITLE
fix: auto-inject node when copilot/codemie/codegraph requested without node

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -80,6 +80,16 @@ if $USE_ALL; then
   TOOL_LIST="${ALL_TOOLS}"
 else
   TOOL_LIST="${EXPLICIT_TOOLS}"
+  # Auto-inject node before any npm-dependent tools (copilot, codemie, codegraph)
+  # if node is not already in the list
+  NEEDS_NODE=false
+  for _t in ${TOOL_LIST}; do
+    case "${_t}" in copilot|codemie|codegraph) NEEDS_NODE=true; break ;; esac
+  done
+  if $NEEDS_NODE && ! echo " ${TOOL_LIST} " | grep -qw "node"; then
+    TOOL_LIST="node ${TOOL_LIST}"
+    echo "ℹ️  Auto-injecting node (required by npm-based tool)"
+  fi
 fi
 
 # ── Run installs ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
When a user calls `install.sh dmtools codegraph` without explicitly including `node`, npm is not available and the installation fails.

This PR auto-prepends `node` to the install list whenever `copilot`, `codemie`, or `codegraph` are requested but `node` is not included.

**Before:** `install.sh dmtools codegraph` → `npm: command not found`
**After:** `install.sh dmtools codegraph` → auto-installs node first, then codegraph