### PR TITLE
test: fix pre-existing unit-test failures

### DIFF
--- a/js/unit-tests/testRunner.js
+++ b/js/unit-tests/testRunner.js
@@ -15,6 +15,17 @@
 var _results_ = { passed: 0, failed: 0, errors: [] };
 var _currentSuite_ = 'default';
 
+// Provide a stub java global for tests that mock java.lang.System.getenv.
+// In a real GraalJS environment java is already present; we never overwrite it.
+if (typeof java === 'undefined') {
+    var _javaStub_ = { lang: { System: { getenv: function() { return null; } } } };
+    if (typeof globalThis !== 'undefined') {
+        globalThis.java = _javaStub_;
+    } else if (typeof this !== 'undefined') {
+        this.java = _javaStub_;
+    }
+}
+
 // Pre-loaded base modules available to all test files as globals
 var configModule = null;
 var configLoaderModule = null;

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -934,7 +934,17 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.notOk(decoded.params.additionalInstructions, 'no additionalInstructions when not configured');
-        assert.equal(decoded.params.agentParams.instructions.length, 1, 'default agent instructions preserved');
+        assert.ok(decoded.params.agentParams, 'agentParams present');
+        // The story_development agent now keeps its default instructions in cliPrompts,
+        // not in agentParams.instructions, so we verify the default cliPrompts survive.
+        var storyDevRaw = file_read({ path: 'agents/story_development.json' }) ||
+                          file_read({ path: 'story_development.json' });
+        var storyDevJson = JSON.parse(storyDevRaw);
+        var defaultCliPrompts = storyDevJson.params.cliPrompts;
+        assert.ok(Array.isArray(decoded.params.cliPrompts) && decoded.params.cliPrompts.length > 0,
+            'default cliPrompts preserved');
+        assert.deepEqual(decoded.params.cliPrompts, defaultCliPrompts,
+            'default cliPrompts match the agent JSON');
     });
 
     test('injects cliPrompts and agent/job param patches from config into encoded_config', function() {
@@ -969,8 +979,15 @@ suite('smAgent: additionalInstructions in encoded_config', function() {
         var inputs = JSON.parse(sm.capturedTriggers[0].inputs);
         var decoded = JSON.parse(decodeURIComponent(inputs.encoded_config));
         assert.equal(decoded.params.cliPrompt, './.dmtools/prompts/main.md');
-        // cliPrompts = agent JSON cliPrompts (bash_tools) + config cliPrompts (role, focus)
-        assert.deepEqual(decoded.params.cliPrompts, ['./agents/prompts/bash_tools.md', './.dmtools/prompts/role.md', './.dmtools/prompts/focus.md']);
+        // cliPrompts = agent JSON cliPrompts + config cliPrompts (role, focus)
+        var storyDevRaw = file_read({ path: 'agents/story_development.json' }) ||
+                          file_read({ path: 'story_development.json' });
+        var storyDevJson = JSON.parse(storyDevRaw);
+        var expectedCliPrompts = storyDevJson.params.cliPrompts.concat([
+            './.dmtools/prompts/role.md',
+            './.dmtools/prompts/focus.md'
+        ]);
+        assert.deepEqual(decoded.params.cliPrompts, expectedCliPrompts);
         assert.equal(decoded.params.agentParams.aiRole, 'Senior Engineer');
         assert.equal(decoded.params.agentParams.customFlag, true);
         assert.deepEqual(decoded.params.confluencePages, ['./.dmtools/instructions/project.md']);

--- a/js/unit-tests/test_timerAutoCommitAndSave.js
+++ b/js/unit-tests/test_timerAutoCommitAndSave.js
@@ -180,10 +180,12 @@ suite('timerAutoCommitAndSave — saveSessionArtefact', function() {
             currentCliOutput: 'Hello CLI output\nline 2'
         });
 
-        // file_write should write the CLI output
+        // file_write should write the CLI output wrapped in a snapshot
         assert.equal(fileWriteCalls.length, 1);
         assert.equal(fileWriteCalls[0].path, '.dmtools-session-output.log');
-        assert.equal(fileWriteCalls[0].content, 'Hello CLI output\nline 2');
+        assert.contains(fileWriteCalls[0].content, 'Hello CLI output\nline 2', 'raw CLI output preserved');
+        assert.contains(fileWriteCalls[0].content, 'TIMER SESSION SNAPSHOT START', 'snapshot header present');
+        assert.contains(fileWriteCalls[0].content, 'TIMER SESSION SNAPSHOT END', 'snapshot footer present');
 
         // Should call github_get_or_create_draft_release
         assert.equal(releaseCalls.length, 1);


### PR DESCRIPTION
Fixes three classes of pre-existing failures in `dmtools run js/unit-tests/run_all.json`:

1. **java global stub in testRunner.js** – the GraalJS JSRunner does not always expose `java`, so tests that mock `java.lang.System.getenv` for `DEFAULT_TRACKER` now get a stub that can be overridden.
2. **smAgent encoded_config tests** – updated to match the current `story_development.json` layout where default instructions/aiRole live in `cliPrompts` rather than `agentParams.instructions`.
3. **timerAutoCommitAndSave snapshot assertions** – now expect the header/footer wrapper that the action adds around `currentCliOutput`.

Verification:
```bash
cd agents && dmtools run js/unit-tests/run_all.json
# 373 passed, 0 failed
```