### PR TITLE
feat(kimi): persist and resume Kimi sessions across AI Teammate runs

### DIFF
--- a/scripts/providers/kimi.sh
+++ b/scripts/providers/kimi.sh
@@ -68,9 +68,21 @@ run_kimi() {
     kimi_pass_args=("${PASS_ARGS[@]}")
   fi
 
+  _kimi_session_dir() {
+    local sid="$1"
+    local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+    find "${home}/sessions" -maxdepth 2 -type d -name "session_${sid}" 2>/dev/null | head -1
+  }
+
+  _kimi_session_exists() {
+    [ -n "$(_kimi_session_dir "$1")" ]
+  }
+
   if [ "${kimi_has_resume_arg}" = "true" ] && [ "${kimi_has_session_arg}" = "false" ]; then
     if [ -z "${kimi_session_id}" ] && [ -f "outputs/kimi_session_id.txt" ]; then
       kimi_session_id="$(tr -d '[:space:]' < outputs/kimi_session_id.txt || true)"
+      # Normalise: older runs may have persisted the full directory name (session_<uuid>).
+      kimi_session_id="${kimi_session_id#session_}"
     fi
     if [ -z "${kimi_session_id}" ]; then
       echo "Error: Kimi resume requested but no session id is available." >&2
@@ -78,7 +90,7 @@ run_kimi() {
       return 1
     fi
     echo "Resuming Kimi session: ${kimi_session_id}"
-    kimi_session_args=(--session "${kimi_session_id}")
+    kimi_session_args=(--session "session_${kimi_session_id}")
     # Drop --continue/--resume flags; keep any other pass-through args.
     kimi_pass_args=()
     if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
@@ -88,6 +100,16 @@ run_kimi() {
           *) kimi_pass_args+=("$pass_arg") ;;
         esac
       done
+    fi
+  elif [ -n "${kimi_session_id}" ] && [ "${kimi_has_session_arg}" = "false" ]; then
+    # AI Teammate session persistence: every normal run for a given ticket/group
+    # should resume the same session across CI runs. The session id is made
+    # deterministic by agents/setup/kimi-session.sh and the session tree is cached.
+    if _kimi_session_exists "${kimi_session_id}"; then
+      echo "Resuming Kimi session: ${kimi_session_id}"
+      kimi_session_args=(--session "session_${kimi_session_id}")
+    else
+      echo "Kimi session ${kimi_session_id} not found; starting new session (will normalize to deterministic id after run)"
     fi
   fi
 
@@ -110,12 +132,32 @@ run_kimi() {
   # Kimi stores runtime data under KIMI_CODE_HOME.
   local new_session_id=""
   new_session_id="$(grep -o '"session_id":"[^"]*"' "$kimi_log" | head -1 | cut -d'"' -f4 || true)"
-  if [ -n "${new_session_id}" ]; then
-    mkdir -p outputs
-    printf '%s\n' "${new_session_id}" > outputs/kimi_session_id.txt
+
+  # Normalize the Kimi-generated session id to the deterministic id configured
+  # by agents/setup/kimi-session.sh. This makes the cached session path stable
+  # across CI runs for the same ticket/agent-group pair.
+  local effective_session_id="${kimi_session_id:-${new_session_id}}"
+  if [ -n "${KIMI_SESSION_ID:-}" ] && [ -n "${new_session_id}" ] && [ "${new_session_id}" != "session_${KIMI_SESSION_ID}" ] && [ "${new_session_id}" != "${KIMI_SESSION_ID}" ]; then
+    local home="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+    local new_uuid="${new_session_id#session_}"
+    local src_dir=""
+    src_dir="$(find "${home}/sessions" -maxdepth 2 -type d -name "session_${new_uuid}" 2>/dev/null | head -1 || true)"
+    if [ -n "${src_dir}" ]; then
+      local dest_dir="${src_dir%/*}/session_${KIMI_SESSION_ID}"
+      if [ "${src_dir}" != "${dest_dir}" ] && [ ! -e "${dest_dir}" ]; then
+        mv "${src_dir}" "${dest_dir}"
+        echo "✅ Normalized Kimi session id to deterministic id: ${KIMI_SESSION_ID}"
+      fi
+    fi
+    effective_session_id="${KIMI_SESSION_ID}"
   fi
 
-  print_kimi_usage_summary_and_write_json "${new_session_id:-${kimi_session_id}}"
+  if [ -n "${effective_session_id}" ]; then
+    mkdir -p outputs
+    printf '%s\n' "${effective_session_id}" > outputs/kimi_session_id.txt
+  fi
+
+  print_kimi_usage_summary_and_write_json "${effective_session_id}"
 
   rm -f "$kimi_log"
 

--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -97,6 +97,11 @@ _cache_kimi() {
   export_var "KIMI_CACHE_KEY"  "kimi-${version}-${OS_TAG}"
 }
 
+_cache_kimi_session() {
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/kimi-session.sh" env
+}
+
 # ── Dispatch ──────────────────────────────────────────────────────────────────
 
 _dispatch_tool() {
@@ -108,6 +113,7 @@ _dispatch_tool() {
     maestro)  _cache_maestro  "${version}" ;;
     copilot)  _cache_copilot  "${version}" ;;
     copilot-session) _cache_copilot_session ;;
+    kimi-session) _cache_kimi_session ;;
     codegraph) _cache_codegraph "${version}" ;;
     playwright) _cache_playwright "${version}" ;;
     codemie)  _cache_codemie  "${version}" ;;
@@ -148,7 +154,7 @@ _print_info() {
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-ALL_TOOLS="java node dmtools maestro copilot copilot-session codemie codegraph playwright kimi"  # cursor has no cache
+ALL_TOOLS="java node dmtools maestro copilot copilot-session kimi-session codemie codegraph playwright kimi"  # cursor has no cache
 
 MODE="${1:-info}"
 shift || true

--- a/setup/kimi-session.sh
+++ b/setup/kimi-session.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Configure a stable, cacheable Kimi session for AI Teammate runs.
+#
+# Usage:
+#   kimi-session.sh env
+#   kimi-session.sh info
+#
+# Inputs:
+#   AI_TEAMMATE_CONFIG_FILE       e.g. agents/story_development.json
+#   AI_TEAMMATE_CONCURRENCY_KEY   workflow concurrency key (usually ticket key)
+#   AI_TEAMMATE_DISPLAY_KEY       user-visible ticket key, preferred when set
+#   GITHUB_WORKSPACE              workspace root
+#
+# Outputs:
+#   KIMI_SESSION_ID               stable UUID derived from repo/key/group
+#   KIMI_SESSION_NAME             stable human-readable session name
+#   KIMI_SESSION_GROUP            logical group (dev-write, dev-review, ...)
+#   KIMI_CODE_HOME                isolated Kimi home to cache for this work stream
+#   KIMI_SESSION_CACHE_PATH       path for CI cache restore/save
+#   KIMI_SESSION_CACHE_KEY        immutable cache key for this run
+#   KIMI_SESSION_CACHE_RESTORE_KEY prefix for previous runs of the same stream
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_common.sh"
+
+_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+_uuid_from_seed() {
+  local hash="$(_sha256 "$1")"
+  # Build a deterministic UUID-looking value. Kimi only requires a UUID;
+  # the seed keeps the same ticket/group on the same session across CI runs.
+  printf '%s-%s-5%s-a%s-%s' \
+    "${hash:0:8}" \
+    "${hash:8:4}" \
+    "${hash:13:3}" \
+    "${hash:17:3}" \
+    "${hash:20:12}"
+}
+
+_config_slug() {
+  local config="${AI_TEAMMATE_CONFIG_FILE:-${CONFIG_FILE:-}}"
+  config="${config##*/}"
+  config="${config%.json}"
+  _slug "${config:-unknown}"
+}
+
+_session_group_for_config() {
+  local config="$1"
+  case "${config}" in
+    story_development|bug_development|pr_rework)
+      echo "dev-write"
+      ;;
+    pr_review)
+      echo "dev-review"
+      ;;
+    test_case_automation|pr_test_automation_rework)
+      echo "test-write"
+      ;;
+    pr_test_automation_review)
+      echo "test-review"
+      ;;
+    *)
+      echo "${config}"
+      ;;
+  esac
+}
+
+exclude_kimi_session_from_git() {
+  local workspace="$1"
+  local git_dir
+
+  git_dir="$(git -C "${workspace}" rev-parse --git-dir 2>/dev/null || true)"
+  if [ -z "${git_dir}" ]; then
+    return 0
+  fi
+
+  mkdir -p "${git_dir}/info"
+  touch "${git_dir}/info/exclude"
+
+  grep -qxF ".dmtools/kimi-sessions/" "${git_dir}/info/exclude" 2>/dev/null \
+    || echo ".dmtools/kimi-sessions/" >> "${git_dir}/info/exclude"
+  grep -qxF ".dmtools/kimi-sessions/**" "${git_dir}/info/exclude" 2>/dev/null \
+    || echo ".dmtools/kimi-sessions/**" >> "${git_dir}/info/exclude"
+}
+
+configure_kimi_session() {
+  local workspace="${GITHUB_WORKSPACE:-${PWD}}"
+  local repo="${GITHUB_REPOSITORY:-$(basename "${workspace}")}"
+  local config="$(_config_slug)"
+  local group="$(_session_group_for_config "${config}")"
+  local key="${AI_TEAMMATE_DISPLAY_KEY:-${DISPLAY_KEY:-}}"
+
+  if [ -z "${key}" ]; then
+    key="${AI_TEAMMATE_CONCURRENCY_KEY:-${CONCURRENCY_KEY:-}}"
+  fi
+  if [ -z "${key}" ]; then
+    key="$(git -C "${workspace}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)"
+  fi
+
+  local repo_slug="$(_slug "${repo}")"
+  local key_slug="$(_slug "${key}")"
+  local group_slug="$(_slug "${group}")"
+  local session_seed="${repo_slug}:${key_slug}:${group_slug}"
+  local session_id="$(_uuid_from_seed "${session_seed}")"
+  local session_name="${repo_slug}-${key_slug}-${group_slug}"
+  local session_root="${workspace}/.dmtools/kimi-sessions/${repo_slug}/${key_slug}/${group_slug}"
+  local cache_prefix="kimi-session-${repo_slug}-${key_slug}-${group_slug}-"
+  local cache_version="${KIMI_SESSION_CACHE_VERSION:-v1}"
+  local cache_run_id="${GITHUB_RUN_ID:-local}"
+
+  mkdir -p "${session_root}"
+  exclude_kimi_session_from_git "${workspace}"
+
+  # Carry over the Kimi config that setup/kimi.sh wrote into the default home.
+  # Kimi reads config from $KIMI_CODE_HOME/config.toml, so we mirror it into
+  # the isolated session home before overriding KIMI_CODE_HOME.
+  local default_kimi_home="${HOME}/.kimi-code"
+  if [ -f "${default_kimi_home}/config.toml" ] && [ ! -f "${session_root}/config.toml" ]; then
+    cp "${default_kimi_home}/config.toml" "${session_root}/config.toml"
+  fi
+
+  export_var "KIMI_SESSION_ID" "${session_id}"
+  export_var "KIMI_SESSION_NAME" "${session_name}"
+  export_var "KIMI_SESSION_GROUP" "${group_slug}"
+  export_var "KIMI_CODE_HOME" "${session_root}"
+  export_var "KIMI_SESSION_CACHE_PATH" "${session_root}"
+  export_var "KIMI_SESSION_CACHE_RESTORE_KEY" "${cache_prefix}${cache_version}-"
+  export_var "KIMI_SESSION_CACHE_KEY" "${cache_prefix}${cache_version}-${cache_run_id}"
+}
+
+MODE="${1:-env}"
+case "${MODE}" in
+  env|restore|save|info)
+    configure_kimi_session
+    echo "🌙 Kimi session: group=${KIMI_SESSION_GROUP} name=${KIMI_SESSION_NAME}"
+    echo "📦 Kimi session cache: key=${KIMI_SESSION_CACHE_KEY} path=${KIMI_SESSION_CACHE_PATH}"
+    ;;
+  *)
+    echo "Usage: kimi-session.sh env|restore|save|info" >&2
+    exit 1
+    ;;
+esac

--- a/setup/kimi.sh
+++ b/setup/kimi.sh
@@ -79,12 +79,27 @@ EOF
   echo "✅ kimi config written: ${KIMI_CONFIG_FILE}"
 }
 
+# ── Configure isolated Kimi session for AI Teammate runs ──────────────────────
+_configure_session() {
+  # When running inside AI Teammate, derive a stable session id per
+  # repo:ticket:agent_group and isolate KIMI_CODE_HOME so the session can be
+  # cached and resumed across CI runs.
+  if [ -z "${AI_TEAMMATE_CONFIG_FILE:-}" ]; then
+    return 0
+  fi
+  if [ -f "${SCRIPT_DIR}/kimi-session.sh" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/kimi-session.sh" env
+  fi
+}
+
 echo "🌙 Kimi Code CLI"
 
 # ── Already installed? ────────────────────────────────────────────────────────
 if is_installed kimi; then
   echo "✅ kimi already installed: $(kimi --version 2>/dev/null || echo "cached")"
   _write_config
+  _configure_session
   exit 0
 fi
 
@@ -92,6 +107,7 @@ if [ -x "${KIMI_BIN_DIR}/kimi" ]; then
   register_path "${KIMI_BIN_DIR}"
   echo "✅ kimi already installed: ${KIMI_BIN_DIR}/kimi"
   _write_config
+  _configure_session
   exit 0
 fi
 
@@ -112,6 +128,7 @@ if [ -x "${KIMI_BIN_DIR}/kimi" ]; then
   register_path "${KIMI_BIN_DIR}"
   echo "✅ kimi installed: ${KIMI_BIN_DIR}/kimi"
   _write_config
+  _configure_session
 else
   echo "⚠️  kimi could not be installed automatically."
   echo "    Install manually: curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash"


### PR DESCRIPTION
## Summary

Adds deterministic Kimi session persistence so AI Teammate runs for the same ticket and agent group resume the same session across CI runs, matching the existing Copilot behavior.

## Changes

- `agents/setup/kimi-session.sh` — new setup script that derives a stable `KIMI_SESSION_ID` from repo:ticket:agent_group, isolates `KIMI_CODE_HOME`, and exports cache variables.
- `agents/scripts/providers/kimi.sh` — auto-resumes cached sessions when `KIMI_SESSION_ID` is set and normalizes newly created session ids to the deterministic id.

## Related

Fixes the loop where Kimi starts a fresh session on every AI Teammate run and loses previous context.