### PR TITLE
chore(agents): auto-start story test automation review after run

### DIFF
--- a/story_test_automation.json
+++ b/story_test_automation.json
@@ -11,7 +11,9 @@
       "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
     },
     "customParams": {
-      "removeLabel": "sm_story_test_automation_triggered"
+      "removeLabel": "sm_story_test_automation_triggered",
+      "autoStartReview": true,
+      "autoStartReviewConfigFile": "agents/pr_story_test_automation_review.json"
     },
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",


### PR DESCRIPTION
Adds autoStartReview customParams to story_test_automation.json so that pr_story_test_automation_review is triggered automatically after a story test automation run completes, keeping the agent chain moving without manual intervention.