### PR TITLE
fix(pr_rework): skip top-level PR comment when review thread replies exist

### DIFF
--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -513,11 +513,14 @@ function action(params) {
             });
             console.log('Thread replies posted:', repliesPosted);
 
-            // Post general fix summary as a top-level PR comment
-            // Post if: code was committed, thread replies were posted, or agent produced a meaningful summary
+            // Post general fix summary as a top-level PR comment only when there are no
+            // review thread replies. When replies exist, the thread replies themselves are
+            // sufficient; an extra top-level comment is noise.
             var hasMeaningfulSummary = fixSummary && fixSummary.length > 50
                 && fixSummary !== '_(No fix summary generated)_';
-            if (repliesPosted > 0 || codeChangesCommitted || hasMeaningfulSummary) {
+            if (repliesPosted > 0) {
+                console.log('ℹ️ Review thread replies posted — skipping general PR comment');
+            } else if (codeChangesCommitted || hasMeaningfulSummary) {
                 prCommentPosted = postPRComment(scm, pr.number, fixSummary, ticketKey, repliesPosted);
             } else {
                 console.log('ℹ️ No thread replies, no code changes, and no meaningful summary — skipping general PR comment');

--- a/js/unit-tests/test_reworkCustomParams.js
+++ b/js/unit-tests/test_reworkCustomParams.js
@@ -282,10 +282,7 @@ suite('rework custom params', function() {
         assert.equal(mocks.threadReplies, 2);
         assert.equal(mocks.resolvedThreads, 2);
         assert.deepEqual(mocks.replyTexts, ['✅ Fixed in `ai/TS-1293`.', '✅ Renamed variable per review.']);
-        assert.equal(mocks.prComments, 1, 'must post a single minimal top-level PR comment');
-        assert.ok(mocks.prCommentTexts[0].indexOf('Rework Complete') !== -1, 'top-level comment should mention rework complete');
-        assert.ok(mocks.prCommentTexts[0].indexOf('thread replies') !== -1, 'top-level comment should point to thread replies');
-        assert.ok(mocks.prCommentTexts[0].indexOf('✅ Fixed in') === -1, 'top-level comment must not duplicate thread reply bodies');
+        assert.equal(mocks.prComments || 0, 0, 'must not post a top-level PR comment when thread replies exist');
     });
 
     test('merges pr_test_automation_rework jobParamPatches into runtime customParams', function() {


### PR DESCRIPTION
When the rework agent replies to open PR review threads, the top-level 'Rework Complete' comment is now skipped entirely. The thread replies are sufficient, so the extra comment was noise.