### PR TITLE
fix(agents): stabilize story test automation merge and resume

### DIFF
--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -141,8 +141,10 @@ function attemptResumeIfOutputsIncomplete(storyKey, result, linkedTestCases, wor
         'Instructions:\n' +
         '- Continue the same story test automation task in the same repository.\n' +
         '- For every missing Test Case, run/verify the corresponding automated test.\n' +
-        '- Append a result entry to outputs/story_test_automation_result.json for each missing Test Case:\n' +
-        '  { "testCaseKey": "TS-XXX", "status": "passed" | "failed", "testPath": "testing/tests/TS-XXX/...", "failedDescriptionFile": "outputs/failed_description_TS-XXX.md", "failureSummary": "..." }\n' +
+        '- Create or update outputs/story_test_automation_result.json with a top-level object: { "storyKey": "' + storyKey + '", "overall": "passed|failed", "summary": "...", "results": [...] }.\n' +
+        '- Append a result entry for each missing Test Case:\n' +
+        '  { "testCaseKey": "TS-XXX", "status": "passed" | "failed" | "skipped" | "irrelevant", "testPath": "testing/tests/TS-XXX/...", "failedDescriptionFile": "outputs/failed_description_TS-XXX.md", "failureSummary": "..." }\n' +
+        '- If the result JSON file is missing, create it from scratch using the existing outputs/response.md and testing/tests/ files as evidence.\n' +
         '- If a test fails, write a failed description file and reference it in the result entry.\n' +
         '- Do NOT push changes; the post-action will commit and push after you finish.\n' +
         '- Do NOT move the Story to another status.\n' +
@@ -460,7 +462,7 @@ function action(params) {
 
         var result = readResultJson(workingDir, storyKey);
         var resumeInfo = null;
-        if (result && linkedTestCases.length > 0) {
+        if (linkedTestCases.length > 0) {
             resumeInfo = attemptResumeIfOutputsIncomplete(storyKey, result, linkedTestCases, workingDir);
             if (resumeInfo.attempted) {
                 result = readResultJson(workingDir, storyKey);

--- a/sm.json
+++ b/sm.json
@@ -133,6 +133,20 @@
           "enabled": true
         },
         {
+          "description": "In Testing Stories (pr_approved) → merge test automation PR",
+          "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('In Testing') AND labels = 'pr_approved' ORDER BY created ASC",
+          "configFile": "agents/story_test_automation_merge.json",
+          "localExecution": true,
+          "enabled": true
+        },
+        {
+          "description": "In Testing Bugs (pr_approved) → merge test automation PR",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('In Testing') AND labels = 'pr_approved' ORDER BY created ASC",
+          "configFile": "agents/bug_test_automation_merge.json",
+          "localExecution": true,
+          "enabled": true
+        },
+        {
           "description": "In Rework Stories & Bugs → trigger pr_rework",
           "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Rework')",
           "configFile": "agents/pr_rework.json",

--- a/sm_merge.json
+++ b/sm_merge.json
@@ -11,6 +11,18 @@
           "localExecution": true
         },
         {
+          "description": "In Testing Stories (pr_approved) → merge test automation PR",
+          "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('In Testing') AND labels = 'pr_approved' ORDER BY created ASC",
+          "configFile": "agents/story_test_automation_merge.json",
+          "localExecution": true
+        },
+        {
+          "description": "In Testing Bugs (pr_approved) → merge test automation PR",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('In Testing') AND labels = 'pr_approved' ORDER BY created ASC",
+          "configFile": "agents/bug_test_automation_merge.json",
+          "localExecution": true
+        },
+        {
           "description": "In Review Test Cases (pr_approved) → retry merge",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Review - Passed', 'In Review - Failed') AND labels = 'pr_approved' ORDER BY created ASC",
           "configFile": "agents/retry_merge_test.json",


### PR DESCRIPTION
- Allow postStoryTestAutomationResults to resume when the result JSON is completely missing.
- Add In Testing merge rules for approved story/bug test automation PRs.