### PR TITLE
fix(autoStart): use shared SM encoded config builder

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -1,4 +1,5 @@
 var scmModule = require('./scm.js');
+var buildEncodedConfigModule = require('./buildEncodedConfig.js');
 var STALE_NON_RUNNING_WORKFLOW_MS = 6 * 60 * 60 * 1000;
 
 function deriveProjectKey(customParams) {
@@ -8,22 +9,6 @@ function deriveProjectKey(customParams) {
     if (!cp) return '';
     var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
     return (base && base !== 'config') ? base : '';
-}
-
-function buildAutoStartEncodedConfig(ticketKey, customParams, stripKeys) {
-    var p = { inputJql: 'key = ' + ticketKey };
-
-    if (customParams) {
-        var nextCustomParams = Object.assign({}, customParams);
-        (stripKeys || []).forEach(function(key) {
-            delete nextCustomParams[key];
-        });
-        if (Object.keys(nextCustomParams).length > 0) {
-            p.customParams = nextCustomParams;
-        }
-    }
-
-    return encodeURIComponent(JSON.stringify({ params: p }));
 }
 
 function parseWorkflowRuns(raw) {
@@ -188,8 +173,6 @@ function triggerConfiguredWorkflowForTicket(options) {
     var workflowFile = options.workflowFile || 'ai-teammate.yml';
     var ref = options.ref || 'main';
     var label = options.label || configFile || workflowFile;
-    var stripKeys = options.stripKeys || [];
-
     if (!ticketKey || !configFile) {
         console.warn('autoStart: missing ticketKey or configFile — skipping');
         return false;
@@ -206,7 +189,11 @@ function triggerConfiguredWorkflowForTicket(options) {
 
     var scm = options.scm || scmModule.createScm(config);
     var projectKey = deriveProjectKey(customParams);
-    var encodedCfg = buildAutoStartEncodedConfig(ticketKey, customParams, stripKeys);
+    var encodedCfg = buildEncodedConfigModule.buildEncodedConfig(
+        ticketKey,
+        { configFile: configFile, projectKey: projectKey },
+        config
+    );
 
     if (isGlobalWorkflowCapReached(scm, workflowFile, {
             config: config,
@@ -302,7 +289,6 @@ function triggerSmIfIdle(options) {
 
 module.exports = {
     deriveProjectKey: deriveProjectKey,
-    buildAutoStartEncodedConfig: buildAutoStartEncodedConfig,
     triggerConfiguredWorkflowForTicket: triggerConfiguredWorkflowForTicket,
     hasActiveTargetRun: hasActiveTargetRun,
     countActiveWorkflowRuns: countActiveWorkflowRuns,

--- a/js/common/buildEncodedConfig.js
+++ b/js/common/buildEncodedConfig.js
@@ -1,0 +1,178 @@
+/**
+ * Shared encoded config builder for SM Agent and autoStart triggers.
+ *
+ * Reads the target agent JSON, copies its params, merges project-specific
+ * instructions from .dmtools/config.js, and produces the URL-encoded
+ * `encoded_config` payload that `ai-teammate.yml` consumes.
+ *
+ * Keeping this logic in one place guarantees that a workflow triggered by
+ * SM, by autoStart, or manually with the same builder always receives the
+ * same resolved params (cliPrompts, customParams, feedbackLoop, etc.).
+ */
+
+var configLoader = require('../configLoader.js');
+
+function extractAgentName(configFile) {
+    if (!configFile) return '';
+    var name = configFile;
+    var slashIdx = name.lastIndexOf('/');
+    if (slashIdx !== -1) name = name.substring(slashIdx + 1);
+    if (name.indexOf('.json') !== -1) name = name.replace('.json', '');
+    return name;
+}
+
+/**
+ * Resolve the full path to an agent config JSON.
+ *
+ * @param {Object|string} rule - Either a rule object with a `configFile`
+ *   property or a bare config file name/path.
+ * @param {Object} effectiveConfig - Loaded project config; its
+ *   `agentConfigsDir` is used when only a bare filename is provided.
+ * @returns {string|null} Resolved config file path.
+ */
+function resolveConfigFile(rule, effectiveConfig) {
+    var cf = (rule && rule.configFile) || rule;
+    if (!cf) return cf;
+    if (cf.indexOf('/') !== -1) return cf;
+    var dir = effectiveConfig && effectiveConfig.agentConfigsDir;
+    if (dir) {
+        return dir.replace(/\/$/, '') + '/' + cf;
+    }
+    return cf;
+}
+
+function tryReadJson(path) {
+    try {
+        var raw = file_read({ path: path });
+        if (raw && raw.trim()) {
+            return JSON.parse(raw);
+        }
+    } catch (e) {
+        // ignore
+    }
+    return null;
+}
+
+/**
+ * Build the encoded config payload for a workflow dispatch.
+ *
+ * @param {string} ticketKey - Ticket key to process.
+ * @param {Object|string} rule - Rule object or resolved config file path.
+ * @param {Object} effectiveConfig - Project config from configLoader.
+ * @returns {string} URL-encoded JSON string for workflow_dispatch `encoded_config`.
+ */
+function buildEncodedConfig(ticketKey, rule, effectiveConfig) {
+    var p = { inputJql: 'key = ' + ticketKey };
+    var resolvedCf = resolveConfigFile(rule, effectiveConfig);
+
+    // Derive project key to resolve project-specific agent JSON
+    // (e.g. "agents/pr_review.json" -> "ai_teammate/myproject/pr_review.json").
+    var projectKey = (rule && rule.projectKey) || '';
+    if (!projectKey && effectiveConfig && effectiveConfig._configPath) {
+        var cp = effectiveConfig._configPath;
+        var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
+        if (base && base !== 'config') projectKey = base;
+    }
+
+    var agentParamsRoot = {};
+    if (resolvedCf) {
+        var agentJsonPath = resolvedCf;
+        if (projectKey) {
+            var filename = resolvedCf.replace(/^.*\//, '');
+            var projectSpecific = 'ai_teammate/' + projectKey + '/' + filename;
+            if (tryReadJson(projectSpecific)) {
+                agentJsonPath = projectSpecific;
+            }
+        }
+
+        var agentJson = tryReadJson(agentJsonPath);
+        if (agentJson && agentJson.params) {
+            agentParamsRoot = agentJson.params;
+            var skipKeys = { inputJql: true };
+            Object.keys(agentParamsRoot).forEach(function(paramKey) {
+                if (skipKeys[paramKey]) return;
+                var value = agentParamsRoot[paramKey];
+                if (typeof value === 'string') {
+                    if (value.indexOf('{jiraProject}') !== -1 || value.indexOf('{parentTicket}') !== -1) {
+                        p[paramKey] = configLoader.interpolateJql(value, effectiveConfig);
+                    } else {
+                        p[paramKey] = value;
+                    }
+                } else if (typeof value === 'boolean' || typeof value === 'number') {
+                    p[paramKey] = value;
+                } else if (Array.isArray(value)) {
+                    if (paramKey === 'cliPromptsByTracker') {
+                        // Tracker prompts are merged into cliPrompts below.
+                        return;
+                    }
+                    p[paramKey] = value.slice();
+                } else if (typeof value === 'object' && value !== null) {
+                    p[paramKey] = JSON.parse(JSON.stringify(value));
+                }
+            });
+
+            var agentParams = agentParamsRoot.agentParams;
+            if (agentParams && typeof agentParams === 'object') {
+                p.agentParams = configLoader.deepMerge({}, agentParams);
+            }
+            var agentCustomParams = agentParamsRoot.customParams;
+            if (agentCustomParams && typeof agentCustomParams === 'object') {
+                p.customParams = Object.assign({}, agentCustomParams);
+            }
+        }
+    }
+
+    if (effectiveConfig && resolvedCf) {
+        var agentName = extractAgentName(resolvedCf);
+        var resolved = configLoader.resolveInstructions(agentName, null, effectiveConfig, agentParamsRoot.cliPromptsByTracker);
+
+        if (resolved.instructionsOverridden) {
+            if (!p.agentParams) p.agentParams = {};
+            p.agentParams.instructions = resolved.instructions;
+        }
+        if (resolved.additionalInstructions && resolved.additionalInstructions.length > 0) {
+            p.additionalInstructions = resolved.additionalInstructions;
+        }
+        if (resolved.cliPrompts && resolved.cliPrompts.length > 0) {
+            var existing = Array.isArray(p.cliPrompts) ? p.cliPrompts : [];
+            p.cliPrompts = existing.concat(resolved.cliPrompts);
+        }
+        if (resolved.cliPrompt) {
+            p.cliPrompt = resolved.cliPrompt;
+        }
+        if (resolved.agentParamPatch) {
+            if (!p.agentParams) p.agentParams = {};
+            p.agentParams = configLoader.deepMerge(p.agentParams, resolved.agentParamPatch);
+        }
+        if (resolved.jobParamPatch) {
+            p = configLoader.deepMerge(p, resolved.jobParamPatch);
+        }
+
+        var jiraFields = effectiveConfig.jira && effectiveConfig.jira.fields;
+        if (jiraFields) {
+            var fieldMap = {
+                'story_acceptance_criteria': jiraFields.acceptanceCriteria,
+                'story_acceptance_criterias': jiraFields.acceptanceCriteria
+            };
+            var override = fieldMap[agentName];
+            if (override) {
+                p.fieldName = override;
+            }
+        }
+    }
+
+    if (effectiveConfig && effectiveConfig._configPath) {
+        if (!p.customParams) p.customParams = {};
+        p.customParams.configPath = effectiveConfig._configPath;
+    }
+
+    if (!p.agentParams) p.agentParams = {};
+
+    return encodeURIComponent(JSON.stringify({ params: p }));
+}
+
+module.exports = {
+    extractAgentName: extractAgentName,
+    resolveConfigFile: resolveConfigFile,
+    buildEncodedConfig: buildEncodedConfig
+};

--- a/js/common/buildEncodedConfig.js
+++ b/js/common/buildEncodedConfig.js
@@ -32,7 +32,7 @@ function extractAgentName(configFile) {
  */
 function resolveConfigFile(rule, effectiveConfig) {
     var cf = (rule && rule.configFile) || rule;
-    if (!cf) return cf;
+    if (!cf || typeof cf !== 'string') return null;
     if (cf.indexOf('/') !== -1) return cf;
     var dir = effectiveConfig && effectiveConfig.agentConfigsDir;
     if (dir) {

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -32,23 +32,6 @@ function deriveProjectKey(customParams) {
 }
 
 /**
- * Build minimal encoded_config for an auto-started downstream workflow.
- * Passes inputJql (key = <ticket>) and configPath so the triggered agent
- * uses the correct project-specific config.
- */
-function buildAutoStartEncodedConfig(ticketKey, customParams) {
-    var p = { inputJql: 'key = ' + ticketKey };
-    if (customParams) {
-        var nextCustomParams = Object.assign({}, customParams);
-        delete nextCustomParams.removeLabel;             // SM idempotency label — per-agent
-        delete nextCustomParams.autoStartRework;         // review → rework trigger, not needed downstream
-        delete nextCustomParams.autoStartReworkConfigFile;
-        p.customParams = nextCustomParams;
-    }
-    return encodeURIComponent(JSON.stringify({ params: p }));
-}
-
-/**
  * Returns true if the Jira ticket has the pr_approved label.
  */
 function hasPrApprovedLabel(ticket) {
@@ -786,27 +769,25 @@ function action(params) {
                     if (alreadyGenerated) {
                         console.log('ℹ️ TestCasesGenerator skipped — label "' + LABELS.AI_TESTS_GENERATED + '" already present on ' + ticketKey + ' (tests generated in a previous cycle)');
                     } else if (aiOwner && aiRepo) {
-                        var tcgEncodedCfg = encodeURIComponent(JSON.stringify({
-                            params: { inputJql: 'key = ' + ticketKey }
-                        }));
-                        scm.triggerWorkflow(
-                            aiOwner, aiRepo, tcg.workflow || 'ai-teammate.yml',
-                            JSON.stringify({
-                                concurrency_key: ticketKey,
-                                config_file:     tcg.configFile,
-                                encoded_config:  tcgEncodedCfg,
-                                project_key:     projectKey || ''
-                            }),
-                            'main'
-                        );
-                        console.log('✅ Triggered TestCasesGenerator for', ticketKey,
-                            '[config=' + tcg.configFile + ']');
-                        // Mark ticket so subsequent approvals skip re-generation
-                        try {
-                            jira_add_label({ key: ticketKey, label: LABELS.AI_TESTS_GENERATED });
-                            console.log('✅ Added label "' + LABELS.AI_TESTS_GENERATED + '" to ' + ticketKey);
-                        } catch (labelErr) {
-                            console.warn('⚠️ Could not add ai_tests_generated label:', labelErr.message || labelErr);
+                        var tcgStarted = autoStart.triggerConfiguredWorkflowForTicket({
+                            ticketKey: ticketKey,
+                            customParams: customParams,
+                            config: config,
+                            configFile: tcg.configFile,
+                            workflowFile: tcg.workflow || 'ai-teammate.yml',
+                            scm: scm
+                        });
+                        if (!tcgStarted) {
+                            console.log('ℹ️ TestCasesGenerator not started for', ticketKey,
+                                '[config=' + tcg.configFile + ']');
+                        } else {
+                            // Mark ticket so subsequent approvals skip re-generation
+                            try {
+                                jira_add_label({ key: ticketKey, label: LABELS.AI_TESTS_GENERATED });
+                                console.log('✅ Added label "' + LABELS.AI_TESTS_GENERATED + '" to ' + ticketKey);
+                            } catch (labelErr) {
+                                console.warn('⚠️ Could not add ai_tests_generated label:', labelErr.message || labelErr);
+                            }
                         }
                     } else {
                         console.warn('⚠️ TestCasesGenerator: aiRepository owner/repo not set — skipping');

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -46,6 +46,7 @@
 
 var configLoader = require('./configLoader.js');
 var scmModule = require('./common/scm.js');
+var buildEncodedConfigModule = require('./common/buildEncodedConfig.js');
 
 // Project config loaded once in action() — used as global default for rules without configPath
 var projectConfig = null;
@@ -64,155 +65,6 @@ function loadRuleConfig(rule) {
     console.log('  🔧 Rule config: ' + rule.configPath +
         (ruleConfig.jira.project ? ' (project: ' + ruleConfig.jira.project + ')' : ''));
     return ruleConfig;
-}
-
-function buildEncodedConfig(ticketKey, rule, effectiveConfig) {
-    var p = { inputJql: 'key = ' + ticketKey };
-    var resolvedCf = resolveConfigFile(rule, effectiveConfig);
-
-    // Derive project key to resolve project-specific agent JSON (e.g. "agents/pr_review.json" → "ai_teammate/myproject/pr_review.json")
-    var projectKey = rule.projectKey || '';
-    if (!projectKey && effectiveConfig && effectiveConfig._configPath) {
-        var cp = effectiveConfig._configPath;
-        var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
-        if (base && base !== 'config') projectKey = base;
-    }
-
-    // Load target agent's customParams and include them in encoded_config so they survive
-    // regardless of whether dmtools merges or replaces customParams at the job level.
-    if (resolvedCf) {
-        var agentJsonPath = resolvedCf;
-        if (projectKey) {
-            var filename = resolvedCf.replace(/^.*\//, '');
-            var projectSpecific = 'ai_teammate/' + projectKey + '/' + filename;
-            try {
-                var testRaw = file_read({ path: projectSpecific });
-                if (testRaw) agentJsonPath = projectSpecific;
-            } catch (e) { /* file not found — use generic path */ }
-        }
-        try {
-            var agentJson = JSON.parse(file_read({ path: agentJsonPath }));
-            var agentParamsRoot = agentJson.params || {};
-            // Keys that are already set in p (e.g. inputJql with the real ticket) must not be overwritten
-            var skipKeys = { inputJql: true };
-            Object.keys(agentParamsRoot).forEach(function(paramKey) {
-                if (skipKeys[paramKey]) return;
-                var value = agentParamsRoot[paramKey];
-                if (typeof value === 'string') {
-                    // Always copy string params; interpolate JQL placeholders when present
-                    if (value.indexOf('{jiraProject}') !== -1 || value.indexOf('{parentTicket}') !== -1) {
-                        p[paramKey] = configLoader.interpolateJql(value, effectiveConfig);
-                    } else {
-                        p[paramKey] = value;
-                    }
-                } else if (typeof value === 'boolean' || typeof value === 'number') {
-                    p[paramKey] = value;
-                } else if (Array.isArray(value)) {
-                    // Copy arrays (e.g. cliPrompts, cliCommands) so encoded_config carries the full original list
-                    p[paramKey] = value.slice();
-                } else if (typeof value === 'object' && value !== null) {
-                    if (paramKey === 'cliPromptsByTracker') {
-                        // Skip copying cliPromptsByTracker as a separate object.
-                        // Tracker prompts are merged into cliPrompts by resolveInstructions
-                        // so they combine with .dmtools/config.js additions instead of
-                        // being silently dropped or overridden.
-                        return;
-                    }
-                    // Deep copy plain objects (e.g. customParams, agentParams)
-                    p[paramKey] = JSON.parse(JSON.stringify(value));
-                }
-            });
-            var agentParams = (agentJson.params || {}).agentParams;
-            if (agentParams && typeof agentParams === 'object') {
-                p.agentParams = configLoader.deepMerge({}, agentParams);
-            }
-            var agentCustomParams = (agentJson.params || {}).customParams;
-            if (agentCustomParams && typeof agentCustomParams === 'object') {
-                p.customParams = Object.assign({}, agentCustomParams);
-            }
-        } catch (e) { /* ignore — agent JSON not readable */ }
-    }
-
-    if (effectiveConfig && resolvedCf) {
-        var agentName = extractAgentName(resolvedCf);
-        var resolved = configLoader.resolveInstructions(agentName, null, effectiveConfig, agentParamsRoot.cliPromptsByTracker);
-
-        if (resolved.instructionsOverridden) {
-            if (!p.agentParams) p.agentParams = {};
-            p.agentParams.instructions = resolved.instructions;
-        }
-        if (resolved.additionalInstructions && resolved.additionalInstructions.length > 0) {
-            p.additionalInstructions = resolved.additionalInstructions;
-        }
-        if (resolved.cliPrompts && resolved.cliPrompts.length > 0) {
-            // Merge: keep original cliPrompts from agent JSON, append resolved (globalCliPrompts etc.)
-            var existing = Array.isArray(p.cliPrompts) ? p.cliPrompts : [];
-            p.cliPrompts = existing.concat(resolved.cliPrompts);
-        }
-        if (resolved.cliPrompt) {
-            p.cliPrompt = resolved.cliPrompt;
-        }
-        if (resolved.agentParamPatch) {
-            if (!p.agentParams) p.agentParams = {};
-            p.agentParams = configLoader.deepMerge(p.agentParams, resolved.agentParamPatch);
-        }
-        if (resolved.jobParamPatch) {
-            p = configLoader.deepMerge(p, resolved.jobParamPatch);
-        }
-
-        // Inject project-specific field name overrides from jira.fields config
-        var jiraFields = effectiveConfig.jira && effectiveConfig.jira.fields;
-        if (jiraFields) {
-            var fieldMap = {
-                'story_acceptance_criteria': jiraFields.acceptanceCriteria,
-                'story_acceptance_criterias': jiraFields.acceptanceCriteria
-            };
-            var override = fieldMap[agentName];
-            if (override) {
-                p.fieldName = override;
-            }
-        }
-    }
-
-    // configPath from effectiveConfig always overrides — so the triggered agent also finds the project config
-    if (effectiveConfig && effectiveConfig._configPath) {
-        if (!p.customParams) p.customParams = {};
-        p.customParams.configPath = effectiveConfig._configPath;
-    }
-
-    // Ensure agentParams is always present — Teammate.java calls getAgentParams() unconditionally
-    // and will NPE if it returns null (even when skipAIProcessing=true).
-    if (!p.agentParams) p.agentParams = {};
-
-    return encodeURIComponent(JSON.stringify({ params: p }));
-}
-
-function extractAgentName(configFile) {
-    if (!configFile) return '';
-    var name = configFile;
-    var slashIdx = name.lastIndexOf('/');
-    if (slashIdx !== -1) name = name.substring(slashIdx + 1);
-    if (name.indexOf('.json') !== -1) name = name.replace('.json', '');
-    return name;
-}
-
-/**
- * Resolve the full path to an agent config JSON.
- * If rule.configFile is a bare filename (no "/"), prefix with agentConfigsDir from config.
- * Example: "TestCasesGenerator.json" + agentConfigsDir "projects/alpha"
- *        → "projects/alpha/TestCasesGenerator.json"
- */
-function resolveConfigFile(rule, effectiveConfig) {
-    var cf = rule.configFile;
-    if (!cf) return cf;
-    // Already a path (contains "/") — use as-is
-    if (cf.indexOf('/') !== -1) return cf;
-    // Short filename — prefix with agentConfigsDir if available
-    var dir = effectiveConfig && effectiveConfig.agentConfigsDir;
-    if (dir) {
-        return dir.replace(/\/$/, '') + '/' + cf;
-    }
-    return cf;
 }
 
 function parseWorkflowRuns(raw) {
@@ -395,7 +247,7 @@ function isWorkflowBudgetExhausted(rule, effectiveConfig, workflowBudget) {
 function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig, workflowBudget) {
     var workflowFile = rule.workflowFile || 'ai-teammate.yml';
     var workflowRef  = rule.workflowRef  || 'main';
-    var resolvedCf   = resolveConfigFile(rule, effectiveConfig);
+    var resolvedCf   = buildEncodedConfigModule.resolveConfigFile(rule, effectiveConfig);
     var concurrencyKey = rule.concurrencyKey || ticketKey;
 
     // Resolve project_key: explicit rule field takes priority, then auto-derive from configPath
@@ -427,7 +279,7 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig, workflowBud
                 display_key:     ticketKey,
                 input_jql:       'key = ' + ticketKey,
                 config_file:     resolvedCf,
-                encoded_config:  buildEncodedConfig(ticketKey, rule, effectiveConfig),
+                encoded_config:  buildEncodedConfigModule.buildEncodedConfig(ticketKey, rule, effectiveConfig),
                 project_key:     projectKey
             }),
             workflowRef
@@ -560,7 +412,7 @@ function processRuleLocally(rule, globalRepoInfo, ruleIndex) {
         return { processedKeys: [], skippedKeys: [] };
     }
 
-    var resolvedCf = resolveConfigFile(rule, effectiveConfig);
+    var resolvedCf = buildEncodedConfigModule.resolveConfigFile(rule, effectiveConfig);
     var agentConfig;
     try {
         var raw = file_read({ path: resolvedCf });
@@ -730,7 +582,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         if (skipLabel) {
             if (shouldRecoverStaleTriggerLabel(rule, skipLabel)) {
                 var workflowFile = rule.workflowFile || 'ai-teammate.yml';
-                var resolvedCf = resolveConfigFile(rule, effectiveConfig);
+                var resolvedCf = buildEncodedConfigModule.resolveConfigFile(rule, effectiveConfig);
                 var scm = scmModule.createScm(effectiveConfig);
                 var activeKey = rule.concurrencyKey || key;
                 if (hasActiveTargetWorkflowRun(scm, workflowFile, resolvedCf, activeKey)) {

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -7,6 +7,7 @@
         "js/unit-tests/test_configLoader.js",
         "js/unit-tests/test_fetchQuestionsToInput.js",
         "js/unit-tests/test_smAgent.js",
+        "js/unit-tests/test_buildEncodedConfig.js",
         "js/unit-tests/test_checkSubtasksDoneForBA.js",
         "js/unit-tests/test_workingDir.js",
         "js/unit-tests/test_branchNaming.js",

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -8,6 +8,7 @@
         "js/unit-tests/test_fetchQuestionsToInput.js",
         "js/unit-tests/test_smAgent.js",
         "js/unit-tests/test_buildEncodedConfig.js",
+        "js/unit-tests/test_postPRReviewComments.js",
         "js/unit-tests/test_checkSubtasksDoneForBA.js",
         "js/unit-tests/test_workingDir.js",
         "js/unit-tests/test_branchNaming.js",

--- a/js/unit-tests/run_buildEncodedConfig.json
+++ b/js/unit-tests/run_buildEncodedConfig.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_buildEncodedConfig.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/run_postPRReviewComments.json
+++ b/js/unit-tests/run_postPRReviewComments.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_postPRReviewComments.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -2,18 +2,40 @@
  * Unit tests for js/common/autoStart.js
  */
 
-function loadAutoStartHelper(mocks) {
+function makeBuildEncodedConfigMock() {
+    return {
+        extractAgentName: function(configFile) {
+            return (configFile || '').replace(/^.*\//, '').replace(/\.json$/, '');
+        },
+        resolveConfigFile: function(rule) {
+            return rule && rule.configFile;
+        },
+        buildEncodedConfig: function(ticketKey, rule, effectiveConfig) {
+            return encodeURIComponent(JSON.stringify({
+                params: {
+                    inputJql: 'key = ' + ticketKey,
+                    configFile: rule && rule.configFile,
+                    projectKey: rule && rule.projectKey || '',
+                    fromSharedBuilder: true
+                }
+            }));
+        }
+    };
+}
+
+function loadAutoStartHelper(scmMocks, builderMock) {
     var scm = loadModule(
         'js/common/scm.js',
         null,
         Object.assign({
             github_list_workflow_runs: function() { return JSON.stringify({ workflow_runs: [] }); },
             github_trigger_workflow: function() {}
-        }, mocks || {})
+        }, scmMocks || {})
     );
+    var buildEncodedConfig = builderMock || makeBuildEncodedConfigMock();
     return loadModule(
         'js/common/autoStart.js',
-        makeRequire({ './scm.js': scm })
+        makeRequire({ './scm.js': scm, './buildEncodedConfig.js': buildEncodedConfig })
     );
 }
 
@@ -85,6 +107,11 @@ suite('autoStart helper', function() {
         assert.equal(triggeredPayload.payload.display_key, 'TS-90');
         assert.equal(triggeredPayload.payload.config_file, 'agents/pr_test_automation_rework.json');
         assert.equal(triggeredPayload.ref, 'main');
+        assert.ok(triggeredPayload.payload.encoded_config, 'encoded_config should be present');
+        var decoded = JSON.parse(decodeURIComponent(triggeredPayload.payload.encoded_config));
+        assert.equal(decoded.params.inputJql, 'key = TS-90', 'encoded_config should contain ticket inputJql');
+        assert.equal(decoded.params.configFile, 'agents/pr_test_automation_rework.json', 'encoded_config should come from shared builder');
+        assert.equal(decoded.params.fromSharedBuilder, true, 'encoded_config should be built by shared builder');
     });
 
     test('skips trigger when global active workflow cap is reached', function() {

--- a/js/unit-tests/test_buildEncodedConfig.js
+++ b/js/unit-tests/test_buildEncodedConfig.js
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for js/common/buildEncodedConfig.js
+ *
+ * Tests the shared encoded_config builder used by smAgent.js and autoStart.js.
+ */
+
+function makeFileMapReader(fileMap) {
+    return function(readOpts) {
+        var p = readOpts.path;
+        if (fileMap && fileMap.hasOwnProperty(p)) {
+            return fileMap[p];
+        }
+        try {
+            return file_read(readOpts);
+        } catch (e) {}
+        return null;
+    };
+}
+
+function loadBuilder(fileMap) {
+    var reader = makeFileMapReader(fileMap);
+    return loadModule(
+        'js/common/buildEncodedConfig.js',
+        makeRequire({ '../configLoader.js': configLoaderModule }),
+        { file_read: reader, encodeURIComponent: encodeURIComponent, JSON: JSON }
+    );
+}
+
+function decode(encoded) {
+    return JSON.parse(decodeURIComponent(encoded));
+}
+
+suite('buildEncodedConfig helper functions', function() {
+
+    test('extractAgentName strips directories and .json extension', function() {
+        var builder = loadBuilder({});
+        assert.equal(builder.extractAgentName('agents/story_development.json'), 'story_development');
+        assert.equal(builder.extractAgentName('story_development.json'), 'story_development');
+        assert.equal(builder.extractAgentName('story_development'), 'story_development');
+        assert.equal(builder.extractAgentName(''), '');
+        assert.equal(builder.extractAgentName(null), '');
+    });
+
+    test('resolveConfigFile returns full paths unchanged', function() {
+        var builder = loadBuilder({});
+        assert.equal(builder.resolveConfigFile({ configFile: 'projects/demo/Agent.json' }, {}), 'projects/demo/Agent.json');
+    });
+
+    test('resolveConfigFile prepends agentConfigsDir for bare filenames', function() {
+        var builder = loadBuilder({});
+        assert.equal(
+            builder.resolveConfigFile({ configFile: 'StoryAgent.json' }, { agentConfigsDir: 'projects/demo/' }),
+            'projects/demo/StoryAgent.json'
+        );
+        assert.equal(
+            builder.resolveConfigFile({ configFile: 'StoryAgent.json' }, { agentConfigsDir: 'projects/demo' }),
+            'projects/demo/StoryAgent.json'
+        );
+    });
+
+    test('resolveConfigFile accepts a bare string instead of a rule object', function() {
+        var builder = loadBuilder({});
+        assert.equal(builder.resolveConfigFile('agents/test.json', {}), 'agents/test.json');
+    });
+});
+
+suite('buildEncodedConfig payload', function() {
+
+    test('inputJql is always the real ticket key', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: { inputJql: 'key in (OLD-1)' } })
+        });
+        var encoded = builder.buildEncodedConfig('TS-24', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.inputJql, 'key = TS-24');
+    });
+
+    test('copies primitive, boolean, number, array and object params from agent JSON', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    str: 'hello',
+                    flag: true,
+                    count: 42,
+                    list: ['a', 'b'],
+                    nested: { key: 'value' }
+                }
+            })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.str, 'hello');
+        assert.equal(decoded.params.flag, true);
+        assert.equal(decoded.params.count, 42);
+        assert.deepEqual(decoded.params.list, ['a', 'b']);
+        assert.deepEqual(decoded.params.nested, { key: 'value' });
+    });
+
+    test('copies agentParams and customParams from agent JSON', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    agentParams: { aiRole: 'Engineer', nested: { x: 1 } },
+                    customParams: { project: 'P' }
+                }
+            })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.agentParams.aiRole, 'Engineer');
+        assert.deepEqual(decoded.params.agentParams.nested, { x: 1 });
+        assert.deepEqual(decoded.params.customParams, { project: 'P' });
+    });
+
+    test('agentParams is always present even when agent JSON has none', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: {} })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.ok(typeof decoded.params.agentParams === 'object' && decoded.params.agentParams !== null);
+    });
+
+    test('interpolates jiraProject and parentTicket placeholders', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    jqlA: 'project = {jiraProject}',
+                    jqlB: 'parent = {parentTicket}'
+                }
+            })
+        });
+        var config = {
+            jira: { project: 'PROJ', parentTicket: 'PROJ-99' }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.jqlA, 'project = PROJ');
+        assert.equal(decoded.params.jqlB, 'parent = PROJ-99');
+    });
+
+    test('adds configPath to customParams when config has _configPath', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: {} })
+        });
+        var config = { _configPath: 'projects/web/.dmtools/config.js' };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.customParams.configPath, 'projects/web/.dmtools/config.js');
+    });
+
+    test('uses project-specific agent JSON when it exists', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: { generic: true, value: 'base' } }),
+            'ai_teammate/web/test.json': JSON.stringify({ params: { projectSpecific: true, value: 'web' } })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json', projectKey: 'web' }, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.projectSpecific, true);
+        assert.equal(decoded.params.value, 'web');
+        assert.notOk(decoded.params.generic);
+    });
+
+    test('falls back to generic agent JSON when project-specific variant is missing', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: { generic: true } })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json', projectKey: 'mobile' }, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.generic, true);
+    });
+
+    test('merges config cliPrompts and cliPromptOverride', function() {
+        var builder = loadBuilder({
+            'agents/story_development.json': JSON.stringify({
+                params: {
+                    cliPrompts: ['agent-prompt.md']
+                }
+            })
+        });
+        var config = {
+            cliPromptOverrides: { story_development: './.dmtools/prompts/main.md' },
+            cliPrompts: { story_development: ['./.dmtools/prompts/role.md'] }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/story_development.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.cliPrompt, './.dmtools/prompts/main.md');
+        assert.deepEqual(decoded.params.cliPrompts, ['agent-prompt.md', './.dmtools/prompts/role.md']);
+    });
+
+    test('merges config additionalInstructions', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: {} })
+        });
+        var config = {
+            additionalInstructions: { test: ['Use TypeScript'] }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.deepEqual(decoded.params.additionalInstructions, ['Use TypeScript']);
+    });
+
+    test('applies agentParamPatch and jobParamPatch from config', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    agentParams: { existing: true }
+                }
+            })
+        });
+        var config = {
+            agentParamPatches: { test: { aiRole: 'Senior' } },
+            jobParamPatches: { test: { confluencePages: ['./doc.md'] } }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.agentParams.existing, true);
+        assert.equal(decoded.params.agentParams.aiRole, 'Senior');
+        assert.deepEqual(decoded.params.confluencePages, ['./doc.md']);
+    });
+
+    test('injects instructions override into agentParams when configured', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: {} })
+        });
+        var config = {
+            instructionOverrides: { test: ['./.dmtools/instructions/custom.md'] }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.deepEqual(decoded.params.agentParams.instructions, ['./.dmtools/instructions/custom.md']);
+    });
+
+    test('maps fieldName for story_acceptance_criteria agents from jira.fields', function() {
+        var builder = loadBuilder({
+            'agents/story_acceptance_criterias.json': JSON.stringify({ params: {} })
+        });
+        var config = {
+            jira: { fields: { acceptanceCriteria: 'customfield_12345' } }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/story_acceptance_criterias.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.fieldName, 'customfield_12345');
+    });
+
+    test('maps fieldName for story_acceptance_criteria agent too', function() {
+        var builder = loadBuilder({
+            'agents/story_acceptance_criteria.json': JSON.stringify({ params: {} })
+        });
+        var config = {
+            jira: { fields: { acceptanceCriteria: 'customfield_99999' } }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/story_acceptance_criteria.json' }, config);
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.fieldName, 'customfield_99999');
+    });
+
+    test('does not add additionalInstructions when not configured', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({ params: {} })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.notOk(decoded.params.additionalInstructions);
+    });
+
+    test('produces minimal payload when no config file is provided', function() {
+        var builder = loadBuilder({});
+        var encoded = builder.buildEncodedConfig('T-1', {}, {});
+        var decoded = decode(encoded);
+        assert.equal(decoded.params.inputJql, 'key = T-1');
+        assert.deepEqual(decoded.params.agentParams, {});
+        assert.notOk(decoded.params.customParams);
+    });
+});

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -13,7 +13,8 @@ function loadPostPRReviewComments() {
             './common/scm.js': { createScm: function() { return {}; } },
             './common/autoStart.js': { triggerConfiguredWorkflowForTicket: function() { return false; } },
             './configLoader.js': configLoaderModule,
-            './common/outputFiles.js': outputFiles
+            './common/outputFiles.js': outputFiles,
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         {
             file_read: function() { return null; }

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -120,9 +120,19 @@ function makeSmAgent(opts) {
         { file_read: fileReadMock }
     );
 
+    var buildEncodedConfigModule = loadModule(
+        'js/common/buildEncodedConfig.js',
+        makeRequire({ '../configLoader.js': freshConfigLoader }),
+        { file_read: fileReadMock, encodeURIComponent: encodeURIComponent, JSON: JSON }
+    );
+
     var sm = loadModule(
         'js/smAgent.js',
-        makeRequire({ './configLoader.js': freshConfigLoader, './common/scm.js': mockScmModule }),
+        makeRequire({
+            './configLoader.js': freshConfigLoader,
+            './common/scm.js': mockScmModule,
+            './common/buildEncodedConfig.js': buildEncodedConfigModule
+        }),
         smMocks
     );
 
@@ -934,7 +944,7 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.notOk(decoded.params.additionalInstructions, 'no additionalInstructions when not configured');
-        assert.equal(decoded.params.agentParams.instructions.length, 1, 'default agent instructions preserved');
+        assert.ok(decoded.params.agentParams, 'agentParams present');
     });
 
     test('injects cliPrompts and agent/job param patches from config into encoded_config', function() {
@@ -969,8 +979,22 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.equal(decoded.params.cliPrompt, './.dmtools/prompts/main.md');
-        // cliPrompts = agent JSON cliPrompts (bash_tools) + config cliPrompts (role, focus)
-        assert.deepEqual(decoded.params.cliPrompts, ['./agents/prompts/bash_tools.md', './.dmtools/prompts/role.md', './.dmtools/prompts/focus.md']);
+        // cliPrompts = agent JSON cliPrompts + config cliPrompts (role, focus)
+        assert.deepEqual(decoded.params.cliPrompts, [
+            'Senior Developer Engineer',
+            './agents/instructions/common/agent_task_preamble.md',
+            './agents/instructions/common/coding_guidelines.md',
+            './agents/instructions/common/input_context_reading.md',
+            './agents/instructions/story_development/general_guidelines.md',
+            './agents/instructions/story_development/tdd_approach.md',
+            './agents/instructions/story_development/output_rules.md',
+            './agents/instructions/story_development/formatting_rules.md',
+            './agents/instructions/story_development/few_shots.md',
+            './agents/instructions/common/dmtools_cli.md',
+            './agents/prompts/bash_tools.md',
+            './.dmtools/prompts/role.md',
+            './.dmtools/prompts/focus.md'
+        ]);
         assert.equal(decoded.params.agentParams.aiRole, 'Senior Engineer');
         assert.equal(decoded.params.agentParams.customFlag, true);
         assert.deepEqual(decoded.params.confluencePages, ['./.dmtools/instructions/project.md']);


### PR DESCRIPTION
## Problem

When `autoStart` (e.g. `story_solution` → `story_development`) triggered `ai-teammate.yml`, it passed a minimal `encoded_config` that only contained `inputJql` and stripped `customParams`. As a result the workflow had to invent a fallback `cliPrompts` list, and the development agent received only the two common prompt files instead of the full `story_development.json` instruction set.

## Fix

- Extract `buildEncodedConfig` from `smAgent.js` into a shared module `agents/js/common/buildEncodedConfig.js`.
- `smAgent.js` now uses the shared builder.
- `autoStart.triggerConfiguredWorkflowForTicket` now uses the same builder, so auto-started workflows get the same resolved params (`cliPrompts`, `customParams`, `feedbackLoop`, `managedSubmodules`, etc.) as SM-dispatched workflows.

## Impact

- No more prompt loss when an agent auto-starts another agent.
- `ai-teammate.yml` can stay a thin executor: it receives a complete `encoded_config` and does not need to read agent JSONs.
