### PR TITLE
fix(agents): fall back to local git diff when github_get_pr_diff returns unusable object

### DIFF
--- a/instructions/pr_review/formatting_rules.md
+++ b/instructions/pr_review/formatting_rules.md
@@ -10,4 +10,6 @@ flowchart TD
     F8["Keep summary under 2 sentences — put details in inline comment files, not in general text"]
     F9["Severity classification follows general_guidelines.md:<br/>BLOCKING = must fix · IMPORTANT = should fix · SUGGESTION = optional"]
     F10["Ticket context: verify PR changes satisfy ticket ACs — note gaps in review"]
+    F11["Inline comments MUST target a line that appears in the PR diff<br/>If the line is not in the diff, the comment becomes a general PR comment instead of a review thread"]
+    F12["Use line numbers from the right-hand side of diff hunks<br/>If pr_diff.txt is truncated, run git diff origin/{base}...HEAD to see the full diff"]
 ```

--- a/instructions/pr_review/general_guidelines.md
+++ b/instructions/pr_review/general_guidelines.md
@@ -127,4 +127,6 @@ Write the standard review artifacts:
 - `outputs/pr_review_general.md` — 1-2 paragraph general PR comment
 - `outputs/pr_review_comments/*.md` — one file per detailed inline comment
 
+**Inline comment lines must be present in the PR diff.** GitHub review threads can only be attached to added or context lines inside a diff hunk. If `pr_diff.txt` is truncated, run `git diff origin/{baseBranch}...HEAD` to locate the correct line numbers. Findings on unchanged code outside the diff belong in `outputs/pr_review_general.md`, not as inline comments.
+
 Do NOT write `outputs/response.md`; the review is posted to GitHub only.

--- a/instructions/pr_review/output_rules.md
+++ b/instructions/pr_review/output_rules.md
@@ -4,5 +4,7 @@ flowchart TD
     O2["Write outputs/pr_review_general.md — brief general PR comment (1-2 paragraphs max)"]
     O3["Write outputs/pr_review_comments/*.md — detailed inline comment files"]
     O4["Always reference inline comment files via the 'comment' field — do NOT use inline 'body'"]
-    O1 --> O2 --> O3 --> O4
+    O5["Inline comments MUST use a line number that exists in the PR diff"]
+    O6["If a finding is on unchanged code outside the diff, put it in outputs/pr_review_general.md instead"]
+    O1 --> O2 --> O3 --> O4 --> O5 --> O6
 ```

--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -43,6 +43,45 @@ function _readFileMaybe(path) {
     return null;
 }
 
+function _cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function(line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function _looksLikeJavaObjectString(value) {
+    return typeof value === 'string' && /^[A-Za-z0-9_.$]+@[0-9a-f]+$/.test(value.trim());
+}
+
+function _isUsableDiff(value) {
+    return typeof value === 'string' && value.indexOf('diff --git') !== -1 && !_looksLikeJavaObjectString(value);
+}
+
+function _runGitDiff(baseRef, headRef) {
+    var variants = [
+        'git diff ' + baseRef + '...' + headRef,
+        'git diff origin/' + baseRef + '...' + headRef,
+        'git diff origin/' + baseRef + '...origin/' + headRef
+    ];
+    for (var i = 0; i < variants.length; i++) {
+        try {
+            var raw = cli_execute_command({ command: variants[i] }) || '';
+            var cleaned = _cleanCommandOutput(raw);
+            if (_isUsableDiff(cleaned)) {
+                console.log('Generated local git diff using: ' + variants[i] + ' (' + cleaned.length + ' chars)');
+                return cleaned;
+            }
+        } catch (e) {
+            console.warn('Git diff variant failed (' + variants[i] + '):', e.message || e);
+        }
+    }
+    return '';
+}
+
 function _createGithubProvider(workspace, repository) {
     return {
         listPrs: function(state) {
@@ -99,10 +138,40 @@ function _createGithubProvider(workspace, repository) {
             return github_remove_pr_label({ workspace: workspace, repository: repository, pullRequestId: String(prId), label: label });
         },
         getPrDiff: function(prId) {
+            var prIdStr = String(prId);
+            var raw = '';
+
             // Note: the generated GitHub MCP executor expects the parameter name
             // to be exactly 'pullRequestID' (capital D). Passing 'pullRequestId'
             // causes a "Required parameter 'pullRequestID' is missing" error.
-            return github_get_pr_diff({ workspace: workspace, repository: repository, pullRequestID: String(prId) });
+            try {
+                raw = github_get_pr_diff({ workspace: workspace, repository: repository, pullRequestID: prIdStr });
+            } catch (e) {
+                console.warn('github_get_pr_diff failed:', e.message || e);
+            }
+
+            if (_isUsableDiff(raw)) {
+                return raw;
+            }
+
+            // Fallback: some DMTools builds return a Java object toString instead
+            // of the diff text. Generate the diff locally from the checked-out branch.
+            console.log('GitHub PR diff MCP returned no usable diff; falling back to local git diff');
+            try {
+                var pr = github_get_pr({ workspace: workspace, repository: repository, pullRequestId: prIdStr });
+                if (!pr) throw new Error('github_get_pr returned empty PR details');
+                var baseRef = pr.base && pr.base.ref ? pr.base.ref : null;
+                var headRef = pr.head && pr.head.ref ? pr.head.ref : null;
+                if (!baseRef || !headRef) throw new Error('PR missing base or head ref');
+                var localDiff = _runGitDiff(baseRef, headRef);
+                if (_isUsableDiff(localDiff)) {
+                    return localDiff;
+                }
+            } catch (e2) {
+                console.warn('Local git diff fallback failed:', e2.message || e2);
+            }
+
+            return raw || '';
         },
         getCommitCheckRuns: function(sha) {
             return github_get_commit_check_runs({ workspace: workspace, repository: repository, commitSha: sha });

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -439,3 +439,80 @@ suite('scm GitLab provider', function() {
         });
     });
 });
+
+suite('scm GitHub provider getPrDiff fallback', function() {
+
+    test('uses github_get_pr_diff directly when it returns a usable diff', function() {
+        var prCalls = [];
+        var gitCalls = [];
+        var scmModule = loadScm({
+            github_get_pr_diff: function(args) {
+                return 'diff --git a/file.txt b/file.txt\n+change\n';
+            },
+            github_get_pr: function(args) { prCalls.push(args); return {}; },
+            cli_execute_command: function(args) { gitCalls.push(args.command); return ''; }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable diff');
+        assert.equal(prCalls.length, 0, 'must not fetch PR details when MCP diff is usable');
+        assert.equal(gitCalls.length, 0, 'must not run git diff when MCP diff is usable');
+    });
+
+    test('falls back to local git diff when github_get_pr_diff returns a Java object string', function() {
+        var prDiffCalls = [];
+        var prCalls = [];
+        var gitCalls = [];
+        var scmModule = loadScm({
+            github_get_pr_diff: function(args) {
+                prDiffCalls.push(args);
+                return 'com.github.istin.dmtools.github.GitHub$1@61edc883';
+            },
+            github_get_pr: function(args) {
+                prCalls.push(args);
+                return { base: { ref: 'main' }, head: { ref: 'ai/TS-577' } };
+            },
+            cli_execute_command: function(args) {
+                gitCalls.push(args.command);
+                if (args.command === 'git diff main...ai/TS-577') {
+                    return 'diff --git a/file.txt b/file.txt\n+change\nCOMMAND_EXIT_CODE=0';
+                }
+                return 'COMMAND_EXIT_CODE=128';
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable local diff');
+        assert.equal(prDiffCalls.length, 1);
+        assert.equal(prDiffCalls[0].pullRequestID, '1789');
+        assert.equal(prCalls.length, 1);
+        assert.equal(prCalls[0].pullRequestId, '1789');
+        assert.ok(gitCalls.indexOf('git diff main...ai/TS-577') !== -1, 'should try three-dot local diff');
+    });
+
+    test('falls back to origin-prefixed git diff when bare refs are not available', function() {
+        var gitCalls = [];
+        var scmModule = loadScm({
+            github_get_pr_diff: function() { return ''; },
+            github_get_pr: function() { return { base: { ref: 'main' }, head: { ref: 'ai/TS-577' } }; },
+            cli_execute_command: function(args) {
+                gitCalls.push(args.command);
+                if (args.command === 'git diff origin/main...ai/TS-577') {
+                    return 'diff --git a/file.txt b/file.txt\n+change\nCOMMAND_EXIT_CODE=0';
+                }
+                return 'COMMAND_EXIT_CODE=128';
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable origin-prefixed diff');
+        assert.ok(gitCalls.indexOf('git diff main...ai/TS-577') !== -1, 'should try bare refs first');
+        assert.ok(gitCalls.indexOf('git diff origin/main...ai/TS-577') !== -1, 'should fall back to origin/ prefix');
+    });
+});

--- a/snapshots/pr_review.md
+++ b/snapshots/pr_review.md
@@ -162,6 +162,8 @@ Write the standard review artifacts:
 - `outputs/pr_review_general.md` — 1-2 paragraph general PR comment
 - `outputs/pr_review_comments/*.md` — one file per detailed inline comment
 
+**Inline comment lines must be present in the PR diff.** GitHub review threads can only be attached to added or context lines inside a diff hunk. If `pr_diff.txt` is truncated, run `git diff origin/{baseBranch}...HEAD` to locate the correct line numbers. Findings on unchanged code outside the diff belong in `outputs/pr_review_general.md`, not as inline comments.
+
 Do NOT write `outputs/response.md`; the review is posted to GitHub only.
 
 
@@ -175,7 +177,9 @@ flowchart TD
     O2["Write outputs/pr_review_general.md — brief general PR comment (1-2 paragraphs max)"]
     O3["Write outputs/pr_review_comments/*.md — detailed inline comment files"]
     O4["Always reference inline comment files via the 'comment' field — do NOT use inline 'body'"]
-    O1 --> O2 --> O3 --> O4
+    O5["Inline comments MUST use a line number that exists in the PR diff"]
+    O6["If a finding is on unchanged code outside the diff, put it in outputs/pr_review_general.md instead"]
+    O1 --> O2 --> O3 --> O4 --> O5 --> O6
 ```
 
 
@@ -195,6 +199,8 @@ flowchart TD
     F8["Keep summary under 2 sentences — put details in inline comment files, not in general text"]
     F9["Severity classification follows general_guidelines.md:<br/>BLOCKING = must fix · IMPORTANT = should fix · SUGGESTION = optional"]
     F10["Ticket context: verify PR changes satisfy ticket ACs — note gaps in review"]
+    F11["Inline comments MUST target a line that appears in the PR diff<br/>If the line is not in the diff, the comment becomes a general PR comment instead of a review thread"]
+    F12["Use line numbers from the right-hand side of diff hunks<br/>If pr_diff.txt is truncated, run git diff origin/{base}...HEAD to see the full diff"]
 ```
 
 


### PR DESCRIPTION
Fixes pr_review agent posting separate PR comments instead of review threads because github_get_pr_diff returned a Java object toString, making inline-comment line validation always fail.

Changes:
- Detect unusable diff output and generate the diff locally from the checked-out PR branch.
- Add unit tests for GitHub provider getPrDiff fallback.
- Instruct pr_review to only attach inline comments to lines present in the PR diff.