### PR TITLE
feat(story_test_automation): bulk automate linked Test Cases from a Story

### DIFF
--- a/instructions/pr_story_test_automation_review/general_guidelines.md
+++ b/instructions/pr_story_test_automation_review/general_guidelines.md
@@ -1,0 +1,29 @@
+# Story Test Automation Bulk Review Guidelines
+
+You are reviewing a bulk Pull Request that automates all Test Cases linked to a Story. The branch is `test/{STORY_KEY}`.
+
+## Review focus
+
+1. **Coverage** — every linked Test Case must have a corresponding automated test under `testing/tests/{TC_KEY}/`.
+2. **Completeness** — each test folder must contain `README.md` and `config.yaml`.
+3. **Architecture** — tests must follow the layer order:
+   - `testing/tests/{TC_KEY}/` → test orchestration
+   - `testing/components/` → reusable page/screen components
+   - `testing/frameworks/` → domain-specific wrappers
+   - `testing/core/` → low-level drivers and fixtures
+4. **No raw locators** — ticket test files must not contain raw Flutter widget locators or direct `WidgetTester` calls.
+5. **Determinism** — tests must be isolated, with proper setup and teardown, and no reliance on shared mutable state.
+6. **Accuracy** — each test must match its Test Case description and acceptance criteria verbatim.
+7. **Reuse** — shared helpers and components must be reused; avoid duplication.
+8. **Cleanup** — no debug prints, commented-out code, or unrelated files.
+
+## Output
+
+Write `outputs/pr_review.json` with:
+
+- `recommendation`: `APPROVE`, `REQUEST_CHANGES`, or `BLOCK`
+- `summary`: concise review summary
+- `generalComment`: path to `outputs/pr_review_general.md`
+- `inlineComments`: array of line-level comments with `path`, `line`, `body`, `severity`
+
+Approve only when all blocking issues are resolved and every linked Test Case is covered.

--- a/instructions/story_test_automation/general_guidelines.md
+++ b/instructions/story_test_automation/general_guidelines.md
@@ -1,0 +1,40 @@
+# Story-level Test Automation Guidelines
+
+You are automating a Story that has reached **Ready For Testing**. The Story already has linked Test Case tickets. Your job is to process **all linked Test Cases in one bulk run**.
+
+## Workflow
+
+1. Read the Story ticket and all linked Test Cases from `input/{STORY_KEY}/linked_test_cases.md`.
+2. For each linked Test Case:
+   - Check if an automated test already exists under `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If it is missing, write a new automated test for it.
+3. Produce a single result JSON: `outputs/story_test_automation_result.json`.
+4. For every failed Test Case, produce `outputs/failed_description_{TC_KEY}.md`.
+5. If environment/credentials are missing, produce `outputs/blocked.json` instead of running tests.
+
+## Scope rules
+
+- You may ONLY write code inside the `testing/` folder.
+- Each Test Case must have its own folder under `testing/tests/{TC_KEY}/`.
+- Reuse components from `testing/components/`, `testing/frameworks/`, and `testing/core/`.
+- Do NOT put raw Flutter/widget locators or `WidgetTester` code directly in the ticket test file.
+- Every `testing/tests/{TC_KEY}/` folder must contain:
+  - `README.md` describing what is being tested.
+  - `config.yaml` with test metadata.
+
+## Output files
+
+| File | Purpose |
+|------|---------|
+| `outputs/story_test_automation_result.json` | Per-TC results and overall status. |
+| `outputs/tracker_comment.md` | Human-readable summary for the Story ticket comment. |
+| `outputs/failed_description_{TC_KEY}.md` | Full failure report for a failed Test Case. |
+| `outputs/blocked.json` | Required when automation cannot run due to missing setup. |
+
+## Result statuses
+
+- `passed` — test ran successfully.
+- `failed` — test ran and failed; a failed description file must be written.
+- `skipped` — test cannot be automated (requires human-only verification); explain why.
+- `blocked_by_human` — the whole Story is blocked by missing credentials/data.

--- a/instructions/story_test_automation/output_rules.md
+++ b/instructions/story_test_automation/output_rules.md
@@ -1,0 +1,56 @@
+# Story Test Automation Output Rules
+
+## Mandatory JSON output
+
+Write `outputs/story_test_automation_result.json` with exactly this schema:
+
+```json
+{
+  "storyKey": "TS-123",
+  "overall": "passed|failed|mixed|blocked_by_human",
+  "summary": "Short human-readable summary of what was done.",
+  "results": [
+    {
+      "testCaseKey": "TS-124",
+      "status": "passed|failed|skipped",
+      "testPath": "testing/tests/TS-124/...",
+      "failedDescriptionFile": "outputs/failed_description_TS-124.md",
+      "failureSummary": "One-line failure summary when status is failed."
+    }
+  ],
+  "blockedReason": "Explanation when overall is blocked_by_human."
+}
+```
+
+### Field rules
+
+- `overall`:
+  - `passed` — every result is `passed`.
+  - `failed` — at least one result is `failed` and none are blocked.
+  - `mixed` — some passed and some skipped, but none failed.
+  - `blocked_by_human` — automation could not run due to missing credentials/data.
+- `results` must contain every linked Test Case found in the input context.
+- `failedDescriptionFile` is required for every `failed` result. It must point to a file under `outputs/`.
+- `failureSummary` is required for every `failed` result.
+- `testPath` is required for every non-skipped result.
+
+## Mandatory tracker comment
+
+Write `outputs/tracker_comment.md` in Jira wiki format. It should include:
+
+- Story key and summary.
+- Counts of passed / failed / skipped Test Cases.
+- List of failed Test Cases with links to their failed description files (will be attached by the post-action).
+- Any blockers or missing setup.
+
+## Failed description files
+
+For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md` containing:
+
+1. Test Case key and summary.
+2. Steps to reproduce.
+3. Expected vs actual result.
+4. Stack trace / logs / screenshots if available.
+5. Environment details.
+
+Use Jira wiki markup (headings, code blocks, lists) so the file is readable when attached to the Test Case ticket.

--- a/js/config.js
+++ b/js/config.js
@@ -102,7 +102,8 @@ const DIAGRAM_FORMAT = {
 // Field Names
 const JIRA_FIELDS = {
     DIAGRAMS: 'Diagrams',
-    SOLUTION: 'Solution'
+    SOLUTION: 'Solution',
+    FAILED_REASON: 'Failed Reason'
 };
 
 // Summary Length Constraints

--- a/js/mergeStoryTestAutomationPR.js
+++ b/js/mergeStoryTestAutomationPR.js
@@ -1,0 +1,219 @@
+/**
+ * Merge Story Test Automation PR
+ * Merges the PR on branch test/{STORY_KEY} and moves all linked Test Cases
+ * from In Review - Passed/Failed to Passed/Failed.
+ */
+
+const { STATUSES, LABELS } = require('./config.js');
+var scmModule = require('./common/scm.js');
+var configLoader = require('./configLoader.js');
+var autoStart = require('./common/autoStart.js');
+var tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function findPRForStory(scm, storyKey) {
+    try {
+        const branchName = 'test/' + storyKey;
+        const prList = scm.listPrs('open');
+        return (Array.isArray(prList) ? prList : []).find(function(pr) {
+            return pr.head && pr.head.ref && pr.head.ref === branchName;
+        }) || null;
+    } catch (e) {
+        console.error('Failed to list PRs:', e);
+        return null;
+    }
+}
+
+function releaseLock(storyKey, customParams) {
+    const removeLabel = customParams && customParams.removeLabel;
+    if (removeLabel && storyKey) {
+        try { jira_remove_label({ key: storyKey, label: removeLabel }); } catch (e) {}
+    }
+}
+
+function fetchLinkedTestCases(storyKey, testCaseType) {
+    var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = "' + testCaseType + '"';
+    try {
+        return jira_search_by_jql({ jql: jql, maxResults: 100 }) || [];
+    } catch (e) {
+        console.warn('Failed to fetch linked Test Cases for merge:', e);
+        return [];
+    }
+}
+
+function resolveFinalStatus(currentStatus) {
+    if (currentStatus === STATUSES.IN_REVIEW_PASSED) return STATUSES.PASSED;
+    if (currentStatus === STATUSES.IN_REVIEW_FAILED) return STATUSES.FAILED;
+    return null;
+}
+
+function moveLinkedTestCases(storyKey, testCaseType) {
+    var testCases = fetchLinkedTestCases(storyKey, testCaseType);
+    var moved = 0;
+    var skipped = 0;
+    testCases.forEach(function(tc) {
+        var currentStatus = tc.fields && tc.fields.status ? tc.fields.status.name : '';
+        var finalStatus = resolveFinalStatus(currentStatus);
+        if (!finalStatus) {
+            console.log('Skipping linked TC', tc.key, '— current status', currentStatus);
+            skipped++;
+            return;
+        }
+        try {
+            jira_move_to_status({ key: tc.key, statusName: finalStatus });
+            console.log('✅ Moved', tc.key, 'to', finalStatus);
+            moved++;
+        } catch (e) {
+            console.warn('Failed to move', tc.key, 'to', finalStatus, ':', e);
+            skipped++;
+        }
+    });
+    return { moved: moved, skipped: skipped, total: testCases.length };
+}
+
+function action(params) {
+    const storyKey = params.ticket && params.ticket.key;
+    if (!storyKey) {
+        console.error('No storyKey provided');
+        return false;
+    }
+
+    var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var scm = scmModule.createScm(config);
+    var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var testCaseType = projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE
+        ? projectConfig.jira.issueTypes.TEST_CASE
+        : 'Test Case';
+
+    const repoInfo = scm.getRemoteRepoInfo();
+    if (!repoInfo) {
+        console.error('Could not determine owner/repo');
+        releaseLock(storyKey, customParams);
+        return false;
+    }
+
+    const pr = findPRForStory(scm, storyKey);
+    if (!pr) {
+        console.warn('No open PR found for story', storyKey, '— releasing lock');
+        releaseLock(storyKey, customParams);
+        return false;
+    }
+
+    const prNumber = pr.number;
+    const prUrl = pr.html_url;
+    console.log('Found PR #' + prNumber + ' for story ' + storyKey);
+
+    let mergeableState = null;
+    let mergeable = null;
+    try {
+        const prDetail = scm.getPr(prNumber);
+        mergeable = prDetail && prDetail.mergeable;
+        mergeableState = prDetail && prDetail.mergeable_state;
+        console.log('PR mergeable: ' + mergeable + ', state: ' + mergeableState);
+    } catch (e) {
+        console.warn('Could not get PR details, will attempt merge anyway:', e);
+    }
+
+    if (mergeable === null ||
+        mergeableState === 'unknown' ||
+        mergeableState === 'blocked' ||
+        mergeableState === 'unstable' ||
+        mergeableState === 'checking' ||
+        mergeableState === 'unchecked' ||
+        mergeableState === 'preparing' ||
+        mergeableState === 'ci_must_pass' ||
+        mergeableState === 'ci_still_running') {
+        console.log('PR not ready to merge (' + mergeableState + ') — will retry next cycle');
+        return false;
+    }
+
+    if (mergeableState === 'behind') {
+        console.log('PR branch is behind base — requesting branch update');
+        try {
+            if (scm.updateBranch) {
+                scm.updateBranch(prNumber, repoInfo.owner, repoInfo.repo);
+            } else {
+                throw new Error('SCM provider does not support updateBranch');
+            }
+        } catch (updateErr) {
+            console.warn('Could not update branch:', updateErr);
+        }
+        return false;
+    }
+
+    if ((mergeable === false && mergeableState === 'dirty') ||
+        mergeableState === 'cannot_be_merged' ||
+        mergeableState === 'conflict') {
+        console.log('PR has merge conflict — moving Story to In Rework');
+        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
+        try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
+        releaseLock(storyKey, customParams);
+        jira_post_comment({
+            key: storyKey,
+            comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE CONFLICT* — PR #' + prNumber + ' has a merge conflict with main.\n\n[View PR|' + prUrl + ']{panel}'
+        });
+        jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+        return true;
+    }
+
+    try {
+        scm.mergePr(prNumber, 'squash');
+        console.log('✅ PR #' + prNumber + ' merged successfully');
+
+        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
+
+        // Move linked Test Cases to final status before removing Jira pr_approved label
+        var tcResult = moveLinkedTestCases(storyKey, testCaseType);
+
+        // Story stays In Testing; story_done_check will move it to Done when all TCs are Passed
+        try {
+            jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
+            console.log('Removed pr_approved label from Jira Story');
+        } catch (e) {
+            console.warn('Could not remove pr_approved from Jira Story:', e);
+        }
+
+        releaseLock(storyKey, customParams);
+
+        jira_post_comment({
+            key: storyKey,
+            comment: 'h3. ✅ Story Test PR Merged\n\n' +
+                'PR [#' + prNumber + '|' + prUrl + '] for branch {code}test/' + storyKey + '{code} was merged.\n\n' +
+                'Linked Test Cases moved to final status: *' + tcResult.moved + '* moved, *' + tcResult.skipped + '* skipped.'
+        });
+
+        try {
+            tokenUsageComment.postTokenUsageComments(storyKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return true;
+
+    } catch (mergeErr) {
+        console.warn('Merge failed:', mergeErr);
+        const errMsg = mergeErr ? String(mergeErr) : '';
+        const isConflict = errMsg.toLowerCase().indexOf('conflict') !== -1;
+        const isCIBlocking = errMsg.indexOf('blocked') !== -1 || errMsg.indexOf('422') !== -1 || errMsg.indexOf('405') !== -1;
+
+        if (!isConflict && (isCIBlocking || errMsg === '')) {
+            console.log('Merge blocked temporarily — will retry next cycle');
+            return false;
+        }
+
+        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
+        try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
+        releaseLock(storyKey, customParams);
+        const reason = isConflict ? 'merge conflict' : 'CI checks failing or PR not mergeable';
+        jira_post_comment({
+            key: storyKey,
+            comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE FAILED* — Could not merge PR #' + prNumber + ': ' + reason + '.\n\n[View PR|' + prUrl + ']{panel}'
+        });
+        jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+        return true;
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -1,0 +1,439 @@
+/**
+ * Post Story Test Automation Results Action
+ * 1. Reads outputs/story_test_automation_result.json
+ * 2. Commits/pushes testing/ folder on test/{STORY_KEY} branch
+ * 3. Creates PR to main
+ * 4. Per linked Test Case:
+ *    - status → In Review - Passed / In Review - Failed
+ *    - failed TC: attach outputs/failed_description_{TC_KEY}.md and set Failed Reason field
+ * 5. Moves Story → In Testing
+ * 6. Triggers pr_story_test_automation_review
+ */
+
+var configLoader = require('./configLoader.js');
+var prHelper = require('./common/pullRequest.js');
+var autoStart = require('./common/autoStart.js');
+const { GIT_CONFIG, STATUSES, LABELS, JIRA_FIELDS } = require('./config.js');
+var outputFiles = require('./common/outputFiles.js');
+var tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function cleanCommandOutput(output) {
+    return prHelper.cleanCommandOutput(output);
+}
+
+function readFile(path) {
+    return outputFiles.readOutputFile(path, {});
+}
+
+function readOutputFile(relativePath, workingDir, ticketKey) {
+    return outputFiles.readOutputFile(relativePath, {
+        workingDir: workingDir,
+        ticketKey: ticketKey
+    });
+}
+
+function readResultJson(workingDir, storyKey) {
+    try {
+        const raw = readOutputFile('story_test_automation_result.json', workingDir, storyKey);
+        if (!raw) {
+            console.warn('outputs/story_test_automation_result.json is empty or missing');
+            return null;
+        }
+        const parsed = JSON.parse(raw);
+        console.log('Story test result overall:', parsed.overall);
+        return parsed;
+    } catch (e) {
+        console.error('Failed to parse story_test_automation_result.json:', e);
+        return null;
+    }
+}
+
+function markdownToJiraWiki(markdown) {
+    if (!markdown) return '';
+    var text = String(markdown);
+    text = text.replace(/```(\w+)?\n([\s\S]*?)```/g, function(_, language, code) {
+        return '{code' + (language ? ':' + language : '') + '}\n' + code.trim() + '\n{code}';
+    });
+    text = text
+        .replace(/^####\s+(.+)$/gm, 'h4. $1')
+        .replace(/^###\s+(.+)$/gm, 'h3. $1')
+        .replace(/^##\s+(.+)$/gm, 'h2. $1')
+        .replace(/^#\s+(.+)$/gm, 'h1. $1')
+        .replace(/^\s*-\s+/gm, '* ')
+        .replace(/\*\*([^*\n]+)\*\*/g, '*$1*')
+        .replace(/`([^`\n]+)`/g, '{{$1}}')
+        .replace(/\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g, '[$1|$2]');
+    return text.trim();
+}
+
+function readJiraComment(params, workingDir, storyKey) {
+    var jiraComment = readOutputFile('tracker_comment.md', workingDir, storyKey);
+    if (jiraComment) return jiraComment;
+
+    jiraComment = readOutputFile('comment.md', workingDir, storyKey);
+    if (jiraComment) return jiraComment;
+
+    jiraComment = readOutputFile('jira_comment.md', workingDir, storyKey);
+    if (jiraComment) return jiraComment;
+
+    return markdownToJiraWiki(params.response || readOutputFile('response.md', workingDir, storyKey) || '');
+}
+
+function runInRepo(command, workingDir) {
+    var args = { command: command };
+    if (workingDir) args.workingDirectory = workingDir;
+    return cli_execute_command(args);
+}
+
+function performGitOperations(branchName, commitMessage, workingDir, testFilesPath) {
+    var addPath = testFilesPath || 'testing/';
+    var inspectPath = addPath.replace(/\/$/, '') || '.';
+    try {
+        try {
+            var lsOutput = runInRepo('git status --short -- ' + inspectPath, workingDir) || '';
+            console.log('Git status for ' + inspectPath + ':', cleanCommandOutput(lsOutput) || '(empty)');
+        } catch (e) {
+            console.warn('Could not list ' + inspectPath + ':', e);
+        }
+
+        console.log('Staging test path:', addPath);
+        runInRepo('git add ' + addPath, workingDir);
+
+        var stagedOutput = cleanCommandOutput(runInRepo('git diff --cached --stat', workingDir) || '');
+        console.log('Staged changes:', stagedOutput || '(none)');
+
+        if (!stagedOutput || !stagedOutput.trim()) {
+            console.warn('No new staged changes in ' + addPath + ' (files may already exist on branch)');
+            var remoteBranchCheck = cleanCommandOutput(
+                runInRepo('git ls-remote --heads origin ' + branchName, workingDir) || ''
+            );
+            if (!remoteBranchCheck.trim()) {
+                console.log('No remote branch found, pushing current branch state...');
+                try {
+                    runInRepo('git push -u origin ' + branchName, workingDir);
+                } catch (pushErr) {
+                    console.warn('Failed to push branch:', pushErr);
+                    return { success: false, error: 'No test files were written and could not push branch' };
+                }
+            } else {
+                console.log('Branch exists on remote — pushing current branch state');
+                try {
+                    runInRepo('git push -u origin ' + branchName, workingDir);
+                } catch (pushErr) {
+                    console.log('Normal push failed, retrying with --force-with-lease...');
+                    try {
+                        runInRepo('git push -u origin ' + branchName + ' --force-with-lease', workingDir);
+                    } catch (forcePushErr) {
+                        console.warn('Failed to publish synced existing branch:', forcePushErr);
+                        return { success: false, error: 'No test files were written and the synced branch could not be pushed' };
+                    }
+                }
+            }
+            return { success: true, branchName: branchName, noNewCommit: true };
+        }
+
+        console.log('Committing...');
+        runInRepo('git commit -m "' + commitMessage.replace(/"/g, '\\"') + '"', workingDir);
+
+        console.log('Pushing to remote...');
+        try {
+            runInRepo('git push -u origin ' + branchName, workingDir);
+        } catch (e) {
+            console.log('Normal push failed, force pushing...');
+            runInRepo('git push -u origin ' + branchName + ' --force', workingDir);
+        }
+
+        const remoteBranch = cleanCommandOutput(
+            runInRepo('git ls-remote --heads origin ' + branchName, workingDir) || ''
+        );
+        if (!remoteBranch.trim()) {
+            throw new Error('Branch not found on remote after push');
+        }
+
+        console.log('✅ Git operations completed');
+        return { success: true, branchName: branchName };
+
+    } catch (error) {
+        console.error('Git operations failed:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+function createPullRequest(title, branchName, baseBranch, workingDir, scm) {
+    console.log('Creating Pull Request...');
+    return prHelper.createPullRequest({
+        title: title,
+        branchName: branchName,
+        baseBranch: baseBranch,
+        workingDir: workingDir,
+        scm: scm,
+        bodyFileCandidates: ['outputs/pr_body.md', 'outputs/response.md'],
+        defaultBody: 'Automated story test automation changes.',
+        runCommand: runInRepo,
+        readFile: readFile
+    });
+}
+
+function getFailedReasonField(config) {
+    return (config.jira && config.jira.fields && config.jira.fields.failedReason)
+        || JIRA_FIELDS.FAILED_REASON
+        || 'Failed Reason';
+}
+
+function attachFailedDescription(tcKey, filePath) {
+    try {
+        if (!filePath) return null;
+        var name = filePath.split('/').pop();
+        jira_attach_file_to_ticket({
+            ticketKey: tcKey,
+            name: name,
+            filePath: filePath,
+            contentType: 'text/markdown'
+        });
+        console.log('✅ Attached failed description to', tcKey, ':', name);
+        return name;
+    } catch (e) {
+        console.warn('Failed to attach failed description to', tcKey, ':', e);
+        return null;
+    }
+}
+
+function updateFailedReasonField(tcKey, attachmentName, failureSummary, fieldName) {
+    try {
+        var value = 'h3. Failure Summary\n\n' + (failureSummary || 'See attached file for full failure details.') + '\n\n';
+        if (attachmentName) {
+            value += '*Attachment*: [^' + attachmentName + ']\n';
+        }
+        jira_update_field({ key: tcKey, field: fieldName, value: value });
+        console.log('✅ Updated Failed Reason field for', tcKey);
+    } catch (e) {
+        console.warn('Failed to update Failed Reason field for', tcKey, ':', e);
+    }
+}
+
+function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
+    try {
+        var targetStatus = status === 'passed' ? STATUSES.IN_REVIEW_PASSED : STATUSES.IN_REVIEW_FAILED;
+        jira_move_to_status({ key: tcKey, statusName: targetStatus });
+        console.log('✅ Moved', tcKey, 'to', targetStatus);
+
+        if (status === 'failed') {
+            var result = readResultJson(workingDir, storyKey);
+            var resultItem = null;
+            if (result && result.results) {
+                resultItem = result.results.find(function(r) { return r.testCaseKey === tcKey; });
+            }
+            var filePath = resultItem && resultItem.failedDescriptionFile
+                ? resultItem.failedDescriptionFile
+                : 'outputs/failed_description_' + tcKey + '.md';
+            var attachmentName = attachFailedDescription(tcKey, filePath);
+            updateFailedReasonField(tcKey, attachmentName, resultItem ? resultItem.failureSummary : '', getFailedReasonField(config));
+        }
+    } catch (e) {
+        console.warn('Failed to update Test Case', tcKey, ':', e);
+    }
+}
+
+function autoStartStoryTestReview(storyKey, config, customParams, noCodeChanges) {
+    if (noCodeChanges) {
+        console.log('ℹ️ autoStartReview: skipped — no test code changes to review');
+        return false;
+    }
+    if (!customParams || !customParams.autoStartReview || !customParams.autoStartReviewConfigFile) {
+        return false;
+    }
+    try {
+        return autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: storyKey,
+            customParams: customParams,
+            config: config,
+            configFile: customParams.autoStartReviewConfigFile,
+            label: 'pr_story_test_automation_review',
+            stripKeys: ['removeLabel', 'autoStartReview', 'autoStartReviewConfigFile']
+        });
+    } catch (e) {
+        console.warn('⚠️ autoStartReview trigger failed:', e.message || e);
+        return false;
+    }
+}
+
+function removeAutomationLabels(storyKey, params) {
+    try {
+        const wipLabel = params.metadata && params.metadata.contextId
+            ? params.metadata.contextId + '_wip'
+            : 'story_test_automation_wip';
+        jira_remove_label({ key: storyKey, label: wipLabel });
+    } catch (e) {}
+
+    try {
+        const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
+        if (smTriggerLabel) {
+            jira_remove_label({ key: storyKey, label: smTriggerLabel });
+            console.log('✅ Removed SM trigger label:', smTriggerLabel);
+        }
+    } catch (e) {}
+}
+
+function action(params) {
+    try {
+        const storyKey = params.ticket.key;
+        const storySummary = params.ticket.fields ? params.ticket.fields.summary : storyKey;
+        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var customParams = (params.jobParams || params).customParams || {};
+        var scm = configLoader.createScm(config);
+        var workingDir = config.workingDir || null;
+        var testFilesPath = customParams.testFilesGlob || 'testing/';
+        const jiraComment = readJiraComment(params, workingDir, storyKey);
+
+        console.log('=== Processing story test automation results for', storyKey, '===');
+
+        // Step 1: Read structured result
+        const result = readResultJson(workingDir, storyKey);
+        if (!result) {
+            var commentMsg = 'h3. ⚠️ Story Test Automation Error\n\nCLI exited without producing result JSON. The Story will stay in Ready For Testing so SM can retry.';
+            jira_post_comment({ key: storyKey, comment: commentMsg });
+            removeAutomationLabels(storyKey, params);
+            return { success: false, error: 'No story test result JSON found' };
+        }
+
+        const overall = (result.overall || '').toLowerCase();
+        const blockedByHuman = overall === 'blocked_by_human';
+
+        // Step 2: Configure git author
+        try {
+            runInRepo('git config user.name "' + config.git.authorName + '"', workingDir);
+            runInRepo('git config user.email "' + config.git.authorEmail + '"', workingDir);
+        } catch (e) {
+            console.warn('Failed to configure git author:', e);
+        }
+
+        // Step 3: Read current branch
+        var rawBranch = runInRepo('git branch --show-current', workingDir) || '';
+        const branchName = cleanCommandOutput(rawBranch);
+        console.log('Cleaned branch name:', JSON.stringify(branchName));
+
+        // Step 4: Commit + push + create PR
+        let prUrl = null;
+        let noCodeChanges = false;
+        if (branchName) {
+            const commitMessage = configLoader.formatTemplate(config.formats.commitMessage.testAutomation, {ticketKey: storyKey, ticketSummary: storySummary});
+            const gitResult = performGitOperations(branchName, commitMessage, workingDir, testFilesPath);
+
+            if (gitResult.success && !gitResult.noNewCommit) {
+                const prTitle = configLoader.formatTemplate(config.formats.prTitle.testAutomation, {ticketKey: storyKey, ticketSummary: storySummary});
+                const prResult = createPullRequest(prTitle, branchName, config.git.baseBranch, workingDir, scm);
+                prUrl = prResult.prUrl;
+                if (!prResult.success || !prUrl) {
+                    console.error('PR creation failed');
+                    jira_post_comment({ key: storyKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.' });
+                    removeAutomationLabels(storyKey, params);
+                    return { success: false, error: 'PR creation failed' };
+                }
+            } else if (gitResult.noNewCommit) {
+                noCodeChanges = true;
+                console.log('ℹ️ No test code changes — skipping PR review, moving Story directly');
+            } else {
+                console.warn('Git operations failed:', gitResult.error);
+                jira_post_comment({ key: storyKey, comment: 'h3. ⚠️ Git Operations Failed\n\n' + gitResult.error });
+                removeAutomationLabels(storyKey, params);
+                return { success: false, error: 'Git operations failed: ' + gitResult.error };
+            }
+        }
+
+        // Step 5: Post Story Jira comment
+        try {
+            let comment = jiraComment || '';
+            if (prUrl) {
+                comment += '\n\n*Story Test Branch PR*: ' + prUrl;
+            }
+            if (noCodeChanges) {
+                comment += '\n\nℹ️ _Test code unchanged from previous run._';
+            }
+            if (comment) {
+                jira_post_comment({ key: storyKey, comment: comment });
+                console.log('✅ Posted story test result comment to Jira');
+            }
+        } catch (e) {
+            console.warn('Failed to post Jira comment:', e);
+        }
+
+        // Step 6: Handle blocked_by_human
+        if (blockedByHuman) {
+            var blockedComment = 'h3. 🚫 Story Test Automation Blocked — Awaiting Human Setup\n\n' +
+                (result.blockedReason || 'Missing credentials or test data.') + '\n\n' +
+                'Once setup is complete, move this Story back to *Ready For Testing* to trigger re-run.';
+            try {
+                jira_post_comment({ key: storyKey, comment: blockedComment });
+                jira_move_to_status({ key: storyKey, statusName: STATUSES.BLOCKED });
+                console.log('✅ Blocked — moved', storyKey, 'to', STATUSES.BLOCKED);
+            } catch (e) {
+                console.warn('Failed to handle blocked story:', e);
+            }
+            removeAutomationLabels(storyKey, params);
+            return { success: true, status: 'blocked_by_human', storyKey: storyKey };
+        }
+
+        // Step 7: Update per-Test Case statuses
+        if (result.results && result.results.length > 0) {
+            result.results.forEach(function(item) {
+                if (item.status === 'passed' || item.status === 'failed') {
+                    updateTestCaseStatus(item.testCaseKey, item.status, workingDir, storyKey, config);
+                } else {
+                    console.log('Skipping status update for', item.testCaseKey, '— status:', item.status);
+                }
+            });
+        }
+
+        // Step 8: Move Story to In Testing
+        try {
+            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+        } catch (e) {
+            console.warn('Failed to move Story to In Testing:', e);
+        }
+
+        // Step 9: Trigger review
+        if (!blockedByHuman) {
+            if (!autoStartStoryTestReview(storyKey, config, customParams, noCodeChanges)) {
+                autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+            }
+        }
+
+        // Step 10: Labels cleanup
+        removeAutomationLabels(storyKey, params);
+        try {
+            jira_add_label({ key: storyKey, label: LABELS.AI_TEST_AUTOMATION });
+        } catch (e) {
+            console.warn('Failed to add ai_test_automation label:', e);
+        }
+
+        // Step 11: Token usage comments
+        try {
+            tokenUsageComment.postTokenUsageComments(storyKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return {
+            success: true,
+            status: overall,
+            storyKey: storyKey,
+            prUrl: prUrl
+        };
+
+    } catch (error) {
+        console.error('❌ Error in postStoryTestAutomationResults:', error);
+        try {
+            jira_post_comment({
+                key: params.ticket.key,
+                comment: 'h3. ❌ Story Test Automation Error\n\n{code}' + error.toString() + '{code}'
+            });
+        } catch (e) {}
+        removeAutomationLabels(params.ticket.key, params);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/postStoryTestAutomationReview.js
+++ b/js/postStoryTestAutomationReview.js
@@ -1,0 +1,290 @@
+/**
+ * Post Story Test Automation Review Comments Action
+ * Handles the bulk review result for a Story PR.
+ * - APPROVED → add pr_approved label, trigger story_test_automation_merge
+ * - REQUEST_CHANGES / BLOCK → move Story to In Rework, trigger story_test_automation_rework
+ */
+
+const { STATUSES, LABELS } = require('./config.js');
+const gh = require('./common/githubHelpers.js');
+const autoStart = require('./common/autoStart.js');
+const configLoader = require('./configLoader.js');
+const outputFiles = require('./common/outputFiles.js');
+const tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function readFile(path) {
+    return outputFiles.readOutputFile(path, {});
+}
+
+function readReviewJson(storyKey, workingDir) {
+    try {
+        const raw = outputFiles.readOutputFile('pr_review.json', {
+            ticketKey: storyKey,
+            workingDir: workingDir
+        });
+        if (!raw) return null;
+        return JSON.parse(raw);
+    } catch (e) {
+        console.error('Failed to parse pr_review.json:', e);
+        return null;
+    }
+}
+
+function getPRNumber(storyKey, repoInfo) {
+    let prNumber = null;
+    let prUrl = null;
+    try {
+        const prInfo = readFile('input/' + storyKey + '/pr_info.md');
+        if (prInfo) {
+            const numMatch = prInfo.match(/\*\*PR #\*\*:\s*(\d+)/);
+            const urlMatch = prInfo.match(/\*\*URL\*\*:\s*(https:\/\/[^\s]+)/);
+            if (numMatch) prNumber = parseInt(numMatch[1], 10);
+            if (urlMatch) prUrl = urlMatch[1];
+        }
+    } catch (e) {}
+
+    if (!prNumber && repoInfo) {
+        const branchName = 'test/' + storyKey;
+        try {
+            const openPRs = github_list_prs({ workspace: repoInfo.owner, repository: repoInfo.repo, state: 'open' });
+            const openMatch = openPRs.filter(function(pr) {
+                return pr.head && pr.head.ref && pr.head.ref === branchName;
+            });
+            if (openMatch.length > 0) {
+                prNumber = openMatch[0].number;
+                prUrl = openMatch[0].html_url;
+            }
+        } catch (e) {
+            console.warn('Failed to find test PR by branch:', e);
+        }
+    }
+    return { prNumber: prNumber, prUrl: prUrl };
+}
+
+function resolveCustomParams(params, config) {
+    var merged = {};
+    var patch = configLoader.resolveInstructions('pr_story_test_automation_review', null, config).jobParamPatch;
+    if (patch && patch.customParams) {
+        Object.assign(merged, patch.customParams);
+    }
+    Object.assign(merged,
+        (params.jobParams && params.jobParams.customParams) || params.customParams || {}
+    );
+    return merged;
+}
+
+function postGeneralComment(repoInfo, prNumber, generalComment) {
+    try {
+        const text = readFile(generalComment);
+        if (text) {
+            github_add_pr_comment({
+                workspace: repoInfo.owner,
+                repository: repoInfo.repo,
+                pullRequestId: String(prNumber),
+                text: text
+            });
+            console.log('✅ Posted general review comment to PR');
+        }
+    } catch (e) {
+        console.warn('Failed to post general comment:', e);
+    }
+}
+
+function postInlineComments(repoInfo, prNumber, inlineComments) {
+    if (!inlineComments || inlineComments.length === 0) return;
+    // Reuse the same diff-aware posting logic from postTestReviewComments is ideal,
+    // but to keep this file self-contained we fall back to PR comments.
+    inlineComments.forEach(function(ic) {
+        try {
+            const filePath = ic.path || ic.file;
+            const body = ic.body || readFile(ic.comment);
+            if (!body || !filePath) return;
+            const lineRef = filePath + (ic.line ? ':' + ic.line : '');
+            github_add_pr_comment({
+                workspace: repoInfo.owner,
+                repository: repoInfo.repo,
+                pullRequestId: String(prNumber),
+                text: '📍 **`' + lineRef + '`**\n\n' + body
+            });
+            console.log('✅ Posted fallback PR comment for', lineRef);
+        } catch (e) {
+            console.warn('Failed to post inline comment:', e);
+        }
+    });
+}
+
+function triggerMerge(storyKey, config, customParams) {
+    if (!customParams || !customParams.autoStartMerge || !customParams.autoStartMergeConfigFile) {
+        return false;
+    }
+    try {
+        return autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: storyKey,
+            customParams: customParams,
+            config: config,
+            configFile: customParams.autoStartMergeConfigFile,
+            label: 'story_test_automation_merge',
+            stripKeys: ['removeLabel', 'autoStartMerge', 'autoStartMergeConfigFile']
+        });
+    } catch (e) {
+        console.warn('⚠️ autoStartMerge trigger failed:', e.message || e);
+        return false;
+    }
+}
+
+function triggerRework(storyKey, config, customParams) {
+    if (!customParams || !customParams.autoStartRework || !customParams.autoStartReworkConfigFile) {
+        return false;
+    }
+    try {
+        return autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: storyKey,
+            customParams: customParams,
+            config: config,
+            configFile: customParams.autoStartReworkConfigFile,
+            label: 'story_test_automation_rework',
+            stripKeys: ['removeLabel', 'autoStartRework', 'autoStartReworkConfigFile']
+        });
+    } catch (e) {
+        console.warn('⚠️ autoStartRework trigger failed:', e.message || e);
+        return false;
+    }
+}
+
+function action(params) {
+    try {
+        const storyKey = params.ticket.key;
+        const config = configLoader.loadProjectConfig(params.jobParams || params);
+        const customParams = resolveCustomParams(params, config);
+        const workingDir = config.workingDir || null;
+
+        console.log('=== Processing story test automation review for', storyKey, '===');
+
+        const reviewData = readReviewJson(storyKey, workingDir);
+        if (!reviewData) {
+            jira_post_comment({
+                key: storyKey,
+                comment: 'h3. ⚠️ Story Test Review Error\n\nCould not read pr_review.json. Removed SM trigger label so SM can retry.'
+            });
+            try {
+                const smTriggerLabel = customParams.removeLabel || 'sm_story_test_review_triggered';
+                jira_remove_label({ key: storyKey, label: smTriggerLabel });
+            } catch (e) {}
+            try {
+                const wipLabel = params.metadata && params.metadata.contextId
+                    ? params.metadata.contextId + '_wip'
+                    : 'pr_story_test_automation_review_wip';
+                jira_remove_label({ key: storyKey, label: wipLabel });
+            } catch (e) {}
+            return { success: false, error: 'No review data found' };
+        }
+
+        const isApproved = (reviewData.recommendation || '').replace(/^APPROVED$/, 'APPROVE') === 'APPROVE';
+        console.log('Review recommendation:', reviewData.recommendation);
+
+        const repoInfo = gh.getGitHubRepoInfo();
+        const { prNumber, prUrl } = getPRNumber(storyKey, repoInfo);
+
+        if (prNumber && repoInfo) {
+            if (reviewData.generalComment) {
+                postGeneralComment(repoInfo, prNumber, reviewData.generalComment);
+            }
+            if (reviewData.inlineComments && reviewData.inlineComments.length > 0) {
+                postInlineComments(repoInfo, prNumber, reviewData.inlineComments);
+            }
+
+            if (isApproved) {
+                try {
+                    github_add_pr_label({
+                        workspace: repoInfo.owner,
+                        repository: repoInfo.repo,
+                        pullRequestId: String(prNumber),
+                        label: LABELS.PR_APPROVED
+                    });
+                    console.log('✅ Added pr_approved label to GitHub PR');
+                } catch (e) {
+                    console.warn('Failed to add pr_approved to GitHub PR:', e);
+                }
+                try {
+                    jira_add_label({ key: storyKey, label: LABELS.PR_APPROVED });
+                    console.log('✅ Added pr_approved label to Jira Story');
+                } catch (e) {
+                    console.warn('Failed to add pr_approved to Jira Story:', e);
+                }
+            }
+        }
+
+        if (params.response) {
+            try {
+                jira_post_comment({ key: storyKey, comment: params.response });
+            } catch (e) {
+                console.warn('Failed to post Jira review comment:', e);
+            }
+        }
+
+        if (isApproved) {
+            console.log('✅ Story PR approved — triggering merge agent');
+            if (!triggerMerge(storyKey, config, customParams)) {
+                autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+            }
+        } else {
+            console.log('📝 Changes requested on story PR — moving Story to In Rework');
+            try {
+                jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+                console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_REWORK);
+            } catch (e) {
+                console.warn('Failed to move Story to In Rework:', e);
+            }
+            if (!triggerRework(storyKey, config, customParams)) {
+                autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+            }
+        }
+
+        // Labels cleanup
+        try {
+            jira_add_label({ key: storyKey, label: LABELS.AI_PR_REVIEWED });
+        } catch (e) {}
+
+        const wipLabel = params.metadata && params.metadata.contextId
+            ? params.metadata.contextId + '_wip'
+            : 'pr_story_test_automation_review_wip';
+        try {
+            jira_remove_label({ key: storyKey, label: wipLabel });
+        } catch (e) {}
+
+        try {
+            jira_remove_label({ key: storyKey, label: 'sm_story_test_review_triggered' });
+        } catch (e) {}
+
+        try {
+            tokenUsageComment.postTokenUsageComments(storyKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return {
+            success: true,
+            recommendation: reviewData.recommendation,
+            storyKey: storyKey,
+            prUrl: prUrl
+        };
+
+    } catch (error) {
+        console.error('❌ Error in postStoryTestAutomationReview:', error);
+        try {
+            const storyKey = params.ticket ? params.ticket.key : null;
+            if (storyKey) {
+                jira_remove_label({ key: storyKey, label: 'sm_story_test_review_triggered' });
+                jira_post_comment({
+                    key: storyKey,
+                    comment: 'h3. ❌ Story Test Review Error\n\n{code}' + error.toString() + '{code}'
+                });
+            }
+        } catch (e) {}
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/preCliStoryTestAutomationSetup.js
+++ b/js/preCliStoryTestAutomationSetup.js
@@ -1,0 +1,258 @@
+/**
+ * Pre-CLI Story Test Automation Setup Action
+ * 1. Fetches all linked Test Cases for the Story.
+ * 2. Writes input/{STORY_KEY}/linked_test_cases.json and .md.
+ * 3. Checks out test/{STORY_KEY} branch aligned with main.
+ */
+
+var configLoader = require('./configLoader.js');
+var prHelper = require('./common/pullRequest.js');
+const { STATUSES } = require('./config.js');
+
+function cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function(line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function runGit(command, workingDir) {
+    var args = { command: command };
+    if (workingDir) args.workingDirectory = workingDir;
+    return cli_execute_command(args);
+}
+
+function writeBranchConflictGuidance(storyKey, branchName, baseBranch, details) {
+    try {
+        file_write({
+            path: 'input/' + storyKey + '/merge_conflicts.md',
+            content: '# Branch Conflict Guidance\n\n' +
+                'Branch `' + branchName + '` has test automation work that is not already merged into `origin/' + baseBranch + '`, ' +
+                'and `origin/' + baseBranch + '` is not an ancestor of this branch.\n\n' +
+                'Before editing tests, sync the branch deliberately with `origin/' + baseBranch + '`. ' +
+                'In most cases, prefer `origin/' + baseBranch + '` for repository setup, generated workflow/config files, ' +
+                'and shared infrastructure, then re-apply only the ticket-specific test automation that is still relevant.\n\n' +
+                'Do not discard test files that are still needed for this ticket. Do not keep stale bootstrap/setup files just because they exist on the old branch.\n\n' +
+                'Details:\n\n```\n' + (details || '(not available)') + '\n```\n'
+        });
+    } catch (e) {
+        console.warn('Could not write branch conflict guidance:', e);
+    }
+}
+
+function branchHasUniquePatches(baseBranch, workingDir) {
+    try {
+        var cherry = cleanCommandOutput(runGit('git cherry origin/' + baseBranch + ' HEAD', workingDir) || '');
+        if (!cherry.trim()) return false;
+        var lines = cherry.split('\n');
+        for (var i = 0; i < lines.length; i++) {
+            if (lines[i].trim().indexOf('+') === 0) return true;
+        }
+        return false;
+    } catch (e) {
+        console.warn('Could not inspect unique test branch patches:', e);
+        return true;
+    }
+}
+
+function isAncestorRef(ancestor, descendant, workingDir) {
+    try {
+        var output = cleanCommandOutput(
+            runGit('git rev-list -1 ' + ancestor + ' --not ' + descendant, workingDir) || ''
+        );
+        return output.trim() === '';
+    } catch (e) {
+        console.warn('Could not inspect branch ancestry for ' + ancestor + ' -> ' + descendant + ':', e);
+        return false;
+    }
+}
+
+function findMergeBase(left, right, workingDir) {
+    try {
+        return cleanCommandOutput(runGit('bash agents/scripts/git-merge-base-or-empty.sh ' + left + ' ' + right, workingDir) || '');
+    } catch (e) {
+        return '';
+    }
+}
+
+function alignBranchWithBase(storyKey, branchName, baseBranch, workingDir) {
+    if (isAncestorRef('HEAD', 'origin/' + baseBranch, workingDir)) {
+        console.log('Test branch changes are already included in origin/' + baseBranch + ', resetting local branch:', branchName);
+        runGit('git reset --hard origin/' + baseBranch, workingDir);
+        return;
+    }
+
+    if (!branchHasUniquePatches(baseBranch, workingDir)) {
+        console.log('Test branch has no unique patches versus origin/' + baseBranch + ', resetting local branch:', branchName);
+        runGit('git reset --hard origin/' + baseBranch, workingDir);
+        return;
+    }
+
+    if (isAncestorRef('origin/' + baseBranch, 'HEAD', workingDir)) {
+        console.log('Test branch already contains origin/' + baseBranch + ':', branchName);
+        return;
+    }
+
+    console.warn('Test branch does not contain origin/' + baseBranch + ':', branchName);
+    var details = '';
+    try {
+        var mergeBase = findMergeBase('HEAD', 'origin/' + baseBranch, workingDir);
+        if (mergeBase) {
+            details = cleanCommandOutput(runGit('git merge-tree ' + mergeBase + ' HEAD origin/' + baseBranch, workingDir) || '');
+        } else {
+            details = 'No merge base found between HEAD and origin/' + baseBranch + '. The branch history may be unrelated to the current base or too shallow.';
+        }
+    } catch (mergeTreeError) {
+        details = mergeTreeError && mergeTreeError.toString ? mergeTreeError.toString() : String(mergeTreeError);
+    }
+    writeBranchConflictGuidance(storyKey, branchName, baseBranch, details.substring(0, 6000));
+    console.warn('Keeping divergent test branch ' + branchName + '; conflict guidance written for the agent.');
+}
+
+function checkoutBranch(storyKey, config) {
+    var branchName = configLoader.formatBranchName(config.git.branchPrefix.test, storyKey);
+    var workingDir = config.workingDir || null;
+    console.log('Setting up branch:', branchName);
+
+    try {
+        runGit('git config user.name "' + config.git.authorName + '"', workingDir);
+        runGit('git config user.email "' + config.git.authorEmail + '"', workingDir);
+    } catch (e) {
+        console.warn('Failed to configure git author:', e);
+    }
+
+    try {
+        runGit(prHelper.buildOriginFetchCommand('--prune'), workingDir);
+    } catch (e) {
+        console.warn('Could not fetch remote branches:', e);
+    }
+
+    var localBranches = cleanCommandOutput(
+        runGit('git branch --list "' + branchName + '"', workingDir) || ''
+    );
+
+    if (localBranches.trim()) {
+        console.log('Branch exists locally, aligning with base:', branchName);
+        runGit('git checkout ' + branchName, workingDir);
+        alignBranchWithBase(storyKey, branchName, config.git.baseBranch, workingDir);
+    } else {
+        var remoteBranches = cleanCommandOutput(
+            runGit('git ls-remote --heads origin ' + branchName, workingDir) || ''
+        );
+
+        if (remoteBranches.trim()) {
+            console.log('Branch exists on remote, checking out and aligning with base:', branchName);
+            runGit('git checkout -b ' + branchName + ' origin/' + branchName, workingDir);
+            alignBranchWithBase(storyKey, branchName, config.git.baseBranch, workingDir);
+        } else {
+            console.log('Creating new branch from', config.git.baseBranch + ':', branchName);
+            runGit('git checkout ' + config.git.baseBranch, workingDir);
+            runGit('git pull origin ' + config.git.baseBranch, workingDir);
+            runGit('git checkout -b ' + branchName, workingDir);
+        }
+    }
+
+    console.log('✅ Branch ready:', branchName);
+}
+
+function fetchLinkedTestCases(storyKey, testCaseType) {
+    var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = "' + testCaseType + '"';
+    console.log('Fetching linked Test Cases with JQL:', jql);
+    try {
+        var results = jira_search_by_jql({ jql: jql, maxResults: 100 });
+        return Array.isArray(results) ? results : [];
+    } catch (e) {
+        console.warn('Failed to fetch linked Test Cases:', e);
+        return [];
+    }
+}
+
+function renderTestCase(tc) {
+    var fields = tc.fields || {};
+    var lines = [];
+    lines.push('## ' + tc.key + ' — ' + (fields.summary || '(no summary)'));
+    lines.push('');
+    lines.push('- **Status**: ' + (fields.status && fields.status.name ? fields.status.name : 'Unknown'));
+    lines.push('- **Priority**: ' + (fields.priority && fields.priority.name ? fields.priority.name : 'Unknown'));
+    lines.push('');
+    lines.push('### Description');
+    lines.push(fields.description || '(no description)');
+    lines.push('');
+    if (fields['Acceptance Criteria']) {
+        lines.push('### Acceptance Criteria');
+        lines.push(fields['Acceptance Criteria']);
+        lines.push('');
+    }
+    return lines.join('\n');
+}
+
+function writeLinkedTestCases(storyKey, testCases) {
+    var inputDir = 'input/' + storyKey;
+    try {
+        file_write({
+            path: inputDir + '/linked_test_cases.json',
+            content: JSON.stringify({ storyKey: storyKey, testCases: testCases }, null, 2)
+        });
+    } catch (e) {
+        console.warn('Could not write linked_test_cases.json:', e);
+    }
+
+    var md = '# Linked Test Cases for ' + storyKey + '\n\n';
+    md += 'Total: ' + testCases.length + '\n\n';
+    testCases.forEach(function(tc) {
+        md += renderTestCase(tc) + '\n';
+    });
+
+    try {
+        file_write({
+            path: inputDir + '/linked_test_cases.md',
+            content: md
+        });
+    } catch (e) {
+        console.warn('Could not write linked_test_cases.md:', e);
+    }
+}
+
+function action(params) {
+    try {
+        var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
+        var folder = actualParams.inputFolderPath;
+        var storyKey = folder.split('/').pop();
+        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var testCaseType = projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE
+            ? projectConfig.jira.issueTypes.TEST_CASE
+            : 'Test Case';
+
+        console.log('=== Story test automation setup for:', storyKey, '===');
+
+        // Step 1: Fetch linked test cases
+        var testCases = fetchLinkedTestCases(storyKey, testCaseType);
+        console.log('Found', testCases.length, 'linked Test Case(s)');
+
+        if (testCases.length === 0) {
+            console.warn('No linked Test Cases found for Story', storyKey);
+        }
+
+        writeLinkedTestCases(storyKey, testCases);
+
+        // Step 2: Checkout test/{STORY_KEY} branch
+        try {
+            checkoutBranch(storyKey, config);
+        } catch (e) {
+            console.error('Branch checkout failed (non-fatal):', e);
+        }
+
+        console.log('✅ Story test automation setup complete for', storyKey);
+
+    } catch (error) {
+        console.error('❌ Error in preCliStoryTestAutomationSetup:', error);
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -1,0 +1,245 @@
+/**
+ * Story Test Automation Rework Action
+ * Applies review feedback to the Story test PR and re-triggers review.
+ */
+
+var configLoader = require('./configLoader.js');
+var autoStart = require('./common/autoStart.js');
+var prHelper = require('./common/pullRequest.js');
+const { STATUSES } = require('./config.js');
+var tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function(line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function readFile(path) {
+    try {
+        const content = file_read({ path: path });
+        return (content && content.trim()) ? content : null;
+    } catch (e) {
+        console.warn('Could not read file ' + path + ':', e);
+        return null;
+    }
+}
+
+function runInRepo(command, workingDir) {
+    var args = { command: command };
+    if (workingDir) args.workingDirectory = workingDir;
+    return cli_execute_command(args);
+}
+
+function commitAndPush(storyKey, config) {
+    var workingDir = config.workingDir || null;
+    var branchName = cleanCommandOutput(runInRepo('git branch --show-current', workingDir) || '');
+    if (!branchName) throw new Error('Could not determine current git branch');
+    if (branchName === 'main' || branchName === 'master') {
+        throw new Error('Refusing to commit rework directly to "' + branchName + '". Expected test/' + storyKey);
+    }
+
+    console.log('Current branch:', branchName);
+    runInRepo('git config user.name "' + config.git.authorName + '"', workingDir);
+    runInRepo('git config user.email "' + config.git.authorEmail + '"', workingDir);
+    runInRepo('git add testing/', workingDir);
+
+    var statusOutput = cleanCommandOutput(runInRepo('git diff --cached --stat', workingDir) || '');
+    if (statusOutput.trim()) {
+        var commitMsg = configLoader.formatTemplate(config.formats.commitMessage.testRework, {
+            ticketKey: storyKey,
+            result: 'address review comments'
+        });
+        runInRepo('git commit -m "' + commitMsg.replace(/"/g, '\\"') + '"', workingDir);
+        console.log('✅ Committed rework changes');
+    } else {
+        console.warn('No changes to commit in testing/ — pushing existing commits only');
+    }
+
+    try {
+        runInRepo('git push -u origin ' + branchName, workingDir);
+    } catch (e) {
+        console.log('Normal push failed, force pushing...');
+        runInRepo('git push -u origin ' + branchName + ' --force', workingDir);
+    }
+
+    var remoteCheck = cleanCommandOutput(runInRepo('git ls-remote --heads origin ' + branchName, workingDir) || '');
+    if (!remoteCheck.trim()) throw new Error('Branch not found on remote after push');
+    console.log('✅ Pushed to remote branch:', branchName);
+    return branchName;
+}
+
+function postThreadReplies(scm, pullRequestId) {
+    const repliesJson = readFile('outputs/review_replies.json');
+    if (!repliesJson) {
+        console.warn('outputs/review_replies.json not found — skipping thread replies');
+        return 0;
+    }
+    var data;
+    try {
+        data = JSON.parse(repliesJson);
+    } catch (e) {
+        console.warn('Failed to parse review_replies.json:', e);
+        return 0;
+    }
+    const replies = (data && data.replies) ? data.replies : [];
+    if (replies.length === 0) return 0;
+
+    var posted = 0;
+    replies.forEach(function(item) {
+        try {
+            scm.replyToThread(pullRequestId, {
+                rootCommentId: item.inReplyToId,
+                threadId: item.threadId || item.discussionId
+            }, item.reply || '✅ Addressed.');
+            posted++;
+        } catch (e) {
+            console.warn('Failed to reply to comment #' + item.inReplyToId + ':', e);
+        }
+        if (item.threadId) {
+            try {
+                scm.resolveThread(pullRequestId, { threadId: item.threadId });
+            } catch (e) {
+                console.warn('Failed to resolve thread', item.threadId + ':', e);
+            }
+        }
+    });
+    console.log('Posted ' + posted + '/' + replies.length + ' thread replies');
+    return posted;
+}
+
+function findStoryPR(scm, storyKey) {
+    try {
+        const branchName = 'test/' + storyKey;
+        const openPRs = scm.listPrs('open') || [];
+        return openPRs.find(function(pr) {
+            return pr.head && pr.head.ref && pr.head.ref === branchName;
+        }) || null;
+    } catch (e) {
+        console.error('Failed to find PR:', e);
+        return null;
+    }
+}
+
+function action(params) {
+    const actualParams = params.ticket ? params : (params.jobParams || params);
+    const storyKey = actualParams.ticket.key;
+    const config = configLoader.loadProjectConfig(params.jobParams || params);
+    const scm = configLoader.createScm(config);
+    const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+    const removeLabel = customParams.removeLabel;
+    const wipLabel = actualParams.metadata && actualParams.metadata.contextId
+        ? actualParams.metadata.contextId + '_wip'
+        : 'story_test_automation_rework_wip';
+
+    function releaseLock() {
+        try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+        if (removeLabel) {
+            try {
+                jira_remove_label({ key: storyKey, label: removeLabel });
+                console.log('✅ Removed SM label:', removeLabel);
+            } catch (e) {}
+        }
+    }
+
+    try {
+        const fixSummary = actualParams.response || '_(No fix summary)_';
+        console.log('=== Processing story test automation rework for', storyKey, '===');
+
+        // Step 1: Commit/push testing/
+        var branchName;
+        try {
+            branchName = commitAndPush(storyKey, config);
+        } catch (e) {
+            console.error('Git operations failed:', e);
+            jira_post_comment({
+                key: storyKey,
+                comment: 'h3. ❌ Story Test Rework Push Failed\n\n{code}' + e.toString() + '{code}'
+            });
+            releaseLock();
+            return { success: false, error: e.toString() };
+        }
+
+        // Step 2: Reply to review threads
+        var pr = findStoryPR(scm, storyKey);
+        if (pr) {
+            postThreadReplies(scm, pr.number);
+            try {
+                scm.addComment(pr.number, '## 🔧 Story Test Rework Complete — ' + storyKey + '\n\n' + fixSummary);
+            } catch (e) {
+                console.warn('Failed to post PR rework comment:', e);
+            }
+        }
+
+        // Step 3: Move Story back to In Testing
+        try {
+            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+        } catch (e) {
+            console.warn('Failed to move Story to In Testing:', e);
+        }
+
+        // Step 4: Post Jira comment
+        try {
+            var comment = 'h3. 🔧 Story Test Rework Completed\n\n';
+            comment += '*Branch*: {code}' + branchName + '{code}\n';
+            if (pr) comment += '*Pull Request*: ' + pr.html_url + '\n';
+            comment += '\n' + fixSummary;
+            jira_post_comment({ key: storyKey, comment: comment });
+        } catch (e) {
+            console.warn('Failed to post Jira comment:', e);
+        }
+
+        // Step 5: Trigger review
+        releaseLock();
+        var autoStarted = false;
+        if (customParams.autoStartReview && customParams.autoStartReviewConfigFile) {
+            try {
+                autoStarted = autoStart.triggerConfiguredWorkflowForTicket({
+                    ticketKey: storyKey,
+                    customParams: customParams,
+                    config: config,
+                    configFile: customParams.autoStartReviewConfigFile,
+                    label: 'pr_story_test_automation_review',
+                    stripKeys: ['removeLabel', 'autoStartReview', 'autoStartReviewConfigFile']
+                });
+            } catch (e) {
+                console.warn('⚠️ autoStartReview trigger failed:', e.message || e);
+            }
+        }
+        if (!autoStarted) {
+            autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+        }
+
+        try {
+            tokenUsageComment.postTokenUsageComments(storyKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return {
+            success: true,
+            storyKey: storyKey,
+            prUrl: pr ? pr.html_url : null
+        };
+
+    } catch (error) {
+        console.error('❌ Error in storyTestAutomationRework:', error);
+        try {
+            jira_post_comment({
+                key: storyKey,
+                comment: 'h3. ❌ Story Test Rework Error\n\n{code}' + error.toString() + '{code}'
+            });
+        } catch (e) {}
+        releaseLock();
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/triggerStoryTestAutomation.js
+++ b/js/triggerStoryTestAutomation.js
@@ -1,0 +1,69 @@
+/**
+ * Trigger Story Test Automation
+ * Post-action for test_cases_generator.
+ * Keeps the Story in Ready For Testing and immediately triggers story_test_automation.
+ */
+
+var autoStart = require('./common/autoStart.js');
+var tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function action(params) {
+    try {
+        const storyKey = params.ticket.key;
+        const config = params.jobParams && params.jobParams.config
+            ? params.jobParams.config
+            : (params.config || {});
+        const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+
+        console.log('=== Triggering story test automation for', storyKey, '===');
+
+        var triggered = false;
+        if (customParams.autoStartStoryTestAutomation && customParams.autoStartStoryTestAutomationConfigFile) {
+            triggered = autoStart.triggerConfiguredWorkflowForTicket({
+                ticketKey: storyKey,
+                customParams: customParams,
+                config: config,
+                configFile: customParams.autoStartStoryTestAutomationConfigFile,
+                label: 'story_test_automation',
+                stripKeys: [
+                    'removeLabel',
+                    'autoStartStoryTestAutomation',
+                    'autoStartStoryTestAutomationConfigFile'
+                ]
+            });
+        }
+
+        if (!triggered) {
+            console.log('Story test automation not triggered via autoStart; asking SM to re-evaluate.');
+            autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+        } else {
+            console.log('✅ Triggered story_test_automation for', storyKey);
+        }
+
+        // Remove the SM trigger label so test_cases_generator does not keep re-running
+        const smTriggerLabel = customParams.removeLabel || 'sm_test_cases_triggered';
+        try {
+            jira_remove_label({ key: storyKey, label: smTriggerLabel });
+            console.log('✅ Removed SM trigger label:', smTriggerLabel);
+        } catch (e) {
+            console.warn('Failed to remove SM trigger label:', e);
+        }
+
+        // Post token usage summary comments from the test-case generation run
+        try {
+            tokenUsageComment.postTokenUsageComments(storyKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return { success: true, triggered: triggered, storyKey: storyKey };
+
+    } catch (error) {
+        console.error('❌ Error in triggerStoryTestAutomation:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/pr_story_test_automation_review.json
+++ b/pr_story_test_automation_review.json
@@ -1,0 +1,35 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "pr_story_test_automation_review" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/prepareTestPRForReview.js",
+    "postJSAction": "agents/js/postStoryTestAutomationReview.js",
+    "customParams": {
+      "removeLabel": "sm_story_test_review_triggered"
+    },
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Engineer & Code Reviewer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/pr_test_automation_review/general_guidelines.md",
+      "./agents/instructions/pr_test_automation_review/output_rules.md",
+      "./agents/instructions/pr_test_automation_review/formatting_rules.md",
+      "./agents/instructions/pr_test_automation_review/few_shots.md",
+      "./agents/prompts/story_test_automation_review_prompt.md",
+      "./agents/instructions/common/dmtools_cli.md",
+      "./agents/prompts/bash_tools.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}

--- a/prompts/story_test_automation_prompt.md
+++ b/prompts/story_test_automation_prompt.md
@@ -1,0 +1,30 @@
+> Role: Senior QA Automation Engineer
+> Task: Bulk automate/run all Test Cases linked to a Story that is Ready For Testing.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md` — Story details, acceptance criteria, solution.
+- `input/{STORY_KEY}/linked_test_cases.md` — all linked Test Cases with key, summary, description, priority, and existing status.
+- `input/{STORY_KEY}/linked_test_cases.json` — machine-readable version of the above.
+- `testing/` — existing reusable components, frameworks, core helpers, and previously automated tests.
+
+## Task steps
+
+1. Run `codegraph context "{STORY_KEY} test automation existing tests and reusable helpers"` before grepping files.
+2. For each linked Test Case `{TC_KEY}`:
+   - Check `testing/tests/{TC_KEY}/`.
+   - If it exists, run the test and record the result.
+   - If it is missing, write a new automated test following the architecture rules.
+3. After running/writing, re-run any failed test at least once to confirm it is a real failure (not a flaky environment issue).
+4. Write `outputs/story_test_automation_result.json` with the exact schema from the output rules.
+5. Write `outputs/tracker_comment.md` summarizing the bulk run.
+6. For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md`.
+
+## Important rules
+
+- One Story = one branch `test/{STORY_KEY}` and one PR.
+- All test code lives under `testing/`.
+- Do NOT modify feature code.
+- Reuse existing helpers; do not duplicate infrastructure.
+- If credentials or test data are missing, stop and write `outputs/blocked.json`.
+- Each new `testing/tests/{TC_KEY}/` folder must contain `README.md` and `config.yaml`.

--- a/prompts/story_test_automation_review_prompt.md
+++ b/prompts/story_test_automation_review_prompt.md
@@ -1,0 +1,46 @@
+> Role: Senior QA Engineer & Code Reviewer
+> Task: Review the bulk test automation Pull Request for a Story.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md`
+- `input/{STORY_KEY}/linked_test_cases.md`
+- `input/{STORY_KEY}/pr_info.md`
+- `input/{STORY_KEY}/pr_diff.txt`
+- `input/{STORY_KEY}/pr_discussions.md`
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Review checklist
+
+1. Every linked Test Case has a corresponding automated test under `testing/tests/{TC_KEY}/`.
+2. Each test folder contains `README.md` and `config.yaml`.
+3. Tests use the correct layers: `tests/` → `components/` → `frameworks/` → `core/`.
+4. No raw Flutter locators or `WidgetTester` calls directly in ticket test files.
+5. Tests are deterministic, isolated, and include proper assertions and teardown.
+6. Tests match the Test Case description and acceptance criteria verbatim.
+7. No dead code, debug prints, or commented-out experiments.
+8. Shared helpers are reused; no unnecessary duplication.
+
+## Output format
+
+Write the same `outputs/pr_review.json` format used by `pr_test_automation_review`:
+
+```json
+{
+  "recommendation": "APPROVE|REQUEST_CHANGES|BLOCK",
+  "summary": "...",
+  "generalComment": "outputs/pr_review_general.md",
+  "inlineComments": [
+    {
+      "path": "testing/tests/TS-124/...",
+      "line": 42,
+      "body": "💡 **Suggestion**: ...",
+      "severity": "BLOCKING|IMPORTANT|SUGGESTION"
+    }
+  ]
+}
+```
+
+- APPROVE only when all blocking checks pass.
+- REQUEST_CHANGES for issues that can be fixed by the rework agent.
+- BLOCK only for fundamental misunderstandings of the Test Case.

--- a/prompts/story_test_automation_rework_prompt.md
+++ b/prompts/story_test_automation_rework_prompt.md
@@ -1,0 +1,26 @@
+> Role: Senior QA Automation Engineer
+> Task: Fix test code based on bulk review feedback for a Story.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md`
+- `input/{STORY_KEY}/linked_test_cases.md`
+- `input/{STORY_KEY}/pr_info.md`
+- `input/{STORY_KEY}/pr_discussions.md`
+- `outputs/review_replies.json` — review comments and required fixes
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Task steps
+
+1. Address every comment in `outputs/review_replies.json`.
+2. Make minimal, focused changes to `testing/` only.
+3. Re-run the affected tests to confirm they still pass.
+4. Update `outputs/story_test_automation_result.json` if any previously failed Test Case now passes.
+5. Write `outputs/tracker_comment.md` describing what was fixed.
+6. Do NOT change feature code or non-test files.
+
+## Output
+
+- Updated test code under `testing/tests/{TC_KEY}/`.
+- `outputs/story_test_automation_result.json` with fresh per-TC results.
+- `outputs/tracker_comment.md`.

--- a/sm.json
+++ b/sm.json
@@ -167,6 +167,14 @@
           "enabled": true
         },
         {
+          "description": "Ready For Testing Stories → automate linked test cases in bulk",
+          "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('Ready For Testing')",
+          "configFile": "agents/story_test_automation.json",
+          "skipIfLabel": "sm_story_test_automation_triggered",
+          "addLabel": "sm_story_test_automation_triggered",
+          "enabled": true
+        },
+        {
           "description": "In Testing Stories → check all TCs passed → Done",
           "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('In Testing')",
           "configFile": "agents/story_done_check.json",

--- a/snapshots/pr_story_test_automation_review.md
+++ b/snapshots/pr_story_test_automation_review.md
@@ -1,0 +1,348 @@
+# Agent Snapshot: `pr_story_test_automation_review`
+
+- **Context ID**: `pr_story_test_automation_review`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Engineer & Code Reviewer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/pr_test_automation_review/general_guidelines.md`
+
+```mermaid
+flowchart TD
+    START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
+    PROJ --> INPUT["Read PR context from input folder"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
+    EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
+    SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]
+    CORRECT --> ARCH["Verify architecture compliance: tests → components → frameworks → core"]
+    ARCH --> OOP["Verify OOP principles: single responsibility, dependency injection, interfaces from core/interfaces/"]
+    OOP --> QUALITY["Check code quality: no hardcoded secrets, proper setup/teardown, no duplicated logic"]
+    QUALITY --> MODERN["Check modern framework usage: explicit waits, typed service objects"]
+    MODERN --> DATA["Check test data self-sufficiency: generate → download → approve blocked_by_human only when genuinely required"]
+    DATA --> RESULT{Test result in PR description}
+    RESULT -->|PASSED| PASSED_REVIEW["Verify the PASSED result is meaningful — not a false positive"]
+    RESULT -->|FAILED| FAILED_REVIEW["Verify the test fails for the right reason — not a test code issue"]
+    PASSED_REVIEW --> OUTPUT[Write outputs: response.md, pr_review.json, pr_review_general.md, pr_review_comments/]
+    FAILED_REVIEW --> OUTPUT
+    OUTPUT --> END([End])
+```
+
+
+---
+
+### [6] `./agents/instructions/pr_test_automation_review/output_rules.md`
+
+```mermaid
+flowchart TD
+    O1["Write outputs/response.md — concise tracker-agnostic Markdown summary"]
+    O2["Write outputs/pr_review.json — structured data for GitHub PR review"]
+    O3["Write outputs/pr_review_general.md — brief general PR comment (1-2 paragraphs max)"]
+    O4["Write outputs/pr_review_comments/ — directory with individual inline comment files"]
+    O5["If pr_discussions.md present → include resolvedThreadIds in pr_review.json"]
+    O6["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup in response.md"]
+    O1 --> O2 --> O3 --> O4 --> O5 --> O6
+```
+
+
+---
+
+### [7] `./agents/instructions/pr_test_automation_review/formatting_rules.md`
+
+```mermaid
+flowchart TD
+    F1["outputs/response.md — tracker-agnostic Markdown, under 20 lines, bullet-focused"]
+    F2["Required sections: Summary, Correctness, Architecture, Code Quality, Framework Usage, Test Data, Recommendation"]
+    F3["outputs/pr_review.json — valid JSON with recommendation, summary, inlineComments, issueCounts"]
+    F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
+    F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
+    F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
+```
+
+
+---
+
+### [8] `./agents/instructions/pr_test_automation_review/few_shots.md`
+
+Example PR test automation review outputs — keep concise:
+
+### outputs/pr_review.json
+```json
+{
+  "recommendation": "BLOCK",
+  "summary": "Test uses hardcoded selectors and sleeps instead of explicit waits. Architecture violates layered design.",
+  "generalComment": "outputs/pr_review_general.md",
+  "inlineComments": [
+    {"path":"testing/tests/TEST-123/test_login.py","line":34,"body":"🚨 BLOCKING: Hardcoded selector — Use Page Object method login_page.username_field instead of raw page.locator('#user').","severity":"BLOCKING"},
+    {"path":"testing/tests/TEST-123/test_login.py","line":45,"body":"🚨 BLOCKING: time.sleep(5) — Replace with Playwright's expect(...).to_be_visible(timeout=5000).","severity":"BLOCKING"},
+    {"path":"testing/tests/TEST-123/test_login.py","line":12,"body":"⚠️ IMPORTANT: Missing config.yaml — Each test folder must include config.yaml with framework, platform, and dependencies.","severity":"IMPORTANT"},
+    {"path":"testing/components/pages/login_page.py","line":8,"body":"💡 SUGGESTION: Add type hints — Constructor parameters lack types. Add driver: IWebDriver and return types.","severity":"SUGGESTION"}
+  ],
+  "issueCounts": {"blocking":2,"important":1,"suggestions":1}
+}
+```
+
+### outputs/pr_review_general.md
+```markdown
+## Automated Test PR Review — BLOCK
+
+**Summary**: Test contains hardcoded selectors and time.sleep(), violating architecture and determinism rules. Missing config.yaml.
+
+**Next Steps**:
+1. Extract selectors into LoginPage Page Object
+2. Replace time.sleep() with explicit waits
+3. Add config.yaml with framework/platform/dependencies
+```
+
+
+---
+
+### [9] `./agents/prompts/story_test_automation_review_prompt.md`
+
+> Role: Senior QA Engineer & Code Reviewer
+> Task: Review the bulk test automation Pull Request for a Story.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md`
+- `input/{STORY_KEY}/linked_test_cases.md`
+- `input/{STORY_KEY}/pr_info.md`
+- `input/{STORY_KEY}/pr_diff.txt`
+- `input/{STORY_KEY}/pr_discussions.md`
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Review checklist
+
+1. Every linked Test Case has a corresponding automated test under `testing/tests/{TC_KEY}/`.
+2. Each test folder contains `README.md` and `config.yaml`.
+3. Tests use the correct layers: `tests/` → `components/` → `frameworks/` → `core/`.
+4. No raw Flutter locators or `WidgetTester` calls directly in ticket test files.
+5. Tests are deterministic, isolated, and include proper assertions and teardown.
+6. Tests match the Test Case description and acceptance criteria verbatim.
+7. No dead code, debug prints, or commented-out experiments.
+8. Shared helpers are reused; no unnecessary duplication.
+
+## Output format
+
+Write the same `outputs/pr_review.json` format used by `pr_test_automation_review`:
+
+```json
+{
+  "recommendation": "APPROVE|REQUEST_CHANGES|BLOCK",
+  "summary": "...",
+  "generalComment": "outputs/pr_review_general.md",
+  "inlineComments": [
+    {
+      "path": "testing/tests/TS-124/...",
+      "line": 42,
+      "body": "💡 **Suggestion**: ...",
+      "severity": "BLOCKING|IMPORTANT|SUGGESTION"
+    }
+  ]
+}
+```
+
+- APPROVE only when all blocking checks pass.
+- REQUEST_CHANGES for issues that can be fixed by the rework agent.
+- BLOCK only for fundamental misunderstandings of the Test Case.
+
+
+---
+
+### [10] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+### [11] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---

--- a/snapshots/story_test_automation.md
+++ b/snapshots/story_test_automation.md
@@ -1,0 +1,788 @@
+# Agent Snapshot: `story_test_automation`
+
+- **Context ID**: `story_test_automation`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Automation Engineer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/story_test_automation/general_guidelines.md`
+
+# Story-level Test Automation Guidelines
+
+You are automating a Story that has reached **Ready For Testing**. The Story already has linked Test Case tickets. Your job is to process **all linked Test Cases in one bulk run**.
+
+## Workflow
+
+1. Read the Story ticket and all linked Test Cases from `input/{STORY_KEY}/linked_test_cases.md`.
+2. For each linked Test Case:
+   - Check if an automated test already exists under `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If it is missing, write a new automated test for it.
+3. Produce a single result JSON: `outputs/story_test_automation_result.json`.
+4. For every failed Test Case, produce `outputs/failed_description_{TC_KEY}.md`.
+5. If environment/credentials are missing, produce `outputs/blocked.json` instead of running tests.
+
+## Scope rules
+
+- You may ONLY write code inside the `testing/` folder.
+- Each Test Case must have its own folder under `testing/tests/{TC_KEY}/`.
+- Reuse components from `testing/components/`, `testing/frameworks/`, and `testing/core/`.
+- Do NOT put raw Flutter/widget locators or `WidgetTester` code directly in the ticket test file.
+- Every `testing/tests/{TC_KEY}/` folder must contain:
+  - `README.md` describing what is being tested.
+  - `config.yaml` with test metadata.
+
+## Output files
+
+| File | Purpose |
+|------|---------|
+| `outputs/story_test_automation_result.json` | Per-TC results and overall status. |
+| `outputs/tracker_comment.md` | Human-readable summary for the Story ticket comment. |
+| `outputs/failed_description_{TC_KEY}.md` | Full failure report for a failed Test Case. |
+| `outputs/blocked.json` | Required when automation cannot run due to missing setup. |
+
+## Result statuses
+
+- `passed` — test ran successfully.
+- `failed` — test ran and failed; a failed description file must be written.
+- `skipped` — test cannot be automated (requires human-only verification); explain why.
+- `blocked_by_human` — the whole Story is blocked by missing credentials/data.
+
+
+---
+
+### [6] `./agents/instructions/story_test_automation/output_rules.md`
+
+# Story Test Automation Output Rules
+
+## Mandatory JSON output
+
+Write `outputs/story_test_automation_result.json` with exactly this schema:
+
+```json
+{
+  "storyKey": "TS-123",
+  "overall": "passed|failed|mixed|blocked_by_human",
+  "summary": "Short human-readable summary of what was done.",
+  "results": [
+    {
+      "testCaseKey": "TS-124",
+      "status": "passed|failed|skipped",
+      "testPath": "testing/tests/TS-124/...",
+      "failedDescriptionFile": "outputs/failed_description_TS-124.md",
+      "failureSummary": "One-line failure summary when status is failed."
+    }
+  ],
+  "blockedReason": "Explanation when overall is blocked_by_human."
+}
+```
+
+### Field rules
+
+- `overall`:
+  - `passed` — every result is `passed`.
+  - `failed` — at least one result is `failed` and none are blocked.
+  - `mixed` — some passed and some skipped, but none failed.
+  - `blocked_by_human` — automation could not run due to missing credentials/data.
+- `results` must contain every linked Test Case found in the input context.
+- `failedDescriptionFile` is required for every `failed` result. It must point to a file under `outputs/`.
+- `failureSummary` is required for every `failed` result.
+- `testPath` is required for every non-skipped result.
+
+## Mandatory tracker comment
+
+Write `outputs/tracker_comment.md` in Jira wiki format. It should include:
+
+- Story key and summary.
+- Counts of passed / failed / skipped Test Cases.
+- List of failed Test Cases with links to their failed description files (will be attached by the post-action).
+- Any blockers or missing setup.
+
+## Failed description files
+
+For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md` containing:
+
+1. Test Case key and summary.
+2. Steps to reproduce.
+3. Expected vs actual result.
+4. Stack trace / logs / screenshots if available.
+5. Environment details.
+
+Use Jira wiki markup (headings, code blocks, lists) so the file is readable when attached to the Test Case ticket.
+
+
+---
+
+### [7] `./agents/instructions/test_automation/test_automation_architecture.md`
+
+# Test Automation Architecture
+
+## High-Level Structure
+
+```mermaid
+flowchart TD
+    subgraph CORE["core/ — Framework-Agnostic Foundation"]
+        C1[models/ User, Product, Order]
+        C2[config/ Env, Creds, Timeouts]
+        C3[interfaces/ IBrowser, IDriver, IClient]
+        C4[utils/ Logger, DataGen, Waiters]
+    end
+
+    subgraph FW["frameworks/ — Concrete Implementations"]
+        direction LR
+        WEB[web/<br/>Playwright<br/>Selenium<br/>Cypress]
+        MOB[mobile/<br/>Appium<br/>XCUITest<br/>Espresso]
+        API[api/<br/>REST<br/>GraphQL<br/>gRPC]
+    end
+
+    subgraph COMP["components/ — Reusable Test Objects"]
+        direction LR
+        PAGES[pages/<br/>LoginPage<br/>CartPage]
+        SCR[screens/<br/>LoginScreen<br/>HomeScreen]
+        SVC[services/<br/>AuthService<br/>OrderService]
+    end
+
+    subgraph TESTS["tests/ — Per Ticket/Story"]
+        T1[TEST-1/ config.yaml + test_*.py]
+        T2[TEST-2/ config.yaml + test_*.py]
+        T3[TEST-3/ config.yaml + test_*.py]
+    end
+
+    FX[fixtures/<br/>users/<br/>products/]
+
+    CORE --> FW
+    FW --> COMP
+    COMP --> TESTS
+    FX --> TESTS
+```
+
+## Architecture Diagram
+
+```mermaid
+flowchart BT
+    subgraph TESTS_LAYER["TESTS"]
+        T1["STORY-123<br/>TEST-1 (web)<br/>TEST-2 (api)"]
+    end
+
+    subgraph COMP_LAYER["COMPONENTS — Reusable Objects"]
+        direction LR
+        P[pages/ Web UI] --> S[screens/ Mobile] --> SV[services/ API]
+    end
+
+    subgraph FW_LAYER["FRAMEWORKS — Implementations"]
+        direction LR
+        W[web/] --> M[mobile/] --> A[api/]
+    end
+
+    subgraph CORE_LAYER["CORE — Framework-Agnostic"]
+        direction LR
+        MOD[models/] --> CFG[config/] --> IF[interfaces/] --> UT[utils/]
+    end
+
+    TESTS_LAYER --> COMP_LAYER
+    COMP_LAYER --> FW_LAYER
+    FW_LAYER --> CORE_LAYER
+```
+
+## Layer Responsibilities
+
+```mermaid
+flowchart LR
+    TESTS["TESTS"] -->|"uses"| COMPONENTS["COMPONENTS"]
+    COMPONENTS -->|"implements via"| FRAMEWORKS["FRAMEWORKS"]
+    FRAMEWORKS -->|"built on"| CORE["CORE"]
+
+    TESTS -. "• Test logic per ticket<br/>• Uses components only<br/>• Ticket-level config" .- TESTS
+    COMPONENTS -. "• Page/Screen/Service objects<br/>• Business abstractions<br/>• Framework-agnostic" .- COMPONENTS
+    FRAMEWORKS -. "• Playwright, Appium, REST<br/>• Wraps vendor libs" .- FRAMEWORKS
+    CORE -. "• Models, Config, Utils<br/>• Abstract protocols" .- CORE
+```
+
+## Test Configuration Per Ticket
+
+```yaml
+# tests/TEST-1/config.yaml
+test_id: TEST-1
+type: web | mobile | api
+framework: playwright | appium | rest
+platform: chrome | ios | android
+dependencies: [TEST-0]
+```
+
+## Cross-Platform Component Sharing
+
+```mermaid
+flowchart TD
+    B[Login Flow<br/>Business Logic] --> W[LoginPage<br/>Web]
+    B --> M[LoginScreen<br/>Mobile]
+    B --> A[AuthService<br/>API]
+    W --> PW[Playwright / Selenium]
+    M --> AP[Appium / XCUITest]
+    A --> REST[REST / GraphQL]
+```
+
+## Key Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Separation** | Tests don't know about frameworks, only components |
+| **Abstraction** | Components use interfaces, not concrete implementations |
+| **Flexibility** | Easy to swap frameworks without changing tests |
+| **Reusability** | Same business logic, different platforms |
+| **Isolation** | Each test ticket has its own config and dependencies |
+
+## OOP & Modern Practices
+
+**Apply OOP throughout all test code:**
+- **Single Responsibility** — each Page/Screen/Service object handles one domain area only
+- **Dependency Injection** — pass drivers, clients, and config via constructor; never instantiate them inside components
+- **Interfaces first** — all components implement contracts defined in `core/interfaces/`; tests depend on interfaces, not concrete classes
+- **Encapsulation** — expose only high-level actions (e.g. `loginPage.loginAs(user)`), never raw selectors or HTTP internals
+
+**Use modern, idiomatic frameworks:**
+- **Web**: prefer Playwright over Selenium for new tests (async, reliable, built-in waits)
+- **API**: use typed API clients with models — no raw `requests.get(url)` calls inline in tests
+- **Mobile**: use Appium with Page Object Model; no hardcoded locators outside Screen classes
+- **Assertions**: use framework-native matchers (e.g. `expect(locator).toBeVisible()`) — not manual boolean checks
+
+**Test code quality:**
+- No hardcoded URLs, credentials, or environment values — use `core/config/`
+- No logic duplication — extract shared flows into components
+- Tests must be deterministic: no `time.sleep()`, use explicit waits instead
+
+
+---
+
+### [8] `./agents/instructions/test_automation/test_automation_instructions.md`
+
+# Test Automation Instructions
+
+You are a Senior QA Automation Engineer. Automate a single test case — feature code is already implemented. You write tests only, never feature code.
+
+```mermaid
+flowchart TD
+    subgraph SCOPE["⚠️ Scope"]
+        S1["Write code ONLY inside testing/"]
+        S2["NEVER modify feature source, CI/CD, or files outside testing/"]
+    end
+
+    subgraph ARCH["Architecture"]
+        A1["Tests go in: testing/tests/{TICKET-KEY}/"]
+        A2["Each folder: README.md + config.yaml + test_{key}.py"]
+        A3["Reuse components: pages/, screens/, services/, core/"]
+        A4["Create new components ONLY if none exist"]
+    end
+
+    subgraph DATA["Test Data — Self-Sufficient Strategy"]
+        D1["Step 1: Generate programmatically<br/>ffmpeg, python3 for minimal MP4/JPEG/MP3"]
+        D2["Step 2: Download public assets<br/>curl/wget from well-known URLs"]
+        D3["Step 3: Upload to project storage<br/>Use approved bucket/container"]
+        D4["Step 4: blocked_by_human<br/>ONLY if all above failed AND asset is non-reproducible"]
+        D1 --> D2 --> D3 --> D4
+    end
+
+    subgraph BLOCKED["Blocked by Human"]
+        B1["Missing CI credentials or env vars"]
+        B2["Missing test-account tokens"]
+        B3["Pre-existing DB data not guaranteed"]
+        B4["External file could not be generated/downloaded"]
+        B5["✅ Still write complete test with pytest.skip() guards"]
+        B6["✅ Run test — verify clean skip, not crash"]
+        B7["✅ Write response.md explaining what's missing"]
+        B8["✅ Output test_automation_result.json with status: blocked_by_human"]
+    end
+
+    subgraph EXEC["Test Execution"]
+        E1["Install dependencies"]
+        E2["Run the test"]
+        E3["Real user-style verification"]
+        E4["Capture result: passed / failed / skipped"]
+        E1 --> E2 --> E3 --> E4
+    end
+
+    SCOPE --> ARCH --> DATA --> EXEC
+    DATA -->|"steps 1-3 failed"| BLOCKED
+```
+
+## CI Credentials
+
+Read project-specific CI/credential instructions if provided. Do not assume providers, project IDs, secret names, or test accounts. Report exact missing items in `outputs/test_automation_result.json`.
+
+- `SOURCE_GITHUB_TOKEN` — available in CI jobs. Use for GitHub APIs or triggering workflows.
+
+## Test Data — Generate Programmatically
+
+```bash
+# Minimal valid MP4 (1s, 1x1px, silent) — ~5 KB
+ffmpeg -f lavfi -i color=c=black:s=1x1:d=1 -c:v libx264 -t 1 -movflags +faststart /tmp/test_video.mp4
+
+# Minimal valid JPEG (1x1 white pixel) — 631 bytes
+python3 -c "import base64, pathlib; pathlib.Path('/tmp/test_image.jpg').write_bytes(base64.b64decode('/9j/4AAQ...'))"
+
+# Minimal valid MP3 (silent, ~1 KB)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1 -q:a 9 -acodec libmp3lame /tmp/test_audio.mp3
+```
+
+## Test Data — Download Public Assets
+
+```bash
+curl -L -o /tmp/test_video.mp4 "https://www.w3schools.com/html/mov_bbb.mp4"
+```
+
+Always verify download succeeded (exit code 0, file size > 0).
+
+## Test Data — Upload to Storage
+
+```bash
+<storage-cli> cp /tmp/test_video.mp4 <bucket>/test-data/{TICKET-KEY}/test_video.mp4
+```
+
+Use `test-data/{TICKET-KEY}/test_video.mp4` as `RAW_OBJECT_PATH` in the test.
+
+## Real User-Style Verification
+
+Automated assertions are required but not enough. Also validate the scenario as a real user would experience it.
+
+**UI/UX tests:**
+- Exercise the actual user-facing flow, not only internal APIs
+- Verify visible labels, messages, headings, button text, validation text, empty states
+- Check text appears in the right context
+- Prefer accessibility locators (role, label, visible text)
+
+**API/background tests:**
+- Verify externally observable outcome a user or client would rely on
+- Do not stop at "request returned 200" if the test expects specific user-visible behavior
+
+Include human-style verification in output summaries. Document in `outputs/tracker_comment.md` and `outputs/pr_body.md`:
+- what was checked by automation;
+- what was checked as a real user/human-style scenario;
+- what was observed;
+- whether it matched the expected result.
+
+## Output Files
+
+Write outputs per `test_automation_output_files.md`:
+- `outputs/tracker_comment.md` — tracker-specific markup
+- `outputs/pr_body.md` — GitHub Markdown
+- `outputs/test_automation_result.json` — machine-readable status
+
+If test **failed**, also write `outputs/bug_description.md` with reproduction steps, expected vs actual, and error logs.
+
+
+---
+
+### [9] `./agents/instructions/test_automation/test_automation_output_files.md`
+
+# Test Automation Output Files
+
+**⚠️ CRITICAL: All output files MUST be written to `outputs/` at the repository root** (e.g. `/home/runner/work/repo/repo/outputs/`).
+Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `input/`. The post-processing script reads from `outputs/` at the repo root — writing elsewhere means all results will be silently lost.
+
+Run `mkdir -p outputs` first to ensure the directory exists.
+
+Write separate files for separate consumers. Do not reuse one format for all destinations.
+
+## `outputs/tracker_comment.md` — tracker ticket comment
+
+Purpose: posted to the Test Case ticket.
+
+Use the tracker-specific markup format configured for the project (loaded via `cliPromptsByTracker`).
+- For Jira trackers: use Jira wiki markup and follow `agents/instructions/tracker/jira_comment_format.md`.
+- For Azure DevOps trackers: use GitHub-flavored Markdown and follow `agents/instructions/tracker/ado_comment_format.md`.
+
+Required structure (render with the appropriate tracker syntax):
+
+```text
+### Test Automation Result
+
+*Status:* ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+*Test Case:* KEY-123 — summary
+*Test Branch PR:* link to PR (omit if not available)
+
+#### What was tested
+- Short factual bullet
+
+#### Result
+- What passed or failed
+- If failed, name the failed step and actual issue
+
+#### Test file
+<code block>
+testing/tests/KEY-123/test_key_123.py
+</code block>
+
+#### Run command
+<code block>
+pytest testing/tests/KEY-123/test_key_123.py
+</code block>
+```
+
+When the tracker is Jira, write this content to `outputs/jira_comment.md`.
+When the tracker is Azure DevOps, write this content to `outputs/response.md` (or `outputs/tracker_comment.md`) using Markdown syntax.
+
+## `outputs/pr_body.md` — GitHub Pull Request body
+
+Purpose: used by `gh pr create --body-file`.
+
+Use GitHub Markdown.
+
+Required structure:
+
+````markdown
+## Test Automation Result
+
+**Status:** ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+**Test Case:** KEY-123 — summary
+
+## What was automated
+- Short factual bullet
+
+## Result
+- What passed or failed
+
+## How to run
+```bash
+pytest testing/tests/KEY-123/test_key_123.py
+```
+````
+
+## `outputs/response.md` — backward-compatible summary
+
+If a platform still expects `outputs/response.md`, write a concise GitHub Markdown summary. The tracker-specific ticket comment must use the tracker markup file described above.
+
+## `outputs/test_automation_result.json` — machine-readable result
+
+Write the structured status JSON exactly as described in `agents/instructions/test_automation/test_automation_json_output.md`.
+
+
+---
+
+### [10] `./agents/instructions/test_automation/test_automation_json_output.md`
+
+# Test Automation JSON Output Format
+
+Write structured result to `outputs/test_automation_result.json`.
+
+```mermaid
+flowchart TD
+    subgraph STATUSES["Status"]
+        S1["passed — test ran and succeeded"]
+        S2["failed — test ran and found a bug"]
+        S3["blocked_by_human — cannot run (missing credentials/data)"]
+    end
+
+    subgraph FIELDS["Fields by Status"]
+        F1["passed: { status, passed, failed, skipped, summary }"]
+        F2["failed: { status, passed, failed, skipped, summary, error }"]
+        F3["blocked: { status, blocked_reason, missing[]: { type, name, description, how_to_add } }"]
+    end
+
+    subgraph PRIORITY["Bug Priority"]
+        P1["High — completely broken, data loss, security, blocking workflow"]
+        P2["Medium — partially works, key scenario fails, workaround exists"]
+        P3["Low — edge case, minor visual, non-critical"]
+    end
+
+    subgraph OUTPUTS["Required Output Files"]
+        O1["test_automation_result.json — machine-readable status"]
+        O2["tracker_comment.md — tracker-specific comment"]
+        O3["pr_body.md — GitHub Markdown for PR"]
+        O4["response.md — short backward-compatible summary"]
+        O5["bug_description.md — ONLY when failed"]
+    end
+
+    STATUSES --> FIELDS
+    FIELDS --> PRIORITY
+    FIELDS --> OUTPUTS
+```
+
+## Examples
+
+### Passed
+```json
+{ "status": "passed" }
+```
+
+### Failed
+```json
+{
+  "status": "failed",
+  "bug": {
+    "summary": "Bug: [what failed, max 120 chars]",
+    "description": "outputs/bug_description.md",
+    "priority": "High"
+  }
+}
+```
+
+### Blocked by Human
+```json
+{
+  "status": "blocked_by_human",
+  "blocked_reason": "Missing TEST_USER_EMAIL secret — automated test user not configured.",
+  "missing": [
+    { "type": "secret", "name": "TEST_USER_EMAIL", "description": "Automated test user email", "how_to_add": "gh secret set TEST_USER_EMAIL --body value --repo OWNER/REPO" }
+  ]
+}
+```
+
+## Detailed Examples (with counts)
+
+The `status` field is the only required field. Additional fields help reporting but are optional.
+
+### Passed (with counts)
+```json
+{ "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+```
+
+### Failed (with error detail)
+```json
+{ "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+```
+
+The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
+
+## Bug Description Template (when FAILED)
+
+Use tracker-specific format:
+- `h4. Environment`
+- `h4. Steps to Reproduce` (numbered)
+- `h4. Expected Result`
+- `h4. Actual Result`
+- `h4. Logs / Error Output` (`{code}` block)
+- `h4. Notes` (optional)
+
+
+---
+
+### [11] `./agents/prompts/story_test_automation_prompt.md`
+
+> Role: Senior QA Automation Engineer
+> Task: Bulk automate/run all Test Cases linked to a Story that is Ready For Testing.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md` — Story details, acceptance criteria, solution.
+- `input/{STORY_KEY}/linked_test_cases.md` — all linked Test Cases with key, summary, description, priority, and existing status.
+- `input/{STORY_KEY}/linked_test_cases.json` — machine-readable version of the above.
+- `testing/` — existing reusable components, frameworks, core helpers, and previously automated tests.
+
+## Task steps
+
+1. Run `codegraph context "{STORY_KEY} test automation existing tests and reusable helpers"` before grepping files.
+2. For each linked Test Case `{TC_KEY}`:
+   - Check `testing/tests/{TC_KEY}/`.
+   - If it exists, run the test and record the result.
+   - If it is missing, write a new automated test following the architecture rules.
+3. After running/writing, re-run any failed test at least once to confirm it is a real failure (not a flaky environment issue).
+4. Write `outputs/story_test_automation_result.json` with the exact schema from the output rules.
+5. Write `outputs/tracker_comment.md` summarizing the bulk run.
+6. For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md`.
+
+## Important rules
+
+- One Story = one branch `test/{STORY_KEY}` and one PR.
+- All test code lives under `testing/`.
+- Do NOT modify feature code.
+- Reuse existing helpers; do not duplicate infrastructure.
+- If credentials or test data are missing, stop and write `outputs/blocked.json`.
+- Each new `testing/tests/{TC_KEY}/` folder must contain `README.md` and `config.yaml`.
+
+
+---
+
+### [12] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+### [13] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---

--- a/snapshots/story_test_automation_merge.md
+++ b/snapshots/story_test_automation_merge.md
@@ -1,0 +1,3 @@
+# Agent Snapshot: `story_test_automation_merge`
+
+- **Context ID**: `story_test_automation_merge`

--- a/snapshots/story_test_automation_rework.md
+++ b/snapshots/story_test_automation_rework.md
@@ -1,0 +1,676 @@
+# Agent Snapshot: `story_test_automation_rework`
+
+- **Context ID**: `story_test_automation_rework`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Automation Engineer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/test_automation/test_automation_architecture.md`
+
+# Test Automation Architecture
+
+## High-Level Structure
+
+```mermaid
+flowchart TD
+    subgraph CORE["core/ — Framework-Agnostic Foundation"]
+        C1[models/ User, Product, Order]
+        C2[config/ Env, Creds, Timeouts]
+        C3[interfaces/ IBrowser, IDriver, IClient]
+        C4[utils/ Logger, DataGen, Waiters]
+    end
+
+    subgraph FW["frameworks/ — Concrete Implementations"]
+        direction LR
+        WEB[web/<br/>Playwright<br/>Selenium<br/>Cypress]
+        MOB[mobile/<br/>Appium<br/>XCUITest<br/>Espresso]
+        API[api/<br/>REST<br/>GraphQL<br/>gRPC]
+    end
+
+    subgraph COMP["components/ — Reusable Test Objects"]
+        direction LR
+        PAGES[pages/<br/>LoginPage<br/>CartPage]
+        SCR[screens/<br/>LoginScreen<br/>HomeScreen]
+        SVC[services/<br/>AuthService<br/>OrderService]
+    end
+
+    subgraph TESTS["tests/ — Per Ticket/Story"]
+        T1[TEST-1/ config.yaml + test_*.py]
+        T2[TEST-2/ config.yaml + test_*.py]
+        T3[TEST-3/ config.yaml + test_*.py]
+    end
+
+    FX[fixtures/<br/>users/<br/>products/]
+
+    CORE --> FW
+    FW --> COMP
+    COMP --> TESTS
+    FX --> TESTS
+```
+
+## Architecture Diagram
+
+```mermaid
+flowchart BT
+    subgraph TESTS_LAYER["TESTS"]
+        T1["STORY-123<br/>TEST-1 (web)<br/>TEST-2 (api)"]
+    end
+
+    subgraph COMP_LAYER["COMPONENTS — Reusable Objects"]
+        direction LR
+        P[pages/ Web UI] --> S[screens/ Mobile] --> SV[services/ API]
+    end
+
+    subgraph FW_LAYER["FRAMEWORKS — Implementations"]
+        direction LR
+        W[web/] --> M[mobile/] --> A[api/]
+    end
+
+    subgraph CORE_LAYER["CORE — Framework-Agnostic"]
+        direction LR
+        MOD[models/] --> CFG[config/] --> IF[interfaces/] --> UT[utils/]
+    end
+
+    TESTS_LAYER --> COMP_LAYER
+    COMP_LAYER --> FW_LAYER
+    FW_LAYER --> CORE_LAYER
+```
+
+## Layer Responsibilities
+
+```mermaid
+flowchart LR
+    TESTS["TESTS"] -->|"uses"| COMPONENTS["COMPONENTS"]
+    COMPONENTS -->|"implements via"| FRAMEWORKS["FRAMEWORKS"]
+    FRAMEWORKS -->|"built on"| CORE["CORE"]
+
+    TESTS -. "• Test logic per ticket<br/>• Uses components only<br/>• Ticket-level config" .- TESTS
+    COMPONENTS -. "• Page/Screen/Service objects<br/>• Business abstractions<br/>• Framework-agnostic" .- COMPONENTS
+    FRAMEWORKS -. "• Playwright, Appium, REST<br/>• Wraps vendor libs" .- FRAMEWORKS
+    CORE -. "• Models, Config, Utils<br/>• Abstract protocols" .- CORE
+```
+
+## Test Configuration Per Ticket
+
+```yaml
+# tests/TEST-1/config.yaml
+test_id: TEST-1
+type: web | mobile | api
+framework: playwright | appium | rest
+platform: chrome | ios | android
+dependencies: [TEST-0]
+```
+
+## Cross-Platform Component Sharing
+
+```mermaid
+flowchart TD
+    B[Login Flow<br/>Business Logic] --> W[LoginPage<br/>Web]
+    B --> M[LoginScreen<br/>Mobile]
+    B --> A[AuthService<br/>API]
+    W --> PW[Playwright / Selenium]
+    M --> AP[Appium / XCUITest]
+    A --> REST[REST / GraphQL]
+```
+
+## Key Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Separation** | Tests don't know about frameworks, only components |
+| **Abstraction** | Components use interfaces, not concrete implementations |
+| **Flexibility** | Easy to swap frameworks without changing tests |
+| **Reusability** | Same business logic, different platforms |
+| **Isolation** | Each test ticket has its own config and dependencies |
+
+## OOP & Modern Practices
+
+**Apply OOP throughout all test code:**
+- **Single Responsibility** — each Page/Screen/Service object handles one domain area only
+- **Dependency Injection** — pass drivers, clients, and config via constructor; never instantiate them inside components
+- **Interfaces first** — all components implement contracts defined in `core/interfaces/`; tests depend on interfaces, not concrete classes
+- **Encapsulation** — expose only high-level actions (e.g. `loginPage.loginAs(user)`), never raw selectors or HTTP internals
+
+**Use modern, idiomatic frameworks:**
+- **Web**: prefer Playwright over Selenium for new tests (async, reliable, built-in waits)
+- **API**: use typed API clients with models — no raw `requests.get(url)` calls inline in tests
+- **Mobile**: use Appium with Page Object Model; no hardcoded locators outside Screen classes
+- **Assertions**: use framework-native matchers (e.g. `expect(locator).toBeVisible()`) — not manual boolean checks
+
+**Test code quality:**
+- No hardcoded URLs, credentials, or environment values — use `core/config/`
+- No logic duplication — extract shared flows into components
+- Tests must be deterministic: no `time.sleep()`, use explicit waits instead
+
+
+---
+
+### [6] `./agents/instructions/test_automation/test_automation_instructions.md`
+
+# Test Automation Instructions
+
+You are a Senior QA Automation Engineer. Automate a single test case — feature code is already implemented. You write tests only, never feature code.
+
+```mermaid
+flowchart TD
+    subgraph SCOPE["⚠️ Scope"]
+        S1["Write code ONLY inside testing/"]
+        S2["NEVER modify feature source, CI/CD, or files outside testing/"]
+    end
+
+    subgraph ARCH["Architecture"]
+        A1["Tests go in: testing/tests/{TICKET-KEY}/"]
+        A2["Each folder: README.md + config.yaml + test_{key}.py"]
+        A3["Reuse components: pages/, screens/, services/, core/"]
+        A4["Create new components ONLY if none exist"]
+    end
+
+    subgraph DATA["Test Data — Self-Sufficient Strategy"]
+        D1["Step 1: Generate programmatically<br/>ffmpeg, python3 for minimal MP4/JPEG/MP3"]
+        D2["Step 2: Download public assets<br/>curl/wget from well-known URLs"]
+        D3["Step 3: Upload to project storage<br/>Use approved bucket/container"]
+        D4["Step 4: blocked_by_human<br/>ONLY if all above failed AND asset is non-reproducible"]
+        D1 --> D2 --> D3 --> D4
+    end
+
+    subgraph BLOCKED["Blocked by Human"]
+        B1["Missing CI credentials or env vars"]
+        B2["Missing test-account tokens"]
+        B3["Pre-existing DB data not guaranteed"]
+        B4["External file could not be generated/downloaded"]
+        B5["✅ Still write complete test with pytest.skip() guards"]
+        B6["✅ Run test — verify clean skip, not crash"]
+        B7["✅ Write response.md explaining what's missing"]
+        B8["✅ Output test_automation_result.json with status: blocked_by_human"]
+    end
+
+    subgraph EXEC["Test Execution"]
+        E1["Install dependencies"]
+        E2["Run the test"]
+        E3["Real user-style verification"]
+        E4["Capture result: passed / failed / skipped"]
+        E1 --> E2 --> E3 --> E4
+    end
+
+    SCOPE --> ARCH --> DATA --> EXEC
+    DATA -->|"steps 1-3 failed"| BLOCKED
+```
+
+## CI Credentials
+
+Read project-specific CI/credential instructions if provided. Do not assume providers, project IDs, secret names, or test accounts. Report exact missing items in `outputs/test_automation_result.json`.
+
+- `SOURCE_GITHUB_TOKEN` — available in CI jobs. Use for GitHub APIs or triggering workflows.
+
+## Test Data — Generate Programmatically
+
+```bash
+# Minimal valid MP4 (1s, 1x1px, silent) — ~5 KB
+ffmpeg -f lavfi -i color=c=black:s=1x1:d=1 -c:v libx264 -t 1 -movflags +faststart /tmp/test_video.mp4
+
+# Minimal valid JPEG (1x1 white pixel) — 631 bytes
+python3 -c "import base64, pathlib; pathlib.Path('/tmp/test_image.jpg').write_bytes(base64.b64decode('/9j/4AAQ...'))"
+
+# Minimal valid MP3 (silent, ~1 KB)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1 -q:a 9 -acodec libmp3lame /tmp/test_audio.mp3
+```
+
+## Test Data — Download Public Assets
+
+```bash
+curl -L -o /tmp/test_video.mp4 "https://www.w3schools.com/html/mov_bbb.mp4"
+```
+
+Always verify download succeeded (exit code 0, file size > 0).
+
+## Test Data — Upload to Storage
+
+```bash
+<storage-cli> cp /tmp/test_video.mp4 <bucket>/test-data/{TICKET-KEY}/test_video.mp4
+```
+
+Use `test-data/{TICKET-KEY}/test_video.mp4` as `RAW_OBJECT_PATH` in the test.
+
+## Real User-Style Verification
+
+Automated assertions are required but not enough. Also validate the scenario as a real user would experience it.
+
+**UI/UX tests:**
+- Exercise the actual user-facing flow, not only internal APIs
+- Verify visible labels, messages, headings, button text, validation text, empty states
+- Check text appears in the right context
+- Prefer accessibility locators (role, label, visible text)
+
+**API/background tests:**
+- Verify externally observable outcome a user or client would rely on
+- Do not stop at "request returned 200" if the test expects specific user-visible behavior
+
+Include human-style verification in output summaries. Document in `outputs/tracker_comment.md` and `outputs/pr_body.md`:
+- what was checked by automation;
+- what was checked as a real user/human-style scenario;
+- what was observed;
+- whether it matched the expected result.
+
+## Output Files
+
+Write outputs per `test_automation_output_files.md`:
+- `outputs/tracker_comment.md` — tracker-specific markup
+- `outputs/pr_body.md` — GitHub Markdown
+- `outputs/test_automation_result.json` — machine-readable status
+
+If test **failed**, also write `outputs/bug_description.md` with reproduction steps, expected vs actual, and error logs.
+
+
+---
+
+### [7] `./agents/instructions/test_automation/test_automation_output_files.md`
+
+# Test Automation Output Files
+
+**⚠️ CRITICAL: All output files MUST be written to `outputs/` at the repository root** (e.g. `/home/runner/work/repo/repo/outputs/`).
+Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `input/`. The post-processing script reads from `outputs/` at the repo root — writing elsewhere means all results will be silently lost.
+
+Run `mkdir -p outputs` first to ensure the directory exists.
+
+Write separate files for separate consumers. Do not reuse one format for all destinations.
+
+## `outputs/tracker_comment.md` — tracker ticket comment
+
+Purpose: posted to the Test Case ticket.
+
+Use the tracker-specific markup format configured for the project (loaded via `cliPromptsByTracker`).
+- For Jira trackers: use Jira wiki markup and follow `agents/instructions/tracker/jira_comment_format.md`.
+- For Azure DevOps trackers: use GitHub-flavored Markdown and follow `agents/instructions/tracker/ado_comment_format.md`.
+
+Required structure (render with the appropriate tracker syntax):
+
+```text
+### Test Automation Result
+
+*Status:* ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+*Test Case:* KEY-123 — summary
+*Test Branch PR:* link to PR (omit if not available)
+
+#### What was tested
+- Short factual bullet
+
+#### Result
+- What passed or failed
+- If failed, name the failed step and actual issue
+
+#### Test file
+<code block>
+testing/tests/KEY-123/test_key_123.py
+</code block>
+
+#### Run command
+<code block>
+pytest testing/tests/KEY-123/test_key_123.py
+</code block>
+```
+
+When the tracker is Jira, write this content to `outputs/jira_comment.md`.
+When the tracker is Azure DevOps, write this content to `outputs/response.md` (or `outputs/tracker_comment.md`) using Markdown syntax.
+
+## `outputs/pr_body.md` — GitHub Pull Request body
+
+Purpose: used by `gh pr create --body-file`.
+
+Use GitHub Markdown.
+
+Required structure:
+
+````markdown
+## Test Automation Result
+
+**Status:** ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+**Test Case:** KEY-123 — summary
+
+## What was automated
+- Short factual bullet
+
+## Result
+- What passed or failed
+
+## How to run
+```bash
+pytest testing/tests/KEY-123/test_key_123.py
+```
+````
+
+## `outputs/response.md` — backward-compatible summary
+
+If a platform still expects `outputs/response.md`, write a concise GitHub Markdown summary. The tracker-specific ticket comment must use the tracker markup file described above.
+
+## `outputs/test_automation_result.json` — machine-readable result
+
+Write the structured status JSON exactly as described in `agents/instructions/test_automation/test_automation_json_output.md`.
+
+
+---
+
+### [8] `./agents/instructions/test_automation/test_automation_json_output.md`
+
+# Test Automation JSON Output Format
+
+Write structured result to `outputs/test_automation_result.json`.
+
+```mermaid
+flowchart TD
+    subgraph STATUSES["Status"]
+        S1["passed — test ran and succeeded"]
+        S2["failed — test ran and found a bug"]
+        S3["blocked_by_human — cannot run (missing credentials/data)"]
+    end
+
+    subgraph FIELDS["Fields by Status"]
+        F1["passed: { status, passed, failed, skipped, summary }"]
+        F2["failed: { status, passed, failed, skipped, summary, error }"]
+        F3["blocked: { status, blocked_reason, missing[]: { type, name, description, how_to_add } }"]
+    end
+
+    subgraph PRIORITY["Bug Priority"]
+        P1["High — completely broken, data loss, security, blocking workflow"]
+        P2["Medium — partially works, key scenario fails, workaround exists"]
+        P3["Low — edge case, minor visual, non-critical"]
+    end
+
+    subgraph OUTPUTS["Required Output Files"]
+        O1["test_automation_result.json — machine-readable status"]
+        O2["tracker_comment.md — tracker-specific comment"]
+        O3["pr_body.md — GitHub Markdown for PR"]
+        O4["response.md — short backward-compatible summary"]
+        O5["bug_description.md — ONLY when failed"]
+    end
+
+    STATUSES --> FIELDS
+    FIELDS --> PRIORITY
+    FIELDS --> OUTPUTS
+```
+
+## Examples
+
+### Passed
+```json
+{ "status": "passed" }
+```
+
+### Failed
+```json
+{
+  "status": "failed",
+  "bug": {
+    "summary": "Bug: [what failed, max 120 chars]",
+    "description": "outputs/bug_description.md",
+    "priority": "High"
+  }
+}
+```
+
+### Blocked by Human
+```json
+{
+  "status": "blocked_by_human",
+  "blocked_reason": "Missing TEST_USER_EMAIL secret — automated test user not configured.",
+  "missing": [
+    { "type": "secret", "name": "TEST_USER_EMAIL", "description": "Automated test user email", "how_to_add": "gh secret set TEST_USER_EMAIL --body value --repo OWNER/REPO" }
+  ]
+}
+```
+
+## Detailed Examples (with counts)
+
+The `status` field is the only required field. Additional fields help reporting but are optional.
+
+### Passed (with counts)
+```json
+{ "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+```
+
+### Failed (with error detail)
+```json
+{ "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+```
+
+The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
+
+## Bug Description Template (when FAILED)
+
+Use tracker-specific format:
+- `h4. Environment`
+- `h4. Steps to Reproduce` (numbered)
+- `h4. Expected Result`
+- `h4. Actual Result`
+- `h4. Logs / Error Output` (`{code}` block)
+- `h4. Notes` (optional)
+
+
+---
+
+### [9] `./agents/prompts/story_test_automation_rework_prompt.md`
+
+> Role: Senior QA Automation Engineer
+> Task: Fix test code based on bulk review feedback for a Story.
+
+## Context files you must read
+
+- `input/{STORY_KEY}/ticket.md`
+- `input/{STORY_KEY}/linked_test_cases.md`
+- `input/{STORY_KEY}/pr_info.md`
+- `input/{STORY_KEY}/pr_discussions.md`
+- `outputs/review_replies.json` — review comments and required fixes
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Task steps
+
+1. Address every comment in `outputs/review_replies.json`.
+2. Make minimal, focused changes to `testing/` only.
+3. Re-run the affected tests to confirm they still pass.
+4. Update `outputs/story_test_automation_result.json` if any previously failed Test Case now passes.
+5. Write `outputs/tracker_comment.md` describing what was fixed.
+6. Do NOT change feature code or non-test files.
+
+## Output
+
+- Updated test code under `testing/tests/{TC_KEY}/`.
+- `outputs/story_test_automation_result.json` with fresh per-TC results.
+- `outputs/tracker_comment.md`.
+
+
+---
+
+### [10] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+### [11] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---

--- a/story_test_automation.json
+++ b/story_test_automation.json
@@ -1,0 +1,40 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "story_test_automation" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "envVariables": {
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
+    },
+    "customParams": {
+      "removeLabel": "sm_story_test_automation_triggered"
+    },
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",
+    "postJSAction": "agents/js/postStoryTestAutomationResults.js",
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Automation Engineer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/story_test_automation/general_guidelines.md",
+      "./agents/instructions/story_test_automation/output_rules.md",
+      "./agents/instructions/test_automation/test_automation_architecture.md",
+      "./agents/instructions/test_automation/test_automation_instructions.md",
+      "./agents/instructions/test_automation/test_automation_output_files.md",
+      "./agents/instructions/test_automation/test_automation_json_output.md",
+      "./agents/prompts/story_test_automation_prompt.md",
+      "./agents/prompts/bash_tools.md",
+      "./agents/instructions/common/dmtools_cli.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}

--- a/story_test_automation_merge.json
+++ b/story_test_automation_merge.json
@@ -1,0 +1,16 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "story_test_automation_merge" },
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "postJSAction": "agents/js/mergeStoryTestAutomationPR.js",
+    "customParams": {
+      "removeLabel": "sm_story_test_merge_triggered",
+      "storyTestMerge": true
+    },
+    "inputJql": "key = JD-111"
+  }
+}

--- a/story_test_automation_rework.json
+++ b/story_test_automation_rework.json
@@ -1,0 +1,35 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "story_test_automation_rework" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",
+    "postJSAction": "agents/js/storyTestAutomationRework.js",
+    "customParams": {
+      "removeLabel": "sm_story_test_rework_triggered"
+    },
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Automation Engineer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/test_automation/test_automation_architecture.md",
+      "./agents/instructions/test_automation/test_automation_instructions.md",
+      "./agents/instructions/test_automation/test_automation_output_files.md",
+      "./agents/instructions/test_automation/test_automation_json_output.md",
+      "./agents/prompts/story_test_automation_rework_prompt.md",
+      "./agents/prompts/bash_tools.md",
+      "./agents/instructions/common/dmtools_cli.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}


### PR DESCRIPTION
Adds a Story-level bulk test automation flow.

- New `story_test_automation` agent triggered when a Story reaches Ready For Testing.
- Collects linked Test Cases, runs or writes tests on `test/{STORY_KEY}` branch.
- Failed Test Cases get `outputs/failed_description_{TC_KEY}.md` attached and the Jira `Failed Reason` field populated.
- New bulk review/merge/rework agents for the Story test PR.
- New SM rule: Ready For Testing Stories → `story_test_automation`.
- Adds `Failed Reason` field constant.