### PR TITLE
fix(pr_rework): close PR review threads via review_replies.json

### DIFF
--- a/instructions/pr_rework/formatting_rules.md
+++ b/instructions/pr_rework/formatting_rules.md
@@ -1,7 +1,13 @@
 ```mermaid
 flowchart TD
-    F1["outputs/response.md must be a markdown document"]
+    F1["outputs/response.md must be Markdown (# headings, - bullets, ``` code fences)"]
     F2["Required sections: ## Issues/Notes (if any), ## Approach, ## Files Modified, ## Test Coverage"]
     F3["Be surgical but thorough — fix exact issues flagged, then check same pattern across codebase"]
     F4["Do NOT refactor unrelated code or add unrequested features"]
+    F5["When open PR review threads exist, create outputs/review_replies/*.md files and reference them from outputs/review_replies.json"]
 ```
+
+- When `input/<TICKET>/pr_discussions_raw.json` contains open PR review threads:
+  - Write one Markdown file per open thread under `outputs/review_replies/`.
+  - Write `outputs/review_replies.json` with one entry per open thread, including `inReplyToId`, `threadId`, and a `reply` field that contains the path to the matching `.md` file.
+  - Do **not** put reply bodies inline in the JSON.

--- a/instructions/pr_rework/general_guidelines.md
+++ b/instructions/pr_rework/general_guidelines.md
@@ -20,7 +20,10 @@ flowchart TD
     SUGGESTIONS -->|No| TEST[Run tests and verify]
     SKIP --> TEST
     TEST --> OUTPUT[Write outputs/response.md]
-    OUTPUT --> END([End])
+    OUTPUT --> REPLIES{Open review threads?}
+    REPLIES -->|Yes| REVIEW_REPLIES["Write outputs/review_replies.json with one reply per open thread using threadId + inReplyToId"]
+    REPLIES -->|No| END([End])
+    REVIEW_REPLIES --> END
 ```
 
 ## 1. Input context — MANDATORY reading order

--- a/instructions/pr_rework/output_rules.md
+++ b/instructions/pr_rework/output_rules.md
@@ -1,0 +1,38 @@
+## PR Rework — Output Rules
+
+Rework posts **only** to the Pull Request. All output must be Markdown.
+
+### Required files
+
+1. `outputs/response.md`
+   - GitHub Markdown fix summary for the top-level PR comment.
+   - Use `#`/`##` headings, ` ``` ` code fences, `-` bullets.
+   - Required sections: `## Issues/Notes`, `## Approach`, `## Files Modified`, `## Test Coverage`.
+
+2. `outputs/review_replies.json`
+   - **Mandatory** when the PR has open review threads.
+   - If there are no open threads, write `{ "replies": [] }`.
+   - Format:
+
+```json
+{
+  "replies": [
+    {
+      "inReplyToId": 1234567890,
+      "threadId": "PRRT_<graphQL_id>",
+      "reply": "outputs/review_replies/thread_1.md"
+    }
+  ]
+}
+```
+
+3. `outputs/review_replies/*.md`
+   - One Markdown file per open PR review thread.
+   - The file path is referenced from `outputs/review_replies.json` via the `reply` field.
+   - Keep each reply concise and factual; reference the fix location when possible.
+
+Rules for review replies:
+- Read `input/<TICKET>/pr_discussions_raw.json` to obtain each open thread's `threadId` and `rootCommentId` (`inReplyToId`).
+- Create one reply entry and one `.md` file for **every** open review thread — do not skip any unresolved conversation.
+- `threadId` is required for GitHub to resolve/close the conversation; `inReplyToId` is required to post the reply in the correct thread.
+- Do **not** put the reply body inline in the JSON; use the `reply` field only as a file path reference.

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -1,10 +1,11 @@
 /**
  * Push Rework Changes Post-Action
  * postJSAction for pr_rework agent:
- * 1. Stages, commits, and force-pushes changes to the existing PR branch
- * 2. Posts the fix summary (outputs/response.md) as a PR comment
- * 3. Moves ticket to "In Review"
- * 4. Posts completion comment to Jira
+ * 1. Stages, commits, and pushes changes to the existing PR branch
+ * 2. Posts replies to each open PR review thread and resolves the threads
+ * 3. Posts the fix summary (outputs/response.md) as a top-level PR comment
+ * 4. Moves ticket to "In Review"
+ * 5. Posts completion comment to Jira
  */
 
 var configLoader = require('./configLoader.js');
@@ -242,10 +243,12 @@ function commitAndPush(ticketKey, config, customParams) {
  * Post replies to each review thread and resolve them.
  * Reads outputs/review_replies.json produced by the cursor agent.
  *
- * JSON format: { "replies": [{ "inReplyToId": 123, "threadId": "PRRT_...", "reply": "..." }] }
+ * JSON format: { "replies": [{ "inReplyToId": 123, "threadId": "PRRT_...", "reply": "outputs/review_replies/thread1.md" }] }
+ * The "reply" field may be a path to a Markdown file (preferred) or inline text (legacy).
  */
-function postThreadReplies(scm, pullRequestId) {
-    let repliesJson = outputFiles.readOutputFile('review_replies.json', {});
+function postThreadReplies(scm, pullRequestId, outputOptions) {
+    outputOptions = outputOptions || {};
+    let repliesJson = outputFiles.readOutputFile('review_replies.json', outputOptions);
     if (!repliesJson) {
         console.warn('outputs/review_replies.json not found — skipping thread replies');
         return 0;
@@ -265,9 +268,23 @@ function postThreadReplies(scm, pullRequestId) {
         return 0;
     }
 
+    function resolveReplyText(replyRef) {
+        if (!replyRef) return '✅ Addressed.';
+        const looksLikePath = replyRef.indexOf('outputs/') === 0 ||
+            replyRef.indexOf('/') !== -1 ||
+            replyRef.indexOf('.md') !== -1;
+        if (looksLikePath) {
+            const fileContent = outputFiles.readOutputFile(replyRef, outputOptions);
+            if (fileContent && fileContent.trim()) {
+                return fileContent.trim();
+            }
+        }
+        return replyRef;
+    }
+
     let posted = 0;
     replies.forEach(function(item) {
-        const replyText = item.reply || '✅ Addressed.';
+        const replyText = resolveReplyText(item.reply);
         const thread = { rootCommentId: item.inReplyToId || null, threadId: item.threadId || null };
 
         try {
@@ -482,7 +499,10 @@ function action(params) {
 
         if (pr && repoInfo) {
             // Reply to each review thread and resolve it
-            const repliesPosted = postThreadReplies(scm, pr.number);
+            const repliesPosted = postThreadReplies(scm, pr.number, {
+                ticketKey: ticketKey,
+                workingDir: config.workingDir || null
+            });
             console.log('Thread replies posted:', repliesPosted);
 
             // Post general fix summary as a top-level PR comment

--- a/js/unit-tests/test_reworkCustomParams.js
+++ b/js/unit-tests/test_reworkCustomParams.js
@@ -13,7 +13,15 @@ function loadPushReworkChanges() {
             './common/pullRequest.js': {},
             './common/feedbackLoop.js': {},
             './common/autoStart.js': { triggerConfiguredWorkflowForTicket: function() { return false; } },
-            './common/outputFiles.js': { readOutputFile: function() { return null; } },
+            './common/outputFiles.js': {
+                readOutputFile: function(path) {
+                    if (mocks.outputFiles && mocks.outputFiles[path] !== undefined) {
+                        return mocks.outputFiles[path];
+                    }
+                    return null;
+                }
+            },
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
             './cacheToReleases.js': {}
         }),
         {}
@@ -33,7 +41,10 @@ function loadPushReworkChangesForAction(mocks) {
                         getRemoteRepoInfo: function() { return { owner: 'IstiN', repo: 'trackstate' }; },
                         listPrs: function() { return [{ number: 1571, title: 'TS-1293 Fix', html_url: 'https://github.com/IstiN/trackstate/pull/1571', head: { ref: 'ai/TS-1293' } }]; },
                         addComment: function() { mocks.prComments = (mocks.prComments || 0) + 1; },
-                        replyToThread: function() { mocks.threadReplies = (mocks.threadReplies || 0) + 1; },
+                        replyToThread: function(prId, thread, text) {
+                            mocks.threadReplies = (mocks.threadReplies || 0) + 1;
+                            mocks.replyTexts = (mocks.replyTexts || []).concat(text);
+                        },
                         resolveThread: function() { mocks.resolvedThreads = (mocks.resolvedThreads || 0) + 1; }
                     };
                 }
@@ -57,7 +68,15 @@ function loadPushReworkChangesForAction(mocks) {
                 triggerConfiguredWorkflowForTicket: function() { mocks.autoStartReview = true; return true; },
                 triggerSmIfIdle: function() { mocks.triggerSm = true; return true; }
             },
-            './common/outputFiles.js': { readOutputFile: function() { return null; } },
+            './common/outputFiles.js': {
+                readOutputFile: function(path) {
+                    if (mocks.outputFiles && mocks.outputFiles[path] !== undefined) {
+                        return mocks.outputFiles[path];
+                    }
+                    return null;
+                }
+            },
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
             './cacheToReleases.js': { action: function() {} }
         }),
         {
@@ -94,7 +113,8 @@ function loadPostTestReworkResults() {
             './configLoader.js': configLoaderModule,
             './common/autoStart.js': { triggerConfiguredWorkflowForTicket: function() { return false; } },
             './common/feedbackLoop.js': {},
-            './common/pullRequest.js': {}
+            './common/pullRequest.js': {},
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         {}
     );
@@ -223,6 +243,45 @@ suite('rework custom params', function() {
             -1,
             'must not force-push over remote PR updates'
         );
+    });
+
+    test('pr_rework posts thread replies from files referenced in review_replies.json and resolves threads', function() {
+        var mocks = {
+            outputFiles: {
+                'review_replies.json': JSON.stringify({
+                    replies: [
+                        {
+                            inReplyToId: 111,
+                            threadId: 'PRRT_abc',
+                            reply: 'outputs/review_replies/thread_111.md'
+                        },
+                        {
+                            inReplyToId: 222,
+                            threadId: 'PRRT_def',
+                            reply: 'outputs/review_replies/thread_222.md'
+                        }
+                    ]
+                }),
+                'outputs/review_replies/thread_111.md': '✅ Fixed in `ai/TS-1293`.',
+                'outputs/review_replies/thread_222.md': '✅ Renamed variable per review.'
+            }
+        };
+        var mod = loadPushReworkChangesForAction(mocks);
+
+        var result = mod.action({
+            jobParams: {
+                ticket: { key: 'TS-1293', fields: { labels: [] } },
+                response: 'Implemented fix and wrote outputs/response.md',
+                customParams: {
+                    removeLabels: ['sm_story_rework_triggered']
+                }
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(mocks.threadReplies, 2);
+        assert.equal(mocks.resolvedThreads, 2);
+        assert.deepEqual(mocks.replyTexts, ['✅ Fixed in `ai/TS-1293`.', '✅ Renamed variable per review.']);
     });
 
     test('merges pr_test_automation_rework jobParamPatches into runtime customParams', function() {

--- a/pr_rework.json
+++ b/pr_rework.json
@@ -29,6 +29,7 @@
       "./agents/instructions/common/coding_guidelines.md",
       "./agents/instructions/pr_rework/general_guidelines.md",
       "./agents/instructions/pr_rework/formatting_rules.md",
+      "./agents/instructions/pr_rework/output_rules.md",
       "./agents/instructions/common/dmtools_cli.md",
       "./agents/prompts/bash_tools.md"
     ]

--- a/snapshots/pr_rework.md
+++ b/snapshots/pr_rework.md
@@ -57,7 +57,10 @@ flowchart TD
     SUGGESTIONS -->|No| TEST[Run tests and verify]
     SKIP --> TEST
     TEST --> OUTPUT[Write outputs/response.md]
-    OUTPUT --> END([End])
+    OUTPUT --> REPLIES{Open review threads?}
+    REPLIES -->|Yes| REVIEW_REPLIES["Write outputs/review_replies.json with one reply per open thread using threadId + inReplyToId"]
+    REPLIES -->|No| END([End])
+    REVIEW_REPLIES --> END
 ```
 
 ## 1. Input context — MANDATORY reading order
@@ -98,16 +101,66 @@ Read PR files to understand WHAT changed. Read ticket files to understand WHY it
 
 ```mermaid
 flowchart TD
-    F1["outputs/response.md must be a markdown document"]
+    F1["outputs/response.md must be Markdown (# headings, - bullets, ``` code fences)"]
     F2["Required sections: ## Issues/Notes (if any), ## Approach, ## Files Modified, ## Test Coverage"]
     F3["Be surgical but thorough — fix exact issues flagged, then check same pattern across codebase"]
     F4["Do NOT refactor unrelated code or add unrequested features"]
+    F5["When open PR review threads exist, create outputs/review_replies/*.md files and reference them from outputs/review_replies.json"]
 ```
+
+- When `input/<TICKET>/pr_discussions_raw.json` contains open PR review threads:
+  - Write one Markdown file per open thread under `outputs/review_replies/`.
+  - Write `outputs/review_replies.json` with one entry per open thread, including `inReplyToId`, `threadId`, and a `reply` field that contains the path to the matching `.md` file.
+  - Do **not** put reply bodies inline in the JSON.
 
 
 ---
 
-### [6] `./agents/instructions/common/dmtools_cli.md`
+### [6] `./agents/instructions/pr_rework/output_rules.md`
+
+## PR Rework — Output Rules
+
+Rework posts **only** to the Pull Request. All output must be Markdown.
+
+### Required files
+
+1. `outputs/response.md`
+   - GitHub Markdown fix summary for the top-level PR comment.
+   - Use `#`/`##` headings, ` ``` ` code fences, `-` bullets.
+   - Required sections: `## Issues/Notes`, `## Approach`, `## Files Modified`, `## Test Coverage`.
+
+2. `outputs/review_replies.json`
+   - **Mandatory** when the PR has open review threads.
+   - If there are no open threads, write `{ "replies": [] }`.
+   - Format:
+
+```json
+{
+  "replies": [
+    {
+      "inReplyToId": 1234567890,
+      "threadId": "PRRT_<graphQL_id>",
+      "reply": "outputs/review_replies/thread_1.md"
+    }
+  ]
+}
+```
+
+3. `outputs/review_replies/*.md`
+   - One Markdown file per open PR review thread.
+   - The file path is referenced from `outputs/review_replies.json` via the `reply` field.
+   - Keep each reply concise and factual; reference the fix location when possible.
+
+Rules for review replies:
+- Read `input/<TICKET>/pr_discussions_raw.json` to obtain each open thread's `threadId` and `rootCommentId` (`inReplyToId`).
+- Create one reply entry and one `.md` file for **every** open review thread — do not skip any unresolved conversation.
+- `threadId` is required for GitHub to resolve/close the conversation; `inReplyToId` is required to post the reply in the correct thread.
+- Do **not** put the reply body inline in the JSON; use the `reply` field only as a file path reference.
+
+
+---
+
+### [7] `./agents/instructions/common/dmtools_cli.md`
 
 ## DMTools CLI — External Data Access
 
@@ -145,7 +198,7 @@ flowchart TD
 
 ---
 
-### [7] `./agents/prompts/bash_tools.md`
+### [8] `./agents/prompts/bash_tools.md`
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary
- Added `instructions/pr_rework/output_rules.md` requiring `outputs/review_replies.json` for every open PR review thread.
- Updated formatting rules and general guidelines flowchart to use GitHub Markdown and produce thread replies.
- Wired `output_rules.md` into `pr_rework.json`.
- Updated `pushReworkChanges.js` header and Jira interrupted message to reference both required outputs.
- Fixed unit-test require stubs for the token-usage comment module.

## Validation
- `dmtools run js/unit-tests/run_validateAllAgents.json`: `pr_rework.json` passes.
- `dmtools run js/unit-tests/run_reworkCustomParams.json`: 9/9 pass.
- Full suite has unrelated failures in other agents (missing tokenUsageComment test stubs + timer snapshot test).