### PR TITLE
fix(pr_rework): keep top-level PR comment minimal when thread replies exist

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -313,12 +313,20 @@ function postThreadReplies(scm, pullRequestId, outputOptions) {
     return posted;
 }
 
-function postPRComment(scm, pullRequestId, fixSummary, ticketKey) {
+function postPRComment(scm, pullRequestId, fixSummary, ticketKey, repliesPosted) {
     try {
-        const commentText = '## 🔧 Rework Complete — ' + ticketKey + '\n\n' +
-            'All PR review comments have been addressed. See fix summary below.\n\n' +
-            '---\n\n' +
-            fixSummary;
+        var commentText;
+        if (repliesPosted > 0) {
+            // When review thread replies exist, keep the top-level comment minimal.
+            // The detailed answers live in the thread replies.
+            commentText = '## 🔧 Rework Complete — ' + ticketKey + '\n\n' +
+                'All review feedback has been addressed in the thread replies above.';
+        } else {
+            commentText = '## 🔧 Rework Complete — ' + ticketKey + '\n\n' +
+                'All PR review comments have been addressed. See fix summary below.\n\n' +
+                '---\n\n' +
+                fixSummary;
+        }
         scm.addComment(pullRequestId, commentText);
         console.log('✅ Posted fix summary to PR #' + pullRequestId);
         return true;
@@ -510,7 +518,7 @@ function action(params) {
             var hasMeaningfulSummary = fixSummary && fixSummary.length > 50
                 && fixSummary !== '_(No fix summary generated)_';
             if (repliesPosted > 0 || codeChangesCommitted || hasMeaningfulSummary) {
-                prCommentPosted = postPRComment(scm, pr.number, fixSummary, ticketKey);
+                prCommentPosted = postPRComment(scm, pr.number, fixSummary, ticketKey, repliesPosted);
             } else {
                 console.log('ℹ️ No thread replies, no code changes, and no meaningful summary — skipping general PR comment');
             }

--- a/js/unit-tests/test_reworkCustomParams.js
+++ b/js/unit-tests/test_reworkCustomParams.js
@@ -40,7 +40,7 @@ function loadPushReworkChangesForAction(mocks) {
                     return {
                         getRemoteRepoInfo: function() { return { owner: 'IstiN', repo: 'trackstate' }; },
                         listPrs: function() { return [{ number: 1571, title: 'TS-1293 Fix', html_url: 'https://github.com/IstiN/trackstate/pull/1571', head: { ref: 'ai/TS-1293' } }]; },
-                        addComment: function() { mocks.prComments = (mocks.prComments || 0) + 1; },
+                        addComment: function(prId, text) { mocks.prComments = (mocks.prComments || 0) + 1; mocks.prCommentTexts = (mocks.prCommentTexts || []).concat(text); },
                         replyToThread: function(prId, thread, text) {
                             mocks.threadReplies = (mocks.threadReplies || 0) + 1;
                             mocks.replyTexts = (mocks.replyTexts || []).concat(text);
@@ -282,6 +282,10 @@ suite('rework custom params', function() {
         assert.equal(mocks.threadReplies, 2);
         assert.equal(mocks.resolvedThreads, 2);
         assert.deepEqual(mocks.replyTexts, ['✅ Fixed in `ai/TS-1293`.', '✅ Renamed variable per review.']);
+        assert.equal(mocks.prComments, 1, 'must post a single minimal top-level PR comment');
+        assert.ok(mocks.prCommentTexts[0].indexOf('Rework Complete') !== -1, 'top-level comment should mention rework complete');
+        assert.ok(mocks.prCommentTexts[0].indexOf('thread replies') !== -1, 'top-level comment should point to thread replies');
+        assert.ok(mocks.prCommentTexts[0].indexOf('✅ Fixed in') === -1, 'top-level comment must not duplicate thread reply bodies');
     });
 
     test('merges pr_test_automation_rework jobParamPatches into runtime customParams', function() {


### PR DESCRIPTION
When the agent posts replies to open PR review threads, the top-level PR comment is now a short notice instead of duplicating the full fix summary. The detailed answers live in the thread replies.