### PR TITLE
fix(agents): use github_get_pr_diff_text and unwrap JSON diff envelopes

### DIFF
--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -61,6 +61,33 @@ function _isUsableDiff(value) {
     return typeof value === 'string' && value.indexOf('diff --git') !== -1 && !_looksLikeJavaObjectString(value);
 }
 
+function _extractDiffFromToolResult(raw) {
+    if (typeof raw !== 'string') {
+        return raw;
+    }
+    // Some DMTools versions wrap the diff in a JSON envelope like {"result": "diff ..."}
+    // or serialize an IBody lambda as {"arg$1": "diff ..."}. Unwrap those first.
+    var trimmed = raw.trim();
+    if (trimmed.charAt(0) === '{' || trimmed.charAt(0) === '[') {
+        try {
+            var parsed = JSON.parse(raw);
+            var candidates = [parsed.result, parsed['arg$1'], parsed.body, parsed.diff];
+            for (var i = 0; i < candidates.length; i++) {
+                var candidate = candidates[i];
+                if (typeof candidate === 'string' && _isUsableDiff(candidate)) {
+                    return candidate;
+                }
+            }
+        } catch (e) {
+            // Not valid JSON — fall through to raw diff check
+        }
+    }
+    if (_isUsableDiff(raw)) {
+        return raw;
+    }
+    return raw;
+}
+
 function _runGitDiff(baseRef, headRef) {
     var variants = [
         'git diff ' + baseRef + '...' + headRef,
@@ -139,23 +166,34 @@ function _createGithubProvider(workspace, repository) {
         },
         getPrDiff: function(prId) {
             var prIdStr = String(prId);
-            var raw = '';
 
-            // Note: the generated GitHub MCP executor expects the parameter name
-            // to be exactly 'pullRequestID' (capital D). Passing 'pullRequestId'
-            // causes a "Required parameter 'pullRequestID' is missing" error.
+            // Primary: DMTools v1.7.210+ exposes a tool that returns the raw diff text.
+            if (typeof github_get_pr_diff_text !== 'undefined') {
+                try {
+                    var textRaw = github_get_pr_diff_text({ workspace: workspace, repository: repository, pullRequestID: prIdStr });
+                    var textDiff = _extractDiffFromToolResult(textRaw);
+                    if (_isUsableDiff(textDiff)) {
+                        return textDiff;
+                    }
+                } catch (e) {
+                    console.warn('github_get_pr_diff_text failed:', e.message || e);
+                }
+            }
+
+            // Legacy fallback: the old tool returns diff statistics (an object) in most builds.
+            var raw = '';
             try {
                 raw = github_get_pr_diff({ workspace: workspace, repository: repository, pullRequestID: prIdStr });
             } catch (e) {
                 console.warn('github_get_pr_diff failed:', e.message || e);
             }
 
-            if (_isUsableDiff(raw)) {
-                return raw;
+            var extracted = _extractDiffFromToolResult(raw);
+            if (_isUsableDiff(extracted)) {
+                return extracted;
             }
 
-            // Fallback: some DMTools builds return a Java object toString instead
-            // of the diff text. Generate the diff locally from the checked-out branch.
+            // Final fallback: generate the diff locally from the checked-out branch.
             console.log('GitHub PR diff MCP returned no usable diff; falling back to local git diff');
             try {
                 var pr = github_get_pr({ workspace: workspace, repository: repository, pullRequestId: prIdStr });

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -515,4 +515,58 @@ suite('scm GitHub provider getPrDiff fallback', function() {
         assert.ok(gitCalls.indexOf('git diff main...ai/TS-577') !== -1, 'should try bare refs first');
         assert.ok(gitCalls.indexOf('git diff origin/main...ai/TS-577') !== -1, 'should fall back to origin/ prefix');
     });
+
+    test('prefers github_get_pr_diff_text when available', function() {
+        var calls = [];
+        var scmModule = loadScm({
+            github_get_pr_diff_text: function(args) {
+                calls.push(args);
+                return 'diff --git a/file.txt b/file.txt\n+change\n';
+            },
+            github_get_pr_diff: function() { throw new Error('legacy tool should not be called'); },
+            github_get_pr: function() { throw new Error('github_get_pr should not be called'); },
+            cli_execute_command: function() { throw new Error('git diff should not be called'); }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should return diff from new tool');
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].pullRequestID, '1789');
+    });
+
+    test('extracts diff from JSON result wrapper', function() {
+        var scmModule = loadScm({
+            github_get_pr_diff_text: function() {
+                return JSON.stringify({ result: 'diff --git a/file.txt b/file.txt\n+change\n' });
+            },
+            github_get_pr_diff: function() { throw new Error('legacy tool should not be called'); },
+            github_get_pr: function() { throw new Error('github_get_pr should not be called'); },
+            cli_execute_command: function() { throw new Error('git diff should not be called'); }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should unwrap JSON result');
+        assert.ok(diff.indexOf('diff --git') === 0, 'should return raw diff, not JSON envelope');
+    });
+
+    test('extracts diff from IBody arg$1 wrapper', function() {
+        var scmModule = loadScm({
+            github_get_pr_diff_text: function() {
+                return JSON.stringify({ 'arg$1': 'diff --git a/file.txt b/file.txt\n+change\n' });
+            },
+            github_get_pr_diff: function() { throw new Error('legacy tool should not be called'); },
+            github_get_pr: function() { throw new Error('github_get_pr should not be called'); },
+            cli_execute_command: function() { throw new Error('git diff should not be called'); }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var diff = provider.getPrDiff('1789');
+
+        assert.ok(diff.indexOf('diff --git') !== -1, 'should unwrap arg$1 field');
+        assert.ok(diff.indexOf('diff --git') === 0, 'should return raw diff, not JSON envelope');
+    });
 });


### PR DESCRIPTION
Depends on epam/dm.ai#271.

- Prefer the new `github_get_pr_diff_text` MCP tool when available.
- Unwrap JSON result envelopes (`{"result": "diff ..."}`, `{"arg": "diff ..."}`).
- Keep the local git diff fallback for older DMTools builds.
- JS unit tests: 452 passed.