### PR TITLE
feat(bug_test_automation): bulk automate linked Test Cases from a Bug

### DIFF
--- a/bug_test_automation.json
+++ b/bug_test_automation.json
@@ -1,0 +1,40 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "bug_test_automation" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "envVariables": {
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
+    },
+    "customParams": {
+      "removeLabel": "sm_bug_test_automation_triggered"
+    },
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",
+    "postJSAction": "agents/js/postStoryTestAutomationResults.js",
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Automation Engineer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/bug_test_automation/general_guidelines.md",
+      "./agents/instructions/bug_test_automation/output_rules.md",
+      "./agents/instructions/test_automation/test_automation_architecture.md",
+      "./agents/instructions/test_automation/test_automation_instructions.md",
+      "./agents/instructions/test_automation/test_automation_output_files.md",
+      "./agents/instructions/test_automation/test_automation_json_output.md",
+      "./agents/prompts/bug_test_automation_prompt.md",
+      "./agents/prompts/bash_tools.md",
+      "./agents/instructions/common/dmtools_cli.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}

--- a/bug_test_automation_merge.json
+++ b/bug_test_automation_merge.json
@@ -1,0 +1,16 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "bug_test_automation_merge" },
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "postJSAction": "agents/js/mergeStoryTestAutomationPR.js",
+    "customParams": {
+      "removeLabel": "sm_bug_test_merge_triggered",
+      "storyTestMerge": true
+    },
+    "inputJql": "key = JD-111"
+  }
+}

--- a/bug_test_automation_rework.json
+++ b/bug_test_automation_rework.json
@@ -1,0 +1,35 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "bug_test_automation_rework" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",
+    "postJSAction": "agents/js/storyTestAutomationRework.js",
+    "customParams": {
+      "removeLabel": "sm_bug_test_rework_triggered"
+    },
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Automation Engineer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/test_automation/test_automation_architecture.md",
+      "./agents/instructions/test_automation/test_automation_instructions.md",
+      "./agents/instructions/test_automation/test_automation_output_files.md",
+      "./agents/instructions/test_automation/test_automation_json_output.md",
+      "./agents/prompts/bug_test_automation_rework_prompt.md",
+      "./agents/prompts/bash_tools.md",
+      "./agents/instructions/common/dmtools_cli.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}

--- a/instructions/bug_test_automation/general_guidelines.md
+++ b/instructions/bug_test_automation/general_guidelines.md
@@ -1,0 +1,29 @@
+# Bug-level Test Automation Guidelines
+
+You are automating tests for a Bug that has reached **Ready For Testing**. The Bug already has linked Test Case tickets. Process **all linked Test Cases in one bulk run**.
+
+## Workflow
+
+1. Read the Bug ticket and all linked Test Cases from `input/{BUG_KEY}/linked_test_cases.md`.
+2. For each linked Test Case:
+   - Check if an automated test already exists under `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If it is missing, write a new automated test for it.
+3. Produce `outputs/story_test_automation_result.json` (shared schema).
+4. For every failed Test Case, produce `outputs/failed_description_{TC_KEY}.md`.
+5. If environment/credentials are missing, produce `outputs/blocked.json`.
+
+## Focus for Bug tests
+
+- Tests must reproduce the original bug scenario and verify the fix.
+- Include regression checks: ensure the bug does not reappear.
+- Use the same layer architecture as Story tests.
+
+## Output files
+
+| File | Purpose |
+|------|---------|
+| `outputs/story_test_automation_result.json` | Per-TC results and overall status. |
+| `outputs/tracker_comment.md` | Summary for the Bug ticket comment. |
+| `outputs/failed_description_{TC_KEY}.md` | Full failure report for a failed Test Case. |
+| `outputs/blocked.json` | Required when automation cannot run. |

--- a/instructions/bug_test_automation/output_rules.md
+++ b/instructions/bug_test_automation/output_rules.md
@@ -1,0 +1,33 @@
+# Bug Test Automation Output Rules
+
+Use the same output schema as Story test automation. Write `outputs/story_test_automation_result.json`:
+
+```json
+{
+  "storyKey": "TS-123",
+  "overall": "passed|failed|mixed|blocked_by_human",
+  "summary": "...",
+  "results": [
+    {
+      "testCaseKey": "TS-124",
+      "status": "passed|failed|skipped",
+      "testPath": "testing/tests/TS-124/...",
+      "failedDescriptionFile": "outputs/failed_description_TS-124.md",
+      "failureSummary": "..."
+    }
+  ],
+  "blockedReason": "..."
+}
+```
+
+The `storyKey` field is reused for backward compatibility; put the Bug key here.
+
+- `overall`:
+  - `passed` — every result is `passed`.
+  - `failed` — at least one result is `failed`.
+  - `mixed` — some passed and some skipped, none failed.
+  - `blocked_by_human` — missing credentials/data.
+- `results` must contain every linked Test Case.
+- `failedDescriptionFile` is required for every `failed` result.
+
+Write `outputs/tracker_comment.md` in Jira wiki format and attach `outputs/failed_description_{TC_KEY}.md` for failed Test Cases.

--- a/js/triggerBugTestAutomation.js
+++ b/js/triggerBugTestAutomation.js
@@ -1,0 +1,69 @@
+/**
+ * Trigger Bug Test Automation
+ * Post-action for bug_test_cases_generator.
+ * Keeps the Bug in Ready For Testing and immediately triggers bug_test_automation.
+ */
+
+var autoStart = require('./common/autoStart.js');
+var tokenUsageComment = require('./common/tokenUsageComment.js');
+
+function action(params) {
+    try {
+        const bugKey = params.ticket.key;
+        const config = params.jobParams && params.jobParams.config
+            ? params.jobParams.config
+            : (params.config || {});
+        const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+
+        console.log('=== Triggering bug test automation for', bugKey, '===');
+
+        var triggered = false;
+        if (customParams.autoStartBugTestAutomation && customParams.autoStartBugTestAutomationConfigFile) {
+            triggered = autoStart.triggerConfiguredWorkflowForTicket({
+                ticketKey: bugKey,
+                customParams: customParams,
+                config: config,
+                configFile: customParams.autoStartBugTestAutomationConfigFile,
+                label: 'bug_test_automation',
+                stripKeys: [
+                    'removeLabel',
+                    'autoStartBugTestAutomation',
+                    'autoStartBugTestAutomationConfigFile'
+                ]
+            });
+        }
+
+        if (!triggered) {
+            console.log('Bug test automation not triggered via autoStart; asking SM to re-evaluate.');
+            autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
+        } else {
+            console.log('✅ Triggered bug_test_automation for', bugKey);
+        }
+
+        // Remove the generator SM trigger label so bug_test_cases_generator does not keep re-running
+        const generatorLabel = 'sm_bug_test_cases_triggered';
+        try {
+            jira_remove_label({ key: bugKey, label: generatorLabel });
+            console.log('✅ Removed generator SM label:', generatorLabel);
+        } catch (e) {
+            console.warn('Failed to remove generator SM label:', e);
+        }
+
+        // Post token usage summary comments from the test-case generation run
+        try {
+            tokenUsageComment.postTokenUsageComments(bugKey, { initiator: params.initiator });
+        } catch (e) {
+            console.warn('Failed to post token usage comments:', e);
+        }
+
+        return { success: true, triggered: triggered, bugKey: bugKey };
+
+    } catch (error) {
+        console.error('❌ Error in triggerBugTestAutomation:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/pr_bug_test_automation_review.json
+++ b/pr_bug_test_automation_review.json
@@ -1,0 +1,35 @@
+{
+  "name": "Teammate",
+  "params": {
+    "metadata": { "contextId": "pr_bug_test_automation_review" },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "outputType": "none",
+    "ticketContextDepth": 1,
+    "skipAIProcessing": true,
+    "alwaysPostComments": true,
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/prepareTestPRForReview.js",
+    "postJSAction": "agents/js/postStoryTestAutomationReview.js",
+    "customParams": {
+      "removeLabel": "sm_bug_test_review_triggered"
+    },
+    "inputJql": "key = JD-111",
+    "cliPrompts": [
+      "Senior QA Engineer & Code Reviewer",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/common/coding_guidelines.md",
+      "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/pr_test_automation_review/general_guidelines.md",
+      "./agents/instructions/pr_test_automation_review/output_rules.md",
+      "./agents/instructions/pr_test_automation_review/formatting_rules.md",
+      "./agents/instructions/pr_test_automation_review/few_shots.md",
+      "./agents/prompts/bug_test_automation_review_prompt.md",
+      "./agents/instructions/common/dmtools_cli.md",
+      "./agents/prompts/bash_tools.md"
+    ],
+    "cliPromptsByTracker": {
+      "jira": ["./agents/instructions/tracker/jira_comment_format.md"],
+      "ado": ["./agents/instructions/tracker/ado_comment_format.md"]
+    }
+  }
+}

--- a/prompts/bug_test_automation_prompt.md
+++ b/prompts/bug_test_automation_prompt.md
@@ -1,0 +1,29 @@
+> Role: Senior QA Automation Engineer
+> Task: Bulk automate/run all Test Cases linked to a Bug that is Ready For Testing.
+
+## Context files you must read
+
+- `input/{BUG_KEY}/ticket.md` — Bug details, description, reproduction steps.
+- `input/{BUG_KEY}/linked_test_cases.md` — all linked Test Cases.
+- `input/{BUG_KEY}/linked_test_cases.json` — machine-readable list.
+- `testing/` — existing tests and reusable helpers.
+
+## Task steps
+
+1. Run `codegraph context "{BUG_KEY} test automation existing tests and reusable helpers"` before grepping.
+2. For each linked Test Case `{TC_KEY}`:
+   - Check `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If missing, write a new automated test that reproduces the bug and verifies the fix.
+3. Re-run failed tests once to confirm real failure.
+4. Write `outputs/story_test_automation_result.json` with the shared schema.
+5. Write `outputs/tracker_comment.md` summarizing the bulk run.
+6. For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md`.
+
+## Rules
+
+- One Bug = one branch `test/{BUG_KEY}` and one PR.
+- All test code lives under `testing/`.
+- Do NOT modify feature code.
+- Each new `testing/tests/{TC_KEY}/` folder must contain `README.md` and `config.yaml`.
+- Focus tests on the bug regression scenario.

--- a/prompts/bug_test_automation_review_prompt.md
+++ b/prompts/bug_test_automation_review_prompt.md
@@ -1,0 +1,26 @@
+> Role: Senior QA Engineer & Code Reviewer
+> Task: Review the bulk test automation Pull Request for a Bug. Branch is `test/{BUG_KEY}`.
+
+## Context files
+
+- `input/{BUG_KEY}/ticket.md`
+- `input/{BUG_KEY}/linked_test_cases.md`
+- `input/{BUG_KEY}/pr_info.md`
+- `input/{BUG_KEY}/pr_diff.txt`
+- `input/{BUG_KEY}/pr_discussions.md`
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Review checklist
+
+1. Every linked Test Case has an automated test.
+2. Each test folder has `README.md` and `config.yaml`.
+3. Tests correctly reproduce the bug and verify the fix.
+4. Architecture layers are respected.
+5. No raw locators in ticket test files.
+6. Tests are deterministic and isolated.
+7. Reuse helpers; no duplication.
+8. No debug/commented-out code.
+
+## Output
+
+Write `outputs/pr_review.json` with `recommendation`, `summary`, `generalComment`, `inlineComments`.

--- a/prompts/bug_test_automation_rework_prompt.md
+++ b/prompts/bug_test_automation_rework_prompt.md
@@ -1,0 +1,19 @@
+> Role: Senior QA Automation Engineer
+> Task: Fix test code based on bulk review feedback for a Bug.
+
+## Context files
+
+- `input/{BUG_KEY}/ticket.md`
+- `input/{BUG_KEY}/linked_test_cases.md`
+- `input/{BUG_KEY}/pr_info.md`
+- `input/{BUG_KEY}/pr_discussions.md`
+- `outputs/review_replies.json`
+- `testing/tests/{TC_KEY}/`
+
+## Task
+
+1. Address every comment in `outputs/review_replies.json`.
+2. Make minimal changes to `testing/` only.
+3. Re-run affected tests.
+4. Update `outputs/story_test_automation_result.json` if statuses changed.
+5. Write `outputs/tracker_comment.md`.

--- a/sm.json
+++ b/sm.json
@@ -167,6 +167,14 @@
           "enabled": true
         },
         {
+          "description": "Ready For Testing Bugs → automate linked test cases in bulk",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Ready For Testing')",
+          "configFile": "agents/bug_test_automation.json",
+          "skipIfLabel": "sm_bug_test_automation_triggered",
+          "addLabel": "sm_bug_test_automation_triggered",
+          "enabled": true
+        },
+        {
           "description": "Ready For Testing Stories → automate linked test cases in bulk",
           "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('Ready For Testing')",
           "configFile": "agents/story_test_automation.json",

--- a/snapshots/bug_test_automation.md
+++ b/snapshots/bug_test_automation.md
@@ -1,0 +1,753 @@
+# Agent Snapshot: `bug_test_automation`
+
+- **Context ID**: `bug_test_automation`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Automation Engineer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/bug_test_automation/general_guidelines.md`
+
+# Bug-level Test Automation Guidelines
+
+You are automating tests for a Bug that has reached **Ready For Testing**. The Bug already has linked Test Case tickets. Process **all linked Test Cases in one bulk run**.
+
+## Workflow
+
+1. Read the Bug ticket and all linked Test Cases from `input/{BUG_KEY}/linked_test_cases.md`.
+2. For each linked Test Case:
+   - Check if an automated test already exists under `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If it is missing, write a new automated test for it.
+3. Produce `outputs/story_test_automation_result.json` (shared schema).
+4. For every failed Test Case, produce `outputs/failed_description_{TC_KEY}.md`.
+5. If environment/credentials are missing, produce `outputs/blocked.json`.
+
+## Focus for Bug tests
+
+- Tests must reproduce the original bug scenario and verify the fix.
+- Include regression checks: ensure the bug does not reappear.
+- Use the same layer architecture as Story tests.
+
+## Output files
+
+| File | Purpose |
+|------|---------|
+| `outputs/story_test_automation_result.json` | Per-TC results and overall status. |
+| `outputs/tracker_comment.md` | Summary for the Bug ticket comment. |
+| `outputs/failed_description_{TC_KEY}.md` | Full failure report for a failed Test Case. |
+| `outputs/blocked.json` | Required when automation cannot run. |
+
+
+---
+
+### [6] `./agents/instructions/bug_test_automation/output_rules.md`
+
+# Bug Test Automation Output Rules
+
+Use the same output schema as Story test automation. Write `outputs/story_test_automation_result.json`:
+
+```json
+{
+  "storyKey": "TS-123",
+  "overall": "passed|failed|mixed|blocked_by_human",
+  "summary": "...",
+  "results": [
+    {
+      "testCaseKey": "TS-124",
+      "status": "passed|failed|skipped",
+      "testPath": "testing/tests/TS-124/...",
+      "failedDescriptionFile": "outputs/failed_description_TS-124.md",
+      "failureSummary": "..."
+    }
+  ],
+  "blockedReason": "..."
+}
+```
+
+The `storyKey` field is reused for backward compatibility; put the Bug key here.
+
+- `overall`:
+  - `passed` — every result is `passed`.
+  - `failed` — at least one result is `failed`.
+  - `mixed` — some passed and some skipped, none failed.
+  - `blocked_by_human` — missing credentials/data.
+- `results` must contain every linked Test Case.
+- `failedDescriptionFile` is required for every `failed` result.
+
+Write `outputs/tracker_comment.md` in Jira wiki format and attach `outputs/failed_description_{TC_KEY}.md` for failed Test Cases.
+
+
+---
+
+### [7] `./agents/instructions/test_automation/test_automation_architecture.md`
+
+# Test Automation Architecture
+
+## High-Level Structure
+
+```mermaid
+flowchart TD
+    subgraph CORE["core/ — Framework-Agnostic Foundation"]
+        C1[models/ User, Product, Order]
+        C2[config/ Env, Creds, Timeouts]
+        C3[interfaces/ IBrowser, IDriver, IClient]
+        C4[utils/ Logger, DataGen, Waiters]
+    end
+
+    subgraph FW["frameworks/ — Concrete Implementations"]
+        direction LR
+        WEB[web/<br/>Playwright<br/>Selenium<br/>Cypress]
+        MOB[mobile/<br/>Appium<br/>XCUITest<br/>Espresso]
+        API[api/<br/>REST<br/>GraphQL<br/>gRPC]
+    end
+
+    subgraph COMP["components/ — Reusable Test Objects"]
+        direction LR
+        PAGES[pages/<br/>LoginPage<br/>CartPage]
+        SCR[screens/<br/>LoginScreen<br/>HomeScreen]
+        SVC[services/<br/>AuthService<br/>OrderService]
+    end
+
+    subgraph TESTS["tests/ — Per Ticket/Story"]
+        T1[TEST-1/ config.yaml + test_*.py]
+        T2[TEST-2/ config.yaml + test_*.py]
+        T3[TEST-3/ config.yaml + test_*.py]
+    end
+
+    FX[fixtures/<br/>users/<br/>products/]
+
+    CORE --> FW
+    FW --> COMP
+    COMP --> TESTS
+    FX --> TESTS
+```
+
+## Architecture Diagram
+
+```mermaid
+flowchart BT
+    subgraph TESTS_LAYER["TESTS"]
+        T1["STORY-123<br/>TEST-1 (web)<br/>TEST-2 (api)"]
+    end
+
+    subgraph COMP_LAYER["COMPONENTS — Reusable Objects"]
+        direction LR
+        P[pages/ Web UI] --> S[screens/ Mobile] --> SV[services/ API]
+    end
+
+    subgraph FW_LAYER["FRAMEWORKS — Implementations"]
+        direction LR
+        W[web/] --> M[mobile/] --> A[api/]
+    end
+
+    subgraph CORE_LAYER["CORE — Framework-Agnostic"]
+        direction LR
+        MOD[models/] --> CFG[config/] --> IF[interfaces/] --> UT[utils/]
+    end
+
+    TESTS_LAYER --> COMP_LAYER
+    COMP_LAYER --> FW_LAYER
+    FW_LAYER --> CORE_LAYER
+```
+
+## Layer Responsibilities
+
+```mermaid
+flowchart LR
+    TESTS["TESTS"] -->|"uses"| COMPONENTS["COMPONENTS"]
+    COMPONENTS -->|"implements via"| FRAMEWORKS["FRAMEWORKS"]
+    FRAMEWORKS -->|"built on"| CORE["CORE"]
+
+    TESTS -. "• Test logic per ticket<br/>• Uses components only<br/>• Ticket-level config" .- TESTS
+    COMPONENTS -. "• Page/Screen/Service objects<br/>• Business abstractions<br/>• Framework-agnostic" .- COMPONENTS
+    FRAMEWORKS -. "• Playwright, Appium, REST<br/>• Wraps vendor libs" .- FRAMEWORKS
+    CORE -. "• Models, Config, Utils<br/>• Abstract protocols" .- CORE
+```
+
+## Test Configuration Per Ticket
+
+```yaml
+# tests/TEST-1/config.yaml
+test_id: TEST-1
+type: web | mobile | api
+framework: playwright | appium | rest
+platform: chrome | ios | android
+dependencies: [TEST-0]
+```
+
+## Cross-Platform Component Sharing
+
+```mermaid
+flowchart TD
+    B[Login Flow<br/>Business Logic] --> W[LoginPage<br/>Web]
+    B --> M[LoginScreen<br/>Mobile]
+    B --> A[AuthService<br/>API]
+    W --> PW[Playwright / Selenium]
+    M --> AP[Appium / XCUITest]
+    A --> REST[REST / GraphQL]
+```
+
+## Key Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Separation** | Tests don't know about frameworks, only components |
+| **Abstraction** | Components use interfaces, not concrete implementations |
+| **Flexibility** | Easy to swap frameworks without changing tests |
+| **Reusability** | Same business logic, different platforms |
+| **Isolation** | Each test ticket has its own config and dependencies |
+
+## OOP & Modern Practices
+
+**Apply OOP throughout all test code:**
+- **Single Responsibility** — each Page/Screen/Service object handles one domain area only
+- **Dependency Injection** — pass drivers, clients, and config via constructor; never instantiate them inside components
+- **Interfaces first** — all components implement contracts defined in `core/interfaces/`; tests depend on interfaces, not concrete classes
+- **Encapsulation** — expose only high-level actions (e.g. `loginPage.loginAs(user)`), never raw selectors or HTTP internals
+
+**Use modern, idiomatic frameworks:**
+- **Web**: prefer Playwright over Selenium for new tests (async, reliable, built-in waits)
+- **API**: use typed API clients with models — no raw `requests.get(url)` calls inline in tests
+- **Mobile**: use Appium with Page Object Model; no hardcoded locators outside Screen classes
+- **Assertions**: use framework-native matchers (e.g. `expect(locator).toBeVisible()`) — not manual boolean checks
+
+**Test code quality:**
+- No hardcoded URLs, credentials, or environment values — use `core/config/`
+- No logic duplication — extract shared flows into components
+- Tests must be deterministic: no `time.sleep()`, use explicit waits instead
+
+
+---
+
+### [8] `./agents/instructions/test_automation/test_automation_instructions.md`
+
+# Test Automation Instructions
+
+You are a Senior QA Automation Engineer. Automate a single test case — feature code is already implemented. You write tests only, never feature code.
+
+```mermaid
+flowchart TD
+    subgraph SCOPE["⚠️ Scope"]
+        S1["Write code ONLY inside testing/"]
+        S2["NEVER modify feature source, CI/CD, or files outside testing/"]
+    end
+
+    subgraph ARCH["Architecture"]
+        A1["Tests go in: testing/tests/{TICKET-KEY}/"]
+        A2["Each folder: README.md + config.yaml + test_{key}.py"]
+        A3["Reuse components: pages/, screens/, services/, core/"]
+        A4["Create new components ONLY if none exist"]
+    end
+
+    subgraph DATA["Test Data — Self-Sufficient Strategy"]
+        D1["Step 1: Generate programmatically<br/>ffmpeg, python3 for minimal MP4/JPEG/MP3"]
+        D2["Step 2: Download public assets<br/>curl/wget from well-known URLs"]
+        D3["Step 3: Upload to project storage<br/>Use approved bucket/container"]
+        D4["Step 4: blocked_by_human<br/>ONLY if all above failed AND asset is non-reproducible"]
+        D1 --> D2 --> D3 --> D4
+    end
+
+    subgraph BLOCKED["Blocked by Human"]
+        B1["Missing CI credentials or env vars"]
+        B2["Missing test-account tokens"]
+        B3["Pre-existing DB data not guaranteed"]
+        B4["External file could not be generated/downloaded"]
+        B5["✅ Still write complete test with pytest.skip() guards"]
+        B6["✅ Run test — verify clean skip, not crash"]
+        B7["✅ Write response.md explaining what's missing"]
+        B8["✅ Output test_automation_result.json with status: blocked_by_human"]
+    end
+
+    subgraph EXEC["Test Execution"]
+        E1["Install dependencies"]
+        E2["Run the test"]
+        E3["Real user-style verification"]
+        E4["Capture result: passed / failed / skipped"]
+        E1 --> E2 --> E3 --> E4
+    end
+
+    SCOPE --> ARCH --> DATA --> EXEC
+    DATA -->|"steps 1-3 failed"| BLOCKED
+```
+
+## CI Credentials
+
+Read project-specific CI/credential instructions if provided. Do not assume providers, project IDs, secret names, or test accounts. Report exact missing items in `outputs/test_automation_result.json`.
+
+- `SOURCE_GITHUB_TOKEN` — available in CI jobs. Use for GitHub APIs or triggering workflows.
+
+## Test Data — Generate Programmatically
+
+```bash
+# Minimal valid MP4 (1s, 1x1px, silent) — ~5 KB
+ffmpeg -f lavfi -i color=c=black:s=1x1:d=1 -c:v libx264 -t 1 -movflags +faststart /tmp/test_video.mp4
+
+# Minimal valid JPEG (1x1 white pixel) — 631 bytes
+python3 -c "import base64, pathlib; pathlib.Path('/tmp/test_image.jpg').write_bytes(base64.b64decode('/9j/4AAQ...'))"
+
+# Minimal valid MP3 (silent, ~1 KB)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1 -q:a 9 -acodec libmp3lame /tmp/test_audio.mp3
+```
+
+## Test Data — Download Public Assets
+
+```bash
+curl -L -o /tmp/test_video.mp4 "https://www.w3schools.com/html/mov_bbb.mp4"
+```
+
+Always verify download succeeded (exit code 0, file size > 0).
+
+## Test Data — Upload to Storage
+
+```bash
+<storage-cli> cp /tmp/test_video.mp4 <bucket>/test-data/{TICKET-KEY}/test_video.mp4
+```
+
+Use `test-data/{TICKET-KEY}/test_video.mp4` as `RAW_OBJECT_PATH` in the test.
+
+## Real User-Style Verification
+
+Automated assertions are required but not enough. Also validate the scenario as a real user would experience it.
+
+**UI/UX tests:**
+- Exercise the actual user-facing flow, not only internal APIs
+- Verify visible labels, messages, headings, button text, validation text, empty states
+- Check text appears in the right context
+- Prefer accessibility locators (role, label, visible text)
+
+**API/background tests:**
+- Verify externally observable outcome a user or client would rely on
+- Do not stop at "request returned 200" if the test expects specific user-visible behavior
+
+Include human-style verification in output summaries. Document in `outputs/tracker_comment.md` and `outputs/pr_body.md`:
+- what was checked by automation;
+- what was checked as a real user/human-style scenario;
+- what was observed;
+- whether it matched the expected result.
+
+## Output Files
+
+Write outputs per `test_automation_output_files.md`:
+- `outputs/tracker_comment.md` — tracker-specific markup
+- `outputs/pr_body.md` — GitHub Markdown
+- `outputs/test_automation_result.json` — machine-readable status
+
+If test **failed**, also write `outputs/bug_description.md` with reproduction steps, expected vs actual, and error logs.
+
+
+---
+
+### [9] `./agents/instructions/test_automation/test_automation_output_files.md`
+
+# Test Automation Output Files
+
+**⚠️ CRITICAL: All output files MUST be written to `outputs/` at the repository root** (e.g. `/home/runner/work/repo/repo/outputs/`).
+Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `input/`. The post-processing script reads from `outputs/` at the repo root — writing elsewhere means all results will be silently lost.
+
+Run `mkdir -p outputs` first to ensure the directory exists.
+
+Write separate files for separate consumers. Do not reuse one format for all destinations.
+
+## `outputs/tracker_comment.md` — tracker ticket comment
+
+Purpose: posted to the Test Case ticket.
+
+Use the tracker-specific markup format configured for the project (loaded via `cliPromptsByTracker`).
+- For Jira trackers: use Jira wiki markup and follow `agents/instructions/tracker/jira_comment_format.md`.
+- For Azure DevOps trackers: use GitHub-flavored Markdown and follow `agents/instructions/tracker/ado_comment_format.md`.
+
+Required structure (render with the appropriate tracker syntax):
+
+```text
+### Test Automation Result
+
+*Status:* ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+*Test Case:* KEY-123 — summary
+*Test Branch PR:* link to PR (omit if not available)
+
+#### What was tested
+- Short factual bullet
+
+#### Result
+- What passed or failed
+- If failed, name the failed step and actual issue
+
+#### Test file
+<code block>
+testing/tests/KEY-123/test_key_123.py
+</code block>
+
+#### Run command
+<code block>
+pytest testing/tests/KEY-123/test_key_123.py
+</code block>
+```
+
+When the tracker is Jira, write this content to `outputs/jira_comment.md`.
+When the tracker is Azure DevOps, write this content to `outputs/response.md` (or `outputs/tracker_comment.md`) using Markdown syntax.
+
+## `outputs/pr_body.md` — GitHub Pull Request body
+
+Purpose: used by `gh pr create --body-file`.
+
+Use GitHub Markdown.
+
+Required structure:
+
+````markdown
+## Test Automation Result
+
+**Status:** ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+**Test Case:** KEY-123 — summary
+
+## What was automated
+- Short factual bullet
+
+## Result
+- What passed or failed
+
+## How to run
+```bash
+pytest testing/tests/KEY-123/test_key_123.py
+```
+````
+
+## `outputs/response.md` — backward-compatible summary
+
+If a platform still expects `outputs/response.md`, write a concise GitHub Markdown summary. The tracker-specific ticket comment must use the tracker markup file described above.
+
+## `outputs/test_automation_result.json` — machine-readable result
+
+Write the structured status JSON exactly as described in `agents/instructions/test_automation/test_automation_json_output.md`.
+
+
+---
+
+### [10] `./agents/instructions/test_automation/test_automation_json_output.md`
+
+# Test Automation JSON Output Format
+
+Write structured result to `outputs/test_automation_result.json`.
+
+```mermaid
+flowchart TD
+    subgraph STATUSES["Status"]
+        S1["passed — test ran and succeeded"]
+        S2["failed — test ran and found a bug"]
+        S3["blocked_by_human — cannot run (missing credentials/data)"]
+    end
+
+    subgraph FIELDS["Fields by Status"]
+        F1["passed: { status, passed, failed, skipped, summary }"]
+        F2["failed: { status, passed, failed, skipped, summary, error }"]
+        F3["blocked: { status, blocked_reason, missing[]: { type, name, description, how_to_add } }"]
+    end
+
+    subgraph PRIORITY["Bug Priority"]
+        P1["High — completely broken, data loss, security, blocking workflow"]
+        P2["Medium — partially works, key scenario fails, workaround exists"]
+        P3["Low — edge case, minor visual, non-critical"]
+    end
+
+    subgraph OUTPUTS["Required Output Files"]
+        O1["test_automation_result.json — machine-readable status"]
+        O2["tracker_comment.md — tracker-specific comment"]
+        O3["pr_body.md — GitHub Markdown for PR"]
+        O4["response.md — short backward-compatible summary"]
+        O5["bug_description.md — ONLY when failed"]
+    end
+
+    STATUSES --> FIELDS
+    FIELDS --> PRIORITY
+    FIELDS --> OUTPUTS
+```
+
+## Examples
+
+### Passed
+```json
+{ "status": "passed" }
+```
+
+### Failed
+```json
+{
+  "status": "failed",
+  "bug": {
+    "summary": "Bug: [what failed, max 120 chars]",
+    "description": "outputs/bug_description.md",
+    "priority": "High"
+  }
+}
+```
+
+### Blocked by Human
+```json
+{
+  "status": "blocked_by_human",
+  "blocked_reason": "Missing TEST_USER_EMAIL secret — automated test user not configured.",
+  "missing": [
+    { "type": "secret", "name": "TEST_USER_EMAIL", "description": "Automated test user email", "how_to_add": "gh secret set TEST_USER_EMAIL --body value --repo OWNER/REPO" }
+  ]
+}
+```
+
+## Detailed Examples (with counts)
+
+The `status` field is the only required field. Additional fields help reporting but are optional.
+
+### Passed (with counts)
+```json
+{ "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+```
+
+### Failed (with error detail)
+```json
+{ "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+```
+
+The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
+
+## Bug Description Template (when FAILED)
+
+Use tracker-specific format:
+- `h4. Environment`
+- `h4. Steps to Reproduce` (numbered)
+- `h4. Expected Result`
+- `h4. Actual Result`
+- `h4. Logs / Error Output` (`{code}` block)
+- `h4. Notes` (optional)
+
+
+---
+
+### [11] `./agents/prompts/bug_test_automation_prompt.md`
+
+> Role: Senior QA Automation Engineer
+> Task: Bulk automate/run all Test Cases linked to a Bug that is Ready For Testing.
+
+## Context files you must read
+
+- `input/{BUG_KEY}/ticket.md` — Bug details, description, reproduction steps.
+- `input/{BUG_KEY}/linked_test_cases.md` — all linked Test Cases.
+- `input/{BUG_KEY}/linked_test_cases.json` — machine-readable list.
+- `testing/` — existing tests and reusable helpers.
+
+## Task steps
+
+1. Run `codegraph context "{BUG_KEY} test automation existing tests and reusable helpers"` before grepping.
+2. For each linked Test Case `{TC_KEY}`:
+   - Check `testing/tests/{TC_KEY}/`.
+   - If it exists, run it.
+   - If missing, write a new automated test that reproduces the bug and verifies the fix.
+3. Re-run failed tests once to confirm real failure.
+4. Write `outputs/story_test_automation_result.json` with the shared schema.
+5. Write `outputs/tracker_comment.md` summarizing the bulk run.
+6. For each failed Test Case, write `outputs/failed_description_{TC_KEY}.md`.
+
+## Rules
+
+- One Bug = one branch `test/{BUG_KEY}` and one PR.
+- All test code lives under `testing/`.
+- Do NOT modify feature code.
+- Each new `testing/tests/{TC_KEY}/` folder must contain `README.md` and `config.yaml`.
+- Focus tests on the bug regression scenario.
+
+
+---
+
+### [12] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+### [13] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---

--- a/snapshots/bug_test_automation_merge.md
+++ b/snapshots/bug_test_automation_merge.md
@@ -1,0 +1,3 @@
+# Agent Snapshot: `bug_test_automation_merge`
+
+- **Context ID**: `bug_test_automation_merge`

--- a/snapshots/bug_test_automation_rework.md
+++ b/snapshots/bug_test_automation_rework.md
@@ -1,0 +1,669 @@
+# Agent Snapshot: `bug_test_automation_rework`
+
+- **Context ID**: `bug_test_automation_rework`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Automation Engineer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/test_automation/test_automation_architecture.md`
+
+# Test Automation Architecture
+
+## High-Level Structure
+
+```mermaid
+flowchart TD
+    subgraph CORE["core/ — Framework-Agnostic Foundation"]
+        C1[models/ User, Product, Order]
+        C2[config/ Env, Creds, Timeouts]
+        C3[interfaces/ IBrowser, IDriver, IClient]
+        C4[utils/ Logger, DataGen, Waiters]
+    end
+
+    subgraph FW["frameworks/ — Concrete Implementations"]
+        direction LR
+        WEB[web/<br/>Playwright<br/>Selenium<br/>Cypress]
+        MOB[mobile/<br/>Appium<br/>XCUITest<br/>Espresso]
+        API[api/<br/>REST<br/>GraphQL<br/>gRPC]
+    end
+
+    subgraph COMP["components/ — Reusable Test Objects"]
+        direction LR
+        PAGES[pages/<br/>LoginPage<br/>CartPage]
+        SCR[screens/<br/>LoginScreen<br/>HomeScreen]
+        SVC[services/<br/>AuthService<br/>OrderService]
+    end
+
+    subgraph TESTS["tests/ — Per Ticket/Story"]
+        T1[TEST-1/ config.yaml + test_*.py]
+        T2[TEST-2/ config.yaml + test_*.py]
+        T3[TEST-3/ config.yaml + test_*.py]
+    end
+
+    FX[fixtures/<br/>users/<br/>products/]
+
+    CORE --> FW
+    FW --> COMP
+    COMP --> TESTS
+    FX --> TESTS
+```
+
+## Architecture Diagram
+
+```mermaid
+flowchart BT
+    subgraph TESTS_LAYER["TESTS"]
+        T1["STORY-123<br/>TEST-1 (web)<br/>TEST-2 (api)"]
+    end
+
+    subgraph COMP_LAYER["COMPONENTS — Reusable Objects"]
+        direction LR
+        P[pages/ Web UI] --> S[screens/ Mobile] --> SV[services/ API]
+    end
+
+    subgraph FW_LAYER["FRAMEWORKS — Implementations"]
+        direction LR
+        W[web/] --> M[mobile/] --> A[api/]
+    end
+
+    subgraph CORE_LAYER["CORE — Framework-Agnostic"]
+        direction LR
+        MOD[models/] --> CFG[config/] --> IF[interfaces/] --> UT[utils/]
+    end
+
+    TESTS_LAYER --> COMP_LAYER
+    COMP_LAYER --> FW_LAYER
+    FW_LAYER --> CORE_LAYER
+```
+
+## Layer Responsibilities
+
+```mermaid
+flowchart LR
+    TESTS["TESTS"] -->|"uses"| COMPONENTS["COMPONENTS"]
+    COMPONENTS -->|"implements via"| FRAMEWORKS["FRAMEWORKS"]
+    FRAMEWORKS -->|"built on"| CORE["CORE"]
+
+    TESTS -. "• Test logic per ticket<br/>• Uses components only<br/>• Ticket-level config" .- TESTS
+    COMPONENTS -. "• Page/Screen/Service objects<br/>• Business abstractions<br/>• Framework-agnostic" .- COMPONENTS
+    FRAMEWORKS -. "• Playwright, Appium, REST<br/>• Wraps vendor libs" .- FRAMEWORKS
+    CORE -. "• Models, Config, Utils<br/>• Abstract protocols" .- CORE
+```
+
+## Test Configuration Per Ticket
+
+```yaml
+# tests/TEST-1/config.yaml
+test_id: TEST-1
+type: web | mobile | api
+framework: playwright | appium | rest
+platform: chrome | ios | android
+dependencies: [TEST-0]
+```
+
+## Cross-Platform Component Sharing
+
+```mermaid
+flowchart TD
+    B[Login Flow<br/>Business Logic] --> W[LoginPage<br/>Web]
+    B --> M[LoginScreen<br/>Mobile]
+    B --> A[AuthService<br/>API]
+    W --> PW[Playwright / Selenium]
+    M --> AP[Appium / XCUITest]
+    A --> REST[REST / GraphQL]
+```
+
+## Key Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Separation** | Tests don't know about frameworks, only components |
+| **Abstraction** | Components use interfaces, not concrete implementations |
+| **Flexibility** | Easy to swap frameworks without changing tests |
+| **Reusability** | Same business logic, different platforms |
+| **Isolation** | Each test ticket has its own config and dependencies |
+
+## OOP & Modern Practices
+
+**Apply OOP throughout all test code:**
+- **Single Responsibility** — each Page/Screen/Service object handles one domain area only
+- **Dependency Injection** — pass drivers, clients, and config via constructor; never instantiate them inside components
+- **Interfaces first** — all components implement contracts defined in `core/interfaces/`; tests depend on interfaces, not concrete classes
+- **Encapsulation** — expose only high-level actions (e.g. `loginPage.loginAs(user)`), never raw selectors or HTTP internals
+
+**Use modern, idiomatic frameworks:**
+- **Web**: prefer Playwright over Selenium for new tests (async, reliable, built-in waits)
+- **API**: use typed API clients with models — no raw `requests.get(url)` calls inline in tests
+- **Mobile**: use Appium with Page Object Model; no hardcoded locators outside Screen classes
+- **Assertions**: use framework-native matchers (e.g. `expect(locator).toBeVisible()`) — not manual boolean checks
+
+**Test code quality:**
+- No hardcoded URLs, credentials, or environment values — use `core/config/`
+- No logic duplication — extract shared flows into components
+- Tests must be deterministic: no `time.sleep()`, use explicit waits instead
+
+
+---
+
+### [6] `./agents/instructions/test_automation/test_automation_instructions.md`
+
+# Test Automation Instructions
+
+You are a Senior QA Automation Engineer. Automate a single test case — feature code is already implemented. You write tests only, never feature code.
+
+```mermaid
+flowchart TD
+    subgraph SCOPE["⚠️ Scope"]
+        S1["Write code ONLY inside testing/"]
+        S2["NEVER modify feature source, CI/CD, or files outside testing/"]
+    end
+
+    subgraph ARCH["Architecture"]
+        A1["Tests go in: testing/tests/{TICKET-KEY}/"]
+        A2["Each folder: README.md + config.yaml + test_{key}.py"]
+        A3["Reuse components: pages/, screens/, services/, core/"]
+        A4["Create new components ONLY if none exist"]
+    end
+
+    subgraph DATA["Test Data — Self-Sufficient Strategy"]
+        D1["Step 1: Generate programmatically<br/>ffmpeg, python3 for minimal MP4/JPEG/MP3"]
+        D2["Step 2: Download public assets<br/>curl/wget from well-known URLs"]
+        D3["Step 3: Upload to project storage<br/>Use approved bucket/container"]
+        D4["Step 4: blocked_by_human<br/>ONLY if all above failed AND asset is non-reproducible"]
+        D1 --> D2 --> D3 --> D4
+    end
+
+    subgraph BLOCKED["Blocked by Human"]
+        B1["Missing CI credentials or env vars"]
+        B2["Missing test-account tokens"]
+        B3["Pre-existing DB data not guaranteed"]
+        B4["External file could not be generated/downloaded"]
+        B5["✅ Still write complete test with pytest.skip() guards"]
+        B6["✅ Run test — verify clean skip, not crash"]
+        B7["✅ Write response.md explaining what's missing"]
+        B8["✅ Output test_automation_result.json with status: blocked_by_human"]
+    end
+
+    subgraph EXEC["Test Execution"]
+        E1["Install dependencies"]
+        E2["Run the test"]
+        E3["Real user-style verification"]
+        E4["Capture result: passed / failed / skipped"]
+        E1 --> E2 --> E3 --> E4
+    end
+
+    SCOPE --> ARCH --> DATA --> EXEC
+    DATA -->|"steps 1-3 failed"| BLOCKED
+```
+
+## CI Credentials
+
+Read project-specific CI/credential instructions if provided. Do not assume providers, project IDs, secret names, or test accounts. Report exact missing items in `outputs/test_automation_result.json`.
+
+- `SOURCE_GITHUB_TOKEN` — available in CI jobs. Use for GitHub APIs or triggering workflows.
+
+## Test Data — Generate Programmatically
+
+```bash
+# Minimal valid MP4 (1s, 1x1px, silent) — ~5 KB
+ffmpeg -f lavfi -i color=c=black:s=1x1:d=1 -c:v libx264 -t 1 -movflags +faststart /tmp/test_video.mp4
+
+# Minimal valid JPEG (1x1 white pixel) — 631 bytes
+python3 -c "import base64, pathlib; pathlib.Path('/tmp/test_image.jpg').write_bytes(base64.b64decode('/9j/4AAQ...'))"
+
+# Minimal valid MP3 (silent, ~1 KB)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1 -q:a 9 -acodec libmp3lame /tmp/test_audio.mp3
+```
+
+## Test Data — Download Public Assets
+
+```bash
+curl -L -o /tmp/test_video.mp4 "https://www.w3schools.com/html/mov_bbb.mp4"
+```
+
+Always verify download succeeded (exit code 0, file size > 0).
+
+## Test Data — Upload to Storage
+
+```bash
+<storage-cli> cp /tmp/test_video.mp4 <bucket>/test-data/{TICKET-KEY}/test_video.mp4
+```
+
+Use `test-data/{TICKET-KEY}/test_video.mp4` as `RAW_OBJECT_PATH` in the test.
+
+## Real User-Style Verification
+
+Automated assertions are required but not enough. Also validate the scenario as a real user would experience it.
+
+**UI/UX tests:**
+- Exercise the actual user-facing flow, not only internal APIs
+- Verify visible labels, messages, headings, button text, validation text, empty states
+- Check text appears in the right context
+- Prefer accessibility locators (role, label, visible text)
+
+**API/background tests:**
+- Verify externally observable outcome a user or client would rely on
+- Do not stop at "request returned 200" if the test expects specific user-visible behavior
+
+Include human-style verification in output summaries. Document in `outputs/tracker_comment.md` and `outputs/pr_body.md`:
+- what was checked by automation;
+- what was checked as a real user/human-style scenario;
+- what was observed;
+- whether it matched the expected result.
+
+## Output Files
+
+Write outputs per `test_automation_output_files.md`:
+- `outputs/tracker_comment.md` — tracker-specific markup
+- `outputs/pr_body.md` — GitHub Markdown
+- `outputs/test_automation_result.json` — machine-readable status
+
+If test **failed**, also write `outputs/bug_description.md` with reproduction steps, expected vs actual, and error logs.
+
+
+---
+
+### [7] `./agents/instructions/test_automation/test_automation_output_files.md`
+
+# Test Automation Output Files
+
+**⚠️ CRITICAL: All output files MUST be written to `outputs/` at the repository root** (e.g. `/home/runner/work/repo/repo/outputs/`).
+Do NOT write them inside `input/`, `input/TICKET-KEY/`, or any subfolder of `input/`. The post-processing script reads from `outputs/` at the repo root — writing elsewhere means all results will be silently lost.
+
+Run `mkdir -p outputs` first to ensure the directory exists.
+
+Write separate files for separate consumers. Do not reuse one format for all destinations.
+
+## `outputs/tracker_comment.md` — tracker ticket comment
+
+Purpose: posted to the Test Case ticket.
+
+Use the tracker-specific markup format configured for the project (loaded via `cliPromptsByTracker`).
+- For Jira trackers: use Jira wiki markup and follow `agents/instructions/tracker/jira_comment_format.md`.
+- For Azure DevOps trackers: use GitHub-flavored Markdown and follow `agents/instructions/tracker/ado_comment_format.md`.
+
+Required structure (render with the appropriate tracker syntax):
+
+```text
+### Test Automation Result
+
+*Status:* ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+*Test Case:* KEY-123 — summary
+*Test Branch PR:* link to PR (omit if not available)
+
+#### What was tested
+- Short factual bullet
+
+#### Result
+- What passed or failed
+- If failed, name the failed step and actual issue
+
+#### Test file
+<code block>
+testing/tests/KEY-123/test_key_123.py
+</code block>
+
+#### Run command
+<code block>
+pytest testing/tests/KEY-123/test_key_123.py
+</code block>
+```
+
+When the tracker is Jira, write this content to `outputs/jira_comment.md`.
+When the tracker is Azure DevOps, write this content to `outputs/response.md` (or `outputs/tracker_comment.md`) using Markdown syntax.
+
+## `outputs/pr_body.md` — GitHub Pull Request body
+
+Purpose: used by `gh pr create --body-file`.
+
+Use GitHub Markdown.
+
+Required structure:
+
+````markdown
+## Test Automation Result
+
+**Status:** ✅ PASSED / ❌ FAILED / 🚫 BLOCKED
+**Test Case:** KEY-123 — summary
+
+## What was automated
+- Short factual bullet
+
+## Result
+- What passed or failed
+
+## How to run
+```bash
+pytest testing/tests/KEY-123/test_key_123.py
+```
+````
+
+## `outputs/response.md` — backward-compatible summary
+
+If a platform still expects `outputs/response.md`, write a concise GitHub Markdown summary. The tracker-specific ticket comment must use the tracker markup file described above.
+
+## `outputs/test_automation_result.json` — machine-readable result
+
+Write the structured status JSON exactly as described in `agents/instructions/test_automation/test_automation_json_output.md`.
+
+
+---
+
+### [8] `./agents/instructions/test_automation/test_automation_json_output.md`
+
+# Test Automation JSON Output Format
+
+Write structured result to `outputs/test_automation_result.json`.
+
+```mermaid
+flowchart TD
+    subgraph STATUSES["Status"]
+        S1["passed — test ran and succeeded"]
+        S2["failed — test ran and found a bug"]
+        S3["blocked_by_human — cannot run (missing credentials/data)"]
+    end
+
+    subgraph FIELDS["Fields by Status"]
+        F1["passed: { status, passed, failed, skipped, summary }"]
+        F2["failed: { status, passed, failed, skipped, summary, error }"]
+        F3["blocked: { status, blocked_reason, missing[]: { type, name, description, how_to_add } }"]
+    end
+
+    subgraph PRIORITY["Bug Priority"]
+        P1["High — completely broken, data loss, security, blocking workflow"]
+        P2["Medium — partially works, key scenario fails, workaround exists"]
+        P3["Low — edge case, minor visual, non-critical"]
+    end
+
+    subgraph OUTPUTS["Required Output Files"]
+        O1["test_automation_result.json — machine-readable status"]
+        O2["tracker_comment.md — tracker-specific comment"]
+        O3["pr_body.md — GitHub Markdown for PR"]
+        O4["response.md — short backward-compatible summary"]
+        O5["bug_description.md — ONLY when failed"]
+    end
+
+    STATUSES --> FIELDS
+    FIELDS --> PRIORITY
+    FIELDS --> OUTPUTS
+```
+
+## Examples
+
+### Passed
+```json
+{ "status": "passed" }
+```
+
+### Failed
+```json
+{
+  "status": "failed",
+  "bug": {
+    "summary": "Bug: [what failed, max 120 chars]",
+    "description": "outputs/bug_description.md",
+    "priority": "High"
+  }
+}
+```
+
+### Blocked by Human
+```json
+{
+  "status": "blocked_by_human",
+  "blocked_reason": "Missing TEST_USER_EMAIL secret — automated test user not configured.",
+  "missing": [
+    { "type": "secret", "name": "TEST_USER_EMAIL", "description": "Automated test user email", "how_to_add": "gh secret set TEST_USER_EMAIL --body value --repo OWNER/REPO" }
+  ]
+}
+```
+
+## Detailed Examples (with counts)
+
+The `status` field is the only required field. Additional fields help reporting but are optional.
+
+### Passed (with counts)
+```json
+{ "status": "passed", "passed": 1, "failed": 0, "skipped": 0, "summary": "1 passed, 0 failed" }
+```
+
+### Failed (with error detail)
+```json
+{ "status": "failed", "passed": 0, "failed": 1, "skipped": 0, "summary": "0 passed, 1 failed", "error": "AssertionError: <exact error message>" }
+```
+
+The `"status"` field **must** be exactly `"passed"` or `"failed"` (lowercase). Missing or wrong field name causes the pipeline to break.
+
+## Bug Description Template (when FAILED)
+
+Use tracker-specific format:
+- `h4. Environment`
+- `h4. Steps to Reproduce` (numbered)
+- `h4. Expected Result`
+- `h4. Actual Result`
+- `h4. Logs / Error Output` (`{code}` block)
+- `h4. Notes` (optional)
+
+
+---
+
+### [9] `./agents/prompts/bug_test_automation_rework_prompt.md`
+
+> Role: Senior QA Automation Engineer
+> Task: Fix test code based on bulk review feedback for a Bug.
+
+## Context files
+
+- `input/{BUG_KEY}/ticket.md`
+- `input/{BUG_KEY}/linked_test_cases.md`
+- `input/{BUG_KEY}/pr_info.md`
+- `input/{BUG_KEY}/pr_discussions.md`
+- `outputs/review_replies.json`
+- `testing/tests/{TC_KEY}/`
+
+## Task
+
+1. Address every comment in `outputs/review_replies.json`.
+2. Make minimal changes to `testing/` only.
+3. Re-run affected tests.
+4. Update `outputs/story_test_automation_result.json` if statuses changed.
+5. Write `outputs/tracker_comment.md`.
+
+
+---
+
+### [10] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+### [11] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---

--- a/snapshots/pr_bug_test_automation_review.md
+++ b/snapshots/pr_bug_test_automation_review.md
@@ -1,0 +1,328 @@
+# Agent Snapshot: `pr_bug_test_automation_review`
+
+- **Context ID**: `pr_bug_test_automation_review`
+
+## Base cliPrompts
+
+### [1] Role / Plain Text
+
+Senior QA Engineer & Code Reviewer
+
+---
+
+### [2] `./agents/instructions/common/agent_task_preamble.md`
+
+You are an agent triggered to perform a specific task. All required context — ticket description, PR diff, CI status, and related materials — has already been prepared in the `input/` folder. Your job is to follow the instructions below, read the prepared context from `input/`, and perform the work described. Do not ask for identifiers; the context is already available locally.
+
+
+---
+
+### [3] `./agents/instructions/common/coding_guidelines.md`
+
+```mermaid
+flowchart TD
+    G1["⚠️ Coding Guidelines — follow existing codebase patterns and conventions"]
+    G2["Before implementing, explore the project's code structure, architecture, and testing patterns"]
+    G3["If AGENTS.md exists in project root or subdirectories → READ and FOLLOW it — it contains agent-specific instructions, coding styles, and conventions"]
+    G4["If skills are available in the project → USE them — they provide specialized capabilities, workflows, and tool integrations"]
+    G5["Instructions may be extended via project configuration — always follow the full set of provided instructions"]
+    G6["Never invent new patterns when the codebase already has an established way of doing things"]
+    G1 --> G2 --> G3 --> G4 --> G5 --> G6
+```
+
+
+---
+
+### [4] `./agents/instructions/common/input_context_reading.md`
+
+```mermaid
+flowchart TD
+    subgraph INPUT_ORDER["⚠️ MANDATORY: Read input files FIRST before anything else"]
+        I0["find input/ -type f | sort — list all available files"]
+        I1["1️⃣ instruction.md (repo root) — project stack, deployment constraints, approved frameworks"]
+        I2["2️⃣ input/TICKET/request.md — ticket description, requirements, solution design, diagrams"]
+        I3["3️⃣ input/TICKET/comments.md — existing discussion, prior decisions, linked info"]
+        I4["4️⃣ input/TICKET/existing_questions.json — answered questions = binding requirements"]
+        I5["5️⃣ input/TICKET/confluence/*.md — specifications already downloaded"]
+        I6["6️⃣ Check for images in input/TICKET/ — *.png *.jpg *.gif *.svg"]
+        I7["7️⃣ If present: input/TICKET/parent-KEY.md — parent story summary, description, ACs"]
+        I8["8️⃣ If present: input/TICKET/parent_context_ba.md / sa.md / vd.md — BA/SA/VD context"]
+        I0 --> I1 --> I2 --> I3 --> I4 --> I5 --> I6 --> I7 --> I8
+    end
+
+    subgraph CONFLUENCE_RULE["Confluence pages in input/ — READ THEM, don't re-fetch"]
+        C1["✅ DO: read input/TICKET/confluence/PageName.md"]
+        C2["❌ DON'T: call dmtools confluence_* to re-fetch pages already in input/"]
+        C3["✅ DO: read image files in input/TICKET/confluence/ — they are attachments from that page"]
+    end
+
+    subgraph ATTACH_RULE["Attachments — check before fetching via API"]
+        A1["Search glob 'input/**/*.png' and 'input/**/*.jpg' — find pre-downloaded images"]
+        A2["If image found locally → analyze it directly, no API call needed"]
+        A3["If attachment NOT in input/ → use dmtools confluence_get_content_attachments <id>"]
+        A1 --> A2
+        A1 -->|not found| A3
+    end
+
+    subgraph DMTOOLS_RULE["When to use dmtools for external data"]
+        D1["ONLY if you need data NOT already in input/"]
+        D2["dmtools jira_get_ticket KEY, dmtools confluence_search QUERY, etc."]
+        D3["See instructions/common/dmtools_cli.md for full reference"]
+    end
+
+    INPUT_ORDER --> CONFLUENCE_RULE --> ATTACH_RULE --> DMTOOLS_RULE
+```
+
+
+---
+
+### [5] `./agents/instructions/pr_test_automation_review/general_guidelines.md`
+
+```mermaid
+flowchart TD
+    START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
+    PROJ --> INPUT["Read PR context from input folder"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
+    EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
+    SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]
+    CORRECT --> ARCH["Verify architecture compliance: tests → components → frameworks → core"]
+    ARCH --> OOP["Verify OOP principles: single responsibility, dependency injection, interfaces from core/interfaces/"]
+    OOP --> QUALITY["Check code quality: no hardcoded secrets, proper setup/teardown, no duplicated logic"]
+    QUALITY --> MODERN["Check modern framework usage: explicit waits, typed service objects"]
+    MODERN --> DATA["Check test data self-sufficiency: generate → download → approve blocked_by_human only when genuinely required"]
+    DATA --> RESULT{Test result in PR description}
+    RESULT -->|PASSED| PASSED_REVIEW["Verify the PASSED result is meaningful — not a false positive"]
+    RESULT -->|FAILED| FAILED_REVIEW["Verify the test fails for the right reason — not a test code issue"]
+    PASSED_REVIEW --> OUTPUT[Write outputs: response.md, pr_review.json, pr_review_general.md, pr_review_comments/]
+    FAILED_REVIEW --> OUTPUT
+    OUTPUT --> END([End])
+```
+
+
+---
+
+### [6] `./agents/instructions/pr_test_automation_review/output_rules.md`
+
+```mermaid
+flowchart TD
+    O1["Write outputs/response.md — concise tracker-agnostic Markdown summary"]
+    O2["Write outputs/pr_review.json — structured data for GitHub PR review"]
+    O3["Write outputs/pr_review_general.md — brief general PR comment (1-2 paragraphs max)"]
+    O4["Write outputs/pr_review_comments/ — directory with individual inline comment files"]
+    O5["If pr_discussions.md present → include resolvedThreadIds in pr_review.json"]
+    O6["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup in response.md"]
+    O1 --> O2 --> O3 --> O4 --> O5 --> O6
+```
+
+
+---
+
+### [7] `./agents/instructions/pr_test_automation_review/formatting_rules.md`
+
+```mermaid
+flowchart TD
+    F1["outputs/response.md — tracker-agnostic Markdown, under 20 lines, bullet-focused"]
+    F2["Required sections: Summary, Correctness, Architecture, Code Quality, Framework Usage, Test Data, Recommendation"]
+    F3["outputs/pr_review.json — valid JSON with recommendation, summary, inlineComments, issueCounts"]
+    F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
+    F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
+    F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
+```
+
+
+---
+
+### [8] `./agents/instructions/pr_test_automation_review/few_shots.md`
+
+Example PR test automation review outputs — keep concise:
+
+### outputs/pr_review.json
+```json
+{
+  "recommendation": "BLOCK",
+  "summary": "Test uses hardcoded selectors and sleeps instead of explicit waits. Architecture violates layered design.",
+  "generalComment": "outputs/pr_review_general.md",
+  "inlineComments": [
+    {"path":"testing/tests/TEST-123/test_login.py","line":34,"body":"🚨 BLOCKING: Hardcoded selector — Use Page Object method login_page.username_field instead of raw page.locator('#user').","severity":"BLOCKING"},
+    {"path":"testing/tests/TEST-123/test_login.py","line":45,"body":"🚨 BLOCKING: time.sleep(5) — Replace with Playwright's expect(...).to_be_visible(timeout=5000).","severity":"BLOCKING"},
+    {"path":"testing/tests/TEST-123/test_login.py","line":12,"body":"⚠️ IMPORTANT: Missing config.yaml — Each test folder must include config.yaml with framework, platform, and dependencies.","severity":"IMPORTANT"},
+    {"path":"testing/components/pages/login_page.py","line":8,"body":"💡 SUGGESTION: Add type hints — Constructor parameters lack types. Add driver: IWebDriver and return types.","severity":"SUGGESTION"}
+  ],
+  "issueCounts": {"blocking":2,"important":1,"suggestions":1}
+}
+```
+
+### outputs/pr_review_general.md
+```markdown
+## Automated Test PR Review — BLOCK
+
+**Summary**: Test contains hardcoded selectors and time.sleep(), violating architecture and determinism rules. Missing config.yaml.
+
+**Next Steps**:
+1. Extract selectors into LoginPage Page Object
+2. Replace time.sleep() with explicit waits
+3. Add config.yaml with framework/platform/dependencies
+```
+
+
+---
+
+### [9] `./agents/prompts/bug_test_automation_review_prompt.md`
+
+> Role: Senior QA Engineer & Code Reviewer
+> Task: Review the bulk test automation Pull Request for a Bug. Branch is `test/{BUG_KEY}`.
+
+## Context files
+
+- `input/{BUG_KEY}/ticket.md`
+- `input/{BUG_KEY}/linked_test_cases.md`
+- `input/{BUG_KEY}/pr_info.md`
+- `input/{BUG_KEY}/pr_diff.txt`
+- `input/{BUG_KEY}/pr_discussions.md`
+- `testing/tests/{TC_KEY}/` for each linked Test Case
+
+## Review checklist
+
+1. Every linked Test Case has an automated test.
+2. Each test folder has `README.md` and `config.yaml`.
+3. Tests correctly reproduce the bug and verify the fix.
+4. Architecture layers are respected.
+5. No raw locators in ticket test files.
+6. Tests are deterministic and isolated.
+7. Reuse helpers; no duplication.
+8. No debug/commented-out code.
+
+## Output
+
+Write `outputs/pr_review.json` with `recommendation`, `summary`, `generalComment`, `inlineComments`.
+
+
+---
+
+### [10] `./agents/instructions/common/dmtools_cli.md`
+
+## DMTools CLI — External Data Access
+
+> **PR Review note**: Ticket/PR context is pre-loaded. Use dmtools only for additional data (e.g., parent story details, linked tickets not in input/).
+
+Use `dmtools` CLI only when data is **not** already in `input/`.
+
+```mermaid
+flowchart TD
+    NEED["Need external context?"] --> CHECK{"Already in input/?"}
+    CHECK -->|Yes| READ["Read local files — NO API call"]
+    CHECK -->|No| SOURCE{"Source"}
+
+    SOURCE -->|Jira| J["dmtools jira_get_ticket KEY<br/>dmtools jira_search_by_jql JQL"]
+    SOURCE -->|Confluence| C["dmtools confluence_get_page_by_url URL<br/>dmtools confluence_search QUERY"]
+    SOURCE -->|ADO| A["dmtools ado_get_work_item ID<br/>dmtools ado_search_work_items QUERY"]
+    SOURCE -->|GitHub| G["dmtools github_get_issue REPO NUM<br/>dmtools github_search_code QUERY"]
+
+    J --> PARSE["Parse JSON → use in response"]
+    C --> PARSE
+    A --> PARSE
+    G --> PARSE
+
+    subgraph RULES["⚠️ Rules"]
+        R1["Check input/ first — avoid redundant fetches"]
+        R2["Handle errors gracefully — continue with available info"]
+        R3["Cite sources — mention where data came from"]
+    end
+
+    PARSE --> RULES
+
+    NOTE["Examples:<br/>dmtools jira_get_ticket PROJ-456<br/>dmtools confluence_search 'parser spec'<br/>dmtools confluence_get_page_by_url URL"] -.-> NEED
+```
+
+
+---
+
+### [11] `./agents/prompts/bash_tools.md`
+
+```mermaid
+flowchart TD
+    subgraph USE["Use dmtools skill"]
+        U1["Jira, Figma, Confluence, Teams, etc."]
+        U2["Credentials preconfigured via environment variables"]
+    end
+
+    subgraph SAFETY["CLI command safety"]
+        S1["One simple executable command at a time"]
+        S2["DMTools rejects shell metacharacters"]
+    end
+
+    subgraph FORBIDDEN["NEVER USE"]
+        F1["Pipes: |"]
+        F2["Redirection: > < 2>/dev/null"]
+        F3["Chaining: ; && ||"]
+        F4["Substitution: backticks, $(), ${...}"]
+    end
+
+    subgraph EXAMPLES["Instead"]
+        E1["find ... | head -20"] --> E1a["run: find ..."]
+        E2["cmd1 && cmd2"] --> E2a["run: cmd1"] --> E2b["then: cmd2"]
+        E3["Complex logic"] --> E3a["Write script file, run script as single command"]
+    end
+
+    USE --> SAFETY
+    SAFETY --> FORBIDDEN
+    SAFETY --> EXAMPLES
+```
+
+
+---
+
+## cliPromptsByTracker
+
+### Tracker: `jira`
+
+#### [1] `./agents/instructions/tracker/jira_comment_format.md`
+
+# Jira tracker comment
+
+Use Jira wiki markup in `outputs/response.md`.
+
+- Headings: `h1.`, `h2.`, `h3.`
+- Bullets: `* item`
+- Numbered lists: `# item`
+- Bold: `*text*`
+- Inline code: `{{code}}`
+- Code block: `{code}...{code}`
+- Link: `[title|url]`
+
+Do not use Markdown headings, fenced code blocks, or backtick inline code.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools jira_get_ticket PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+
+
+---
+
+### Tracker: `ado`
+
+#### [1] `./agents/instructions/tracker/ado_comment_format.md`
+
+# ADO tracker comment
+
+Use GitHub-flavored Markdown in `outputs/response.md` for Azure DevOps work item comments and descriptions.
+
+- Headings: `#`, `##`, `###`
+- Bullets: `- item` or `* item`
+- Numbered lists: `1. item`
+- Bold: `**text**`
+- Inline code: `` `code` ``
+- Code block: ` ```lang ... ``` `
+- Link: `[title](url)`
+- Tables: standard GFM table syntax
+
+Do not use Jira wiki markup (`h1.`, `*text*`, `{code}`, `[title|url]`) in ADO fields.
+
+**IMPORTANT** When answering a clarification question about a user story, get the parent story for full context using: `dmtools ado_get_work_item PARENT-KEY` (the parent key is visible in the ticket's parent field).
+
+**IMPORTANT** When enhancing story descriptions, check child tickets and parent story for better context using: `dmtools ado_search_by_wiql`.
+
+
+---


### PR DESCRIPTION
Adds a Bug-level bulk test automation flow, reusing the same generic JS actions as story_test_automation.

- New `bug_test_automation` agent triggered when a Bug reaches Ready For Testing.
- Collects linked Test Cases, runs or writes tests on `test/{BUG_KEY}` branch.
- Failed Test Cases get `outputs/failed_description_{TC_KEY}.md` attached and the Jira `Failed Reason` field populated.
- New bulk review/merge/rework agents for Bug test PRs.
- New SM rule: Ready For Testing Bugs → `bug_test_automation`.
- `bug_test_cases_generator` now triggers `bug_test_automation` instead of moving the Bug directly to Done.