### PR TITLE
feat(story_questions): add ADO-specific question description format

### DIFF
--- a/instructions/tracker/ado_question_description_format.md
+++ b/instructions/tracker/ado_question_description_format.md
@@ -1,0 +1,32 @@
+# ADO Question Description Format
+
+When writing question descriptions for Azure DevOps tracker, render the generic formatting tags as Markdown:
+
+| Generic tag | Markdown |
+|-------------|----------|
+| `<bold>X</bold>` | `**X**` |
+| `<bullet>` | `-` |
+
+Additional formatting rules:
+- `**bold**` — double asterisks for bold text
+- `- item` — dashes for bullet lists
+- `# headers` are allowed if needed
+
+```mermaid
+flowchart TD
+    subgraph SYNTAX["Markdown Syntax"]
+        S1["<bold>X</bold> → **X**"]
+        S2["<bullet> → - item"]
+        S3["**bold** — double asterisks for bold text"]
+        S4["# headers are allowed"]
+    end
+
+    subgraph EXAMPLE["Rendered Example"]
+        T1["**Background:** 1-2 sentences explaining why this matters"]
+        T2["**Question:** clear, specific question"]
+        T3["**Options:** 2-3 bullets (omit if only one valid path)"]
+        T4["**Recommended Decision:** always provide your best guess even if uncertain"]
+    end
+
+    SYNTAX --> EXAMPLE
+```

--- a/story_questions.json
+++ b/story_questions.json
@@ -1,29 +1,36 @@
 {
-  "name": "Teammate",
-  "params": {
-    "cliCommands": [
-      "./agents/scripts/run-agent.sh"
-    ],
-    "outputType": "none",
-    "ticketContextDepth": 1,
-    "attachResponseAsFile": false,
-    "skipAIProcessing": true,
-    "alwaysPostComments": true,
-    "preCliJSAction": "agents/js/fetchQuestionsToInput.js",
-    "postJSAction": "agents/js/createQuestionsAndAssignForReview.js",
-    "inputJql": "key = JD-82",
-      "cliPrompts": [
-      "Experienced Business Analyst",
-      "./agents/instructions/story_questions/general_guidelines.md",
-      "./agents/instructions/story_questions/file_handling.md",
-      "./agents/instructions/story_questions/output_rules.md",
-      "./agents/instructions/story_questions/formatting_rules.md",
-      "./agents/instructions/story_questions/description_template.md",
-      "./agents/instructions/tracker/jira_question_description_format.md",
-      "./agents/instructions/story_questions/few_shots.md",
-      "./agents/instructions/common/dmtools_cli.md",
-      "./agents/prompts/bash_tools.md",
-      "./agents/prompts/questions_prompt.md"
-    ]
-  }
+    "name": "Teammate",
+    "params": {
+        "cliCommands": [
+            "./agents/scripts/run-agent.sh"
+        ],
+        "outputType": "none",
+        "ticketContextDepth": 1,
+        "attachResponseAsFile": false,
+        "skipAIProcessing": true,
+        "alwaysPostComments": true,
+        "preCliJSAction": "agents/js/fetchQuestionsToInput.js",
+        "postJSAction": "agents/js/createQuestionsAndAssignForReview.js",
+        "inputJql": "key = JD-82",
+        "cliPrompts": [
+            "Experienced Business Analyst",
+            "./agents/instructions/story_questions/general_guidelines.md",
+            "./agents/instructions/story_questions/file_handling.md",
+            "./agents/instructions/story_questions/output_rules.md",
+            "./agents/instructions/story_questions/formatting_rules.md",
+            "./agents/instructions/story_questions/description_template.md",
+            "./agents/instructions/story_questions/few_shots.md",
+            "./agents/instructions/common/dmtools_cli.md",
+            "./agents/prompts/bash_tools.md",
+            "./agents/prompts/questions_prompt.md"
+        ],
+        "cliPromptsByTracker": {
+            "jira": [
+                "./agents/instructions/tracker/jira_question_description_format.md"
+            ],
+            "ado": [
+                "./agents/instructions/tracker/ado_question_description_format.md"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Adds Azure DevOps (Markdown) variant for question descriptions and wires it through `cliPromptsByTracker`, keeping the existing Jira wiki-markup variant. This mirrors the tracker-specific pattern already used by other agents.