### PR TITLE
docs(story_development): clarify TDD test location

### DIFF
--- a/instructions/story_development/general_guidelines.md
+++ b/instructions/story_development/general_guidelines.md
@@ -6,7 +6,8 @@ flowchart TD
     ANALYZE --> ARCH["Understand existing codebase patterns, architecture, and test structure"]
     ARCH --> PRINCIPLES["Apply OOP principles: SRP, OCP, DI, Encapsulation, Composition over inheritance"]
     PRINCIPLES --> TDD["Follow TDD approach — see tdd_approach.md"]
-    TDD --> IMPLEMENT["Implement source code and unit tests following existing patterns"]
+    TDD --> TEST_LOC["Write TDD tests in the standard unit-test tree only<br/>— Flutter/Dart: test/<br/>— NEVER in testing/ (owned by test-automation agents)"]
+    TEST_LOC --> IMPLEMENT["Implement source code and unit tests following existing patterns"]
     IMPLEMENT --> DOCS["Update documentation ONLY if ticket explicitly requires it"]
     DOCS --> RUN["Run all unit tests — MUST pass before finishing"]
     RUN --> PASS{Tests pass?}

--- a/instructions/story_development/tdd_approach.md
+++ b/instructions/story_development/tdd_approach.md
@@ -22,3 +22,17 @@ flowchart TD
 
     TDD --> RULES
 ```
+
+## Where to write TDD tests
+
+Write failing unit / widget tests in the project's standard unit-test tree **only**:
+
+- Flutter / Dart projects → `test/`
+- Node projects → `__tests__/` or `test/` according to the repo convention
+- Python projects → `tests/` or project-specific unit-test directory
+
+❌ **Never** place development TDD tests under `testing/`.
+`testing/` is owned by test-automation agents (regression probes, workflow
+observation tests, accessibility gates, etc.). If your production changes break
+existing tests there, leave them untouched and mention the breakage in
+`outputs/response.md` so the test-automation agent can update them.


### PR DESCRIPTION
## What

Clarifies that development TDD tests must be written in the project standard unit-test tree (e.g. `test/` for Flutter/Dart) and never under `testing/`.

## Why

TS-576 dev agent updated regression workflow tests under `testing/tests/TS-706`, `TS-707`, etc. because the TDD instruction did not explicitly forbid it. `testing/` is owned by test-automation agents, so this change removes the ambiguity.

## Changes

- `tdd_approach.md`: added "Where to write TDD tests" section.
- `general_guidelines.md`: added explicit `TEST_LOC` step before implementation.

## Related

- trackstate discussion about TS-576 dev agent touching `testing/`.
