### PR TITLE
refactor: remove duplicated input-reading guidance from test_case_automation_prompt

### DIFF
--- a/prompts/test_case_automation_prompt.md
+++ b/prompts/test_case_automation_prompt.md
@@ -1,14 +1,8 @@
-User request is in the 'input' folder. Read all files there.
-
-**IMPORTANT**: Before writing any test, read and follow these inputs in order:
-1. `request.md` — the Test Case ticket: objective, preconditions, steps, expected result, and priority.
-2. `comments.md` *(if present)* — ticket comment history; recent comments may contain prior test run results, failure analysis, or reviewer feedback.
-3. `linked_bugs.md` *(if present)* — **CRITICAL**: linked bugs that block or are related to this test case.
-   - Read the **Solution** field and **AI Fix Comments** for each bug carefully.
-   - If the fix introduced **timing or async behavior** (e.g., a heartbeat probe with a delay, a polling interval, a retry timeout) — your test **MUST** wait long enough to observe the effect. Do NOT assert immediately after triggering the action.
-   - Example: if a bug was fixed by adding a heartbeat probe that runs every 5 seconds, your test must wait at least 5–10 seconds after blocking auth domains before asserting the error appears.
-   - If the bug status is `Done` or `In Testing`, the fix is deployed — **run the test against the live implementation** and expect it to pass.
-4. Any other files present in the input folder for additional context.
+**CRITICAL — linked bugs**: If `linked_bugs.md` is present in the input folder, read it carefully before writing any test.
+- Read the **Solution** field and **AI Fix Comments** for each bug.
+- If the fix introduced **timing or async behavior** (e.g., a heartbeat probe with a delay, a polling interval, a retry timeout) — your test **MUST** wait long enough to observe the effect. Do NOT assert immediately after triggering the action.
+- Example: if a bug was fixed by adding a heartbeat probe that runs every 5 seconds, your test must wait at least 5–10 seconds after blocking auth domains before asserting the error appears.
+- If the bug status is `Done` or `In Testing`, the fix is deployed — **run the test against the live implementation** and expect it to pass.
 
 The feature code is **already implemented** in the `main` branch and **deployed**. Your job is to automate this test case — not to implement features.
 

--- a/snapshots/test_case_automation.md
+++ b/snapshots/test_case_automation.md
@@ -530,17 +530,11 @@ Use tracker-specific format:
 
 ### [10] `./agents/prompts/test_case_automation_prompt.md`
 
-User request is in the 'input' folder. Read all files there.
-
-**IMPORTANT**: Before writing any test, read and follow these inputs in order:
-1. `request.md` — the Test Case ticket: objective, preconditions, steps, expected result, and priority.
-2. `comments.md` *(if present)* — ticket comment history; recent comments may contain prior test run results, failure analysis, or reviewer feedback.
-3. `linked_bugs.md` *(if present)* — **CRITICAL**: linked bugs that block or are related to this test case.
-   - Read the **Solution** field and **AI Fix Comments** for each bug carefully.
-   - If the fix introduced **timing or async behavior** (e.g., a heartbeat probe with a delay, a polling interval, a retry timeout) — your test **MUST** wait long enough to observe the effect. Do NOT assert immediately after triggering the action.
-   - Example: if a bug was fixed by adding a heartbeat probe that runs every 5 seconds, your test must wait at least 5–10 seconds after blocking auth domains before asserting the error appears.
-   - If the bug status is `Done` or `In Testing`, the fix is deployed — **run the test against the live implementation** and expect it to pass.
-4. Any other files present in the input folder for additional context.
+**CRITICAL — linked bugs**: If `linked_bugs.md` is present in the input folder, read it carefully before writing any test.
+- Read the **Solution** field and **AI Fix Comments** for each bug.
+- If the fix introduced **timing or async behavior** (e.g., a heartbeat probe with a delay, a polling interval, a retry timeout) — your test **MUST** wait long enough to observe the effect. Do NOT assert immediately after triggering the action.
+- Example: if a bug was fixed by adding a heartbeat probe that runs every 5 seconds, your test must wait at least 5–10 seconds after blocking auth domains before asserting the error appears.
+- If the bug status is `Done` or `In Testing`, the fix is deployed — **run the test against the live implementation** and expect it to pass.
 
 The feature code is **already implemented** in the `main` branch and **deployed**. Your job is to automate this test case — not to implement features.
 


### PR DESCRIPTION
## Problem

The \"test_case_automation_prompt.md\" file contained a detailed \"read input files in order\" section that duplicated the shared instruction file \"instructions/common/input_context_reading.md\". The latter is already included in the \"test_case_automation\" agent's cliPrompts, so the same guidance appeared twice in the aggregated snapshot.

## Change

- Removed the generic input-reading wrapper (lines 1–11) from \"prompts/test_case_automation_prompt.md\"
- Kept the test-automation-specific \"linked_bugs.md\" guidance (timing/async behavior rules), which is not covered by the shared instruction file
- Regenerated \"snapshots/test_case_automation.md\" accordingly

## Impact

- Snapshots are smaller with no redundant input-reading instructions
- The shared instruction file remains the single source of truth for general input-reading guidance
- Test-automation-specific linked-bugs guidance is preserved in the prompt file