### PR TITLE
fix(sm): re-enable all SM workflows

### DIFF
--- a/instructions/story_questions/description_template.md
+++ b/instructions/story_questions/description_template.md
@@ -1,4 +1,4 @@
-Each question `.md` file (referenced from `questions.json` as `description`) must follow this Jira Markdown template:
+Each question `.md` file (referenced from `questions.json` as `description`) must follow this template:
 
 ```
 *Background:* [Brief context — 1-2 sentences explaining why this matters]
@@ -15,6 +15,5 @@ Each question `.md` file (referenced from `questions.json` as `description`) mus
 
 Rules:
 - Do NOT repeat the summary in the description — start directly with `*Background:*`
-- Use Jira Markdown: `*bold*`, `-` for bullets, no `**` or `#` headers
 - `*Recommended Decision:*` is required — always provide your best guess even if uncertain
 - Keep options focused: 2–3 max; omit if only one valid path exists

--- a/instructions/story_questions/description_template.md
+++ b/instructions/story_questions/description_template.md
@@ -2,19 +2,19 @@ Each question `.md` file (referenced from `questions.json` as `description`) mus
 
 Structure:
 ```
-{{background}} [Brief context — 1-2 sentences explaining why this matters]
+<bold>Background</bold>: [Brief context — 1-2 sentences explaining why this matters]
 
-{{question}} [Clear, specific question]
+<bold>Question</bold>: [Clear, specific question]
 
-{{options}}
-- Option A: [Brief description]
-- Option B: [Brief description]
-- Option C: [Brief description if needed]
+<bold>Options</bold>:
+<bullet> Option A: [Brief description]
+<bullet> Option B: [Brief description]
+<bullet> Option C: [Brief description if needed]
 
-{{recommended_decision}} [Write your proposed answer here]
+<bold>Recommended Decision</bold>: [Write your proposed answer here]
 ```
 
 Rules:
-- Do NOT repeat the summary in the description — start directly with {{background}}
-- {{recommended_decision}} is required — always provide your best guess even if uncertain
+- Do NOT repeat the summary in the description — start directly with <bold>Background</bold>
+- <bold>Recommended Decision</bold> is required — always provide your best guess even if uncertain
 - Keep options focused: 2–3 max; omit if only one valid path exists

--- a/instructions/story_questions/description_template.md
+++ b/instructions/story_questions/description_template.md
@@ -1,19 +1,20 @@
-Each question `.md` file (referenced from `questions.json` as `description`) must follow this template:
+Each question `.md` file (referenced from `questions.json` as `description`) must follow this template. If a tracker-specific template is provided in the instructions, use that instead.
 
+Structure:
 ```
-*Background:* [Brief context — 1-2 sentences explaining why this matters]
+{{background}} [Brief context — 1-2 sentences explaining why this matters]
 
-*Question:* [Clear, specific question]
+{{question}} [Clear, specific question]
 
-*Options:*
+{{options}}
 - Option A: [Brief description]
 - Option B: [Brief description]
 - Option C: [Brief description if needed]
 
-*Recommended Decision:* [Write your proposed answer here]
+{{recommended_decision}} [Write your proposed answer here]
 ```
 
 Rules:
-- Do NOT repeat the summary in the description — start directly with `*Background:*`
-- `*Recommended Decision:*` is required — always provide your best guess even if uncertain
+- Do NOT repeat the summary in the description — start directly with {{background}}
+- {{recommended_decision}} is required — always provide your best guess even if uncertain
 - Keep options focused: 2–3 max; omit if only one valid path exists

--- a/instructions/story_questions/general_guidelines.md
+++ b/instructions/story_questions/general_guidelines.md
@@ -1,6 +1,6 @@
 ```mermaid
 flowchart TD
-    G1["Question descriptions must be in Jira Markdown format"]
+    G1["Question descriptions must follow the tracker-specific format"]
     G4["Read input/existing_questions.json to avoid duplicates"]
 
     subgraph CODEGRAPH["⚠️ MANDATORY: Investigate codebase BEFORE writing any question"]

--- a/instructions/tracker/jira_question_description_format.md
+++ b/instructions/tracker/jira_question_description_format.md
@@ -1,0 +1,22 @@
+# Jira Question Description Format
+
+When writing question descriptions for Jira tracker, follow these formatting rules:
+
+```mermaid
+flowchart TD
+    subgraph SYNTAX["Jira Markdown Syntax"]
+        S1["*bold* — single asterisks for bold text"]
+        S2["- item — dashes for bullet lists"]
+        S3["Do NOT use ** double asterisks"]
+        S4["Do NOT use # Markdown headers"]
+    end
+
+    subgraph TEMPLATE["Required Question Structure"]
+        T1["*Background:* 1-2 sentences explaining why this matters"]
+        T2["*Question:* clear, specific question"]
+        T3["*Options:* 2-3 bullets (omit if only one valid path)"]
+        T4["*Recommended Decision:* always provide your best guess even if uncertain"]
+    end
+
+    SYNTAX --> TEMPLATE
+```

--- a/instructions/tracker/jira_question_description_format.md
+++ b/instructions/tracker/jira_question_description_format.md
@@ -1,6 +1,19 @@
 # Jira Question Description Format
 
-When writing question descriptions for Jira tracker, follow these formatting rules:
+When writing question descriptions for Jira tracker, replace the meta tags from the generic template with Jira Markdown equivalents:
+
+| Meta tag | Jira Markdown |
+|----------|---------------|
+| `{{background}}` | `*Background:*` |
+| `{{question}}` | `*Question:*` |
+| `{{options}}` | `*Options:*` |
+| `{{recommended_decision}}` | `*Recommended Decision:*` |
+
+Formatting rules:
+- `*bold*` — single asterisks for bold text
+- `- item` — dashes for bullet lists
+- Do NOT use `**` double asterisks
+- Do NOT use `#` Markdown headers
 
 ```mermaid
 flowchart TD
@@ -11,12 +24,12 @@ flowchart TD
         S4["Do NOT use # Markdown headers"]
     end
 
-    subgraph TEMPLATE["Required Question Structure"]
+    subgraph EXAMPLE["Rendered Example"]
         T1["*Background:* 1-2 sentences explaining why this matters"]
         T2["*Question:* clear, specific question"]
         T3["*Options:* 2-3 bullets (omit if only one valid path)"]
         T4["*Recommended Decision:* always provide your best guess even if uncertain"]
     end
 
-    SYNTAX --> TEMPLATE
+    SYNTAX --> EXAMPLE
 ```

--- a/instructions/tracker/jira_question_description_format.md
+++ b/instructions/tracker/jira_question_description_format.md
@@ -1,15 +1,13 @@
 # Jira Question Description Format
 
-When writing question descriptions for Jira tracker, replace the meta tags from the generic template with Jira Markdown equivalents:
+When writing question descriptions for Jira tracker, render the generic formatting tags as Jira Markdown:
 
-| Meta tag | Jira Markdown |
-|----------|---------------|
-| `{{background}}` | `*Background:*` |
-| `{{question}}` | `*Question:*` |
-| `{{options}}` | `*Options:*` |
-| `{{recommended_decision}}` | `*Recommended Decision:*` |
+| Generic tag | Jira Markdown |
+|-------------|---------------|
+| `<bold>X</bold>` | `*X*` |
+| `<bullet>` | `-` |
 
-Formatting rules:
+Additional formatting rules:
 - `*bold*` — single asterisks for bold text
 - `- item` — dashes for bullet lists
 - Do NOT use `**` double asterisks
@@ -18,8 +16,8 @@ Formatting rules:
 ```mermaid
 flowchart TD
     subgraph SYNTAX["Jira Markdown Syntax"]
-        S1["*bold* — single asterisks for bold text"]
-        S2["- item — dashes for bullet lists"]
+        S1["<bold>X</bold> → *X*"]
+        S2["<bullet> → - item"]
         S3["Do NOT use ** double asterisks"]
         S4["Do NOT use # Markdown headers"]
     end

--- a/sm.json
+++ b/sm.json
@@ -11,7 +11,7 @@
           "configFile": "agents/story_ba_check.json",
           "skipIfLabel": "sm_story_ba_check_triggered",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "BA Analysis Stories → generate Acceptance Criteria",
@@ -22,7 +22,7 @@
             "sm_story_acceptance_criterias_triggered"
           ],
           "addLabel": "sm_story_acceptance_criteria_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Solution Architecture Stories → generate Solution Design",
@@ -30,7 +30,7 @@
           "configFile": "agents/story_solution.json",
           "skipIfLabel": "sm_story_solution_triggered",
           "addLabel": "sm_story_solution_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Subtasks with 'q' label → trigger PO refinement",
@@ -38,7 +38,7 @@
           "configFile": "agents/po_refinement.json",
           "skipIfLabel": "sm_po_refinement_triggered",
           "addLabel": "sm_po_refinement_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Backlog / To Do Stories → ask clarification questions",
@@ -58,7 +58,7 @@
           "configFile": "agents/intake.json",
           "skipIfLabel": "sm_task_intake_triggered",
           "addLabel": "sm_task_intake_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Ready For Development Stories → trigger story_development",
@@ -66,14 +66,14 @@
           "configFile": "agents/story_development.json",
           "skipIfLabel": "sm_story_development_triggered",
           "addLabel": "sm_story_development_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Failed Test Cases with linked Bugs → recover Bug To Fix",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('Failed') ORDER BY updated ASC",
           "configFile": "agents/recover_failed_tc_bug_status.json",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Failed Test Cases → create or link bugs in batch",
@@ -84,7 +84,7 @@
           "addLabel": "sm_bulk_bugs_creation_triggered",
           "recoverStaleTriggerLabel": true,
           "limit": 1,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development",
@@ -94,14 +94,14 @@
           "skipIfLabel": "sm_bug_development_triggered",
           "addLabel": "sm_bug_development_triggered",
           "limit": 1,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Review/Rework/Blocked Stories & Bugs with already merged PR → recover Merged status",
           "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review', 'In Rework', 'Blocked') ORDER BY updated ASC",
           "configFile": "agents/recover_merged_pr.json",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Review Stories & Bugs → trigger pr_review",
@@ -109,21 +109,21 @@
           "configFile": "agents/pr_review.json",
           "skipIfLabel": "sm_story_review_triggered",
           "addLabel": "sm_story_review_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Review Stories & Bugs (pr_approved) → retry merge",
           "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Review') AND labels = 'pr_approved' ORDER BY created ASC",
           "configFile": "agents/retry_merge.json",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Review Test Cases (pr_approved) → retry merge",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Review - Passed', 'In Review - Failed') AND labels = 'pr_approved' ORDER BY created ASC",
           "configFile": "agents/retry_merge_test.json",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Rework Stories & Bugs → trigger pr_rework",
@@ -131,7 +131,7 @@
           "configFile": "agents/pr_rework.json",
           "skipIfLabel": "sm_story_rework_triggered",
           "addLabel": "sm_story_rework_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Merged Stories → Ready For Testing + generate test cases",
@@ -140,7 +140,7 @@
           "configFile": "agents/test_cases_generator.json",
           "skipIfLabel": "sm_test_cases_triggered",
           "addLabel": "sm_test_cases_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Merged Bugs → Ready For Testing",
@@ -148,7 +148,7 @@
           "targetStatus": "Ready For Testing",
           "configFile": "agents/bug_merged.json",
           "skipIfLabel": "sm_bug_merged_triggered",
-          "enabled": false,
+          "enabled": true,
           "localExecution": true
         },
         {
@@ -157,14 +157,14 @@
           "configFile": "agents/bug_test_cases_generator.json",
           "skipIfLabel": "sm_bug_test_cases_triggered",
           "addLabel": "sm_bug_test_cases_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Testing Stories → check all TCs passed → Done",
           "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('In Testing')",
           "configFile": "agents/story_done_check.json",
           "skipIfLabel": "sm_story_done_check_triggered",
-          "enabled": false,
+          "enabled": true,
           "localExecution": true
         },
         {
@@ -172,7 +172,7 @@
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('In Testing')",
           "configFile": "agents/bug_done_check.json",
           "skipIfLabel": "sm_bug_done_check_triggered",
-          "enabled": false,
+          "enabled": true,
           "localExecution": true
         },
         {
@@ -181,14 +181,14 @@
           "configFile": "agents/task_done_check.json",
           "skipIfLabel": "sm_task_done_check_triggered",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Stuck In Development Test Cases → recover (check PR, route to Rework/Review/Backlog)",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Development') AND updated <= -15m",
           "configFile": "agents/recover_stuck_test_case.json",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Rework Test Cases → trigger pr_test_automation_rework",
@@ -196,7 +196,7 @@
           "configFile": "agents/pr_test_automation_rework.json",
           "skipIfLabel": "sm_test_rework_triggered",
           "addLabel": "sm_test_rework_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "In Review Test Cases → trigger pr_test_automation_review",
@@ -204,7 +204,7 @@
           "configFile": "agents/pr_test_automation_review.json",
           "skipIfLabel": "sm_test_review_triggered",
           "addLabel": "sm_test_review_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Failed Test Cases → create or link bug (single, disabled by default — use bulk_bugs_creation instead)",
@@ -213,7 +213,7 @@
           "skipIfLabel": "sm_bug_creation_triggered",
           "addLabel": "sm_bug_creation_triggered",
           "limit": 5,
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Backlog / To Do / Ready For Development Test Cases → In Development + automate",
@@ -222,7 +222,7 @@
           "configFile": "agents/test_case_automation.json",
           "skipIfLabel": "sm_test_automation_triggered",
           "addLabel": "sm_test_automation_triggered",
-          "enabled": false
+          "enabled": true
         },
         {
           "description": "Bug To Fix Test Cases → all linked Bugs Done → move to Backlog",
@@ -230,7 +230,7 @@
           "configFile": "agents/bug_to_fix_check.json",
           "skipIfLabel": "sm_bug_to_fix_check_triggered",
           "localExecution": true,
-          "enabled": false
+          "enabled": true
         }
       ]
     }

--- a/story_questions.json
+++ b/story_questions.json
@@ -19,6 +19,7 @@
       "./agents/instructions/story_questions/output_rules.md",
       "./agents/instructions/story_questions/formatting_rules.md",
       "./agents/instructions/story_questions/description_template.md",
+      "./agents/instructions/tracker/jira_question_description_format.md",
       "./agents/instructions/story_questions/few_shots.md",
       "./agents/instructions/common/dmtools_cli.md",
       "./agents/prompts/bash_tools.md",


### PR DESCRIPTION
Re-enables all SM workflows that were disabled in 24f8ad6 for testing phase.\n\nIncludes:\n- story_ba_check\n- story_acceptance_criteria\n- story_solution\n- po_refinement\n- task_intake\n- story_development\n- recover_failed_tc_bug_status\n- bulk_bugs_creation\n- bug_development\n- recover_merged_pr\n- pr_review\n- retry_merge\n- retry_merge_test\n- pr_rework\n- test_cases_generator\n- bug_merged\n- bug_test_cases_generator\n- story_done_check\n- bug_done_check\n- task_done_check\n- recover_stuck_test_case\n- pr_test_automation_rework\n- pr_test_automation_review\n- bug_creation\n- test_case_automation\n- bug_to_fix_check