### PR TITLE
fix(pr_review): correct pullRequestID casing and inline comment fallback

### DIFF
--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -99,7 +99,10 @@ function _createGithubProvider(workspace, repository) {
             return github_remove_pr_label({ workspace: workspace, repository: repository, pullRequestId: String(prId), label: label });
         },
         getPrDiff: function(prId) {
-            return github_get_pr_diff({ workspace: workspace, repository: repository, pullRequestId: String(prId) });
+            // Note: the generated GitHub MCP executor expects the parameter name
+            // to be exactly 'pullRequestID' (capital D). Passing 'pullRequestId'
+            // causes a "Required parameter 'pullRequestID' is missing" error.
+            return github_get_pr_diff({ workspace: workspace, repository: repository, pullRequestID: String(prId) });
         },
         getCommitCheckRuns: function(sha) {
             return github_get_commit_check_runs({ workspace: workspace, repository: repository, commitSha: sha });

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -380,15 +380,23 @@ function postInlineComment(scm, pullRequestId, inlineComment, ticketKey, working
 
         console.log('Posting inline comment on ' + filePath + ':' + inlineComment.line);
 
+        var diffText = null;
         try {
-            var diffText = scm.getPrDiff(pullRequestId);
-            if (diffText !== null && !isLinePresentInDiff(diffText, filePath, inlineComment.line)) {
-                console.warn('Inline comment line is not present in PR diff; falling back to PR comment on ' + filePath + ':' + inlineComment.line);
-                postFallbackInlineComment(scm, pullRequestId, filePath, inlineComment.line, commentText);
-                return true;
-            }
+            diffText = scm.getPrDiff(pullRequestId);
         } catch (diffError) {
             console.warn('Could not fetch PR diff for inline comment validation:', diffError.message || diffError);
+        }
+
+        if (diffText === null || diffText === '') {
+            console.warn('PR diff unavailable; falling back to general PR comment on ' + filePath + ':' + inlineComment.line);
+            postFallbackInlineComment(scm, pullRequestId, filePath, inlineComment.line, commentText);
+            return true;
+        }
+
+        if (!isLinePresentInDiff(diffText, filePath, inlineComment.line)) {
+            console.warn('Inline comment line is not present in PR diff; falling back to PR comment on ' + filePath + ':' + inlineComment.line);
+            postFallbackInlineComment(scm, pullRequestId, filePath, inlineComment.line, commentText);
+            return true;
         }
 
         scm.addInlineComment(


### PR DESCRIPTION
Fixes github_get_pr_diff parameter casing (must be pullRequestID capital D) and makes inline comments fall back to general PR comments when the diff is unavailable or the line is not in the diff.