### PR TITLE
fix(sm): add label filter to bug_test_cases_generator JQL

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -174,7 +174,7 @@
         },
         {
           "description": "Ready For Testing Bugs → generate test cases",
-          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Ready For Testing')",
+          "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Ready For Testing') AND (labels is EMPTY OR labels NOT IN ('sm_bug_test_cases_triggered'))",
           "configFile": "agents/bug_test_cases_generator.json",
           "skipIfLabel": "sm_bug_test_cases_triggered",
           "addLabel": "sm_bug_test_cases_triggered",


### PR DESCRIPTION
Adds an explicit labels NOT IN ('sm_bug_test_cases_triggered') filter to the Ready For Testing Bugs generator JQL so the SM does not keep re-triggering bug_test_cases_generator while the bug is waiting for bug_test_automation.