### PR TITLE
fix(agents): handle empty test branches and normalize PASS/FAIL review verdicts

### DIFF
--- a/js/postTestReviewComments.js
+++ b/js/postTestReviewComments.js
@@ -312,8 +312,16 @@ function action(params) {
             return { success: false, error: 'No review data found' };
         }
 
-        // Normalize: LLM sometimes returns "APPROVED" instead of "APPROVE"
-        const isApproved = (reviewData.recommendation || '').replace(/^APPROVED$/, 'APPROVE') === 'APPROVE';
+        // Normalize recommendation: LLM may return "PASS"/"PASSED" or "APPROVED" instead of "APPROVE",
+        // and "FAIL"/"FAILED" instead of "BLOCK".
+        function normalizeRecommendation(rec) {
+            const value = String(rec || '').toUpperCase().trim();
+            if (value === 'PASS' || value === 'PASSED' || value === 'APPROVED') return 'APPROVE';
+            if (value === 'FAIL' || value === 'FAILED' || value === 'REJECT') return 'BLOCK';
+            return rec;
+        }
+        reviewData.recommendation = normalizeRecommendation(reviewData.recommendation);
+        const isApproved = reviewData.recommendation === 'APPROVE';
         console.log('Review recommendation:', reviewData.recommendation);
 
         // Step 2: Get current ticket status (to determine Passed vs Failed on approval)

--- a/js/prepareTestPRForReview.js
+++ b/js/prepareTestPRForReview.js
@@ -39,6 +39,49 @@ function findTestPRForTicket(scm, ticketKey) {
     }
 }
 
+function clearStaleReviewOutputs() {
+    try {
+        cli_execute_command({
+            command: 'rm -f outputs/pr_review.json outputs/response.md outputs/pr_review_general.md && rm -rf outputs/pr_review_comments'
+        });
+        console.log('✅ Cleared stale review outputs');
+    } catch (e) {
+        console.warn('Could not clear stale review outputs:', e);
+    }
+}
+
+function isNoCommitsError(error) {
+    const msg = error && error.toString ? error.toString() : String(error);
+    return msg.indexOf('No commits between') !== -1 ||
+           msg.indexOf('no commits between') !== -1;
+}
+
+function finalizeAlreadyMergedTestCase(ticketKey, branchName) {
+    try {
+        const ticket = jira_get_ticket({ key: ticketKey });
+        const currentStatus = ticket && ticket.fields && ticket.fields.status
+            ? ticket.fields.status.name
+            : '';
+        const finalStatus = currentStatus === 'In Review - Failed' ? 'Failed' : 'Passed';
+        jira_move_to_status({ key: ticketKey, statusName: finalStatus });
+        jira_post_comment({
+            key: ticketKey,
+            comment: 'h3. ✅ Test Code Already Merged\n\n' +
+                'Branch {code}' + branchName + '{code} has no commits ahead of main, so the test code is already in main.\n\n' +
+                'Moved ticket to *' + finalStatus + '* and removed the stale branch.'
+        });
+        console.log('✅ Branch has no commits ahead of main — moved', ticketKey, 'to', finalStatus);
+        try {
+            cli_execute_command({ command: 'git push origin --delete ' + branchName });
+            console.log('✅ Deleted stale branch:', branchName);
+        } catch (delErr) {
+            console.warn('Could not delete stale branch', branchName + ':', delErr);
+        }
+    } catch (e) {
+        console.warn('Failed to finalize already-merged test case:', e);
+    }
+}
+
 function action(params) {
     try {
         const inputFolder = params.inputFolderPath;
@@ -47,6 +90,8 @@ function action(params) {
         var scm = configLoader.createScm(config);
 
         console.log('=== Preparing test PR for review:', ticketKey, '===');
+
+        clearStaleReviewOutputs();
 
         // Step 1: GitHub repo info
         var repoInfo = scm.getRemoteRepoInfo();
@@ -105,6 +150,11 @@ function action(params) {
                     throw new Error('PR was created but could not be found immediately after creation');
                 }
             } catch (createErr) {
+                if (isNoCommitsError(createErr)) {
+                    console.log('Branch test/' + ticketKey + ' has no commits ahead of main — test code is already merged.');
+                    finalizeAlreadyMergedTestCase(ticketKey, branchName);
+                    return false;
+                }
                 const err = 'Branch test/' + ticketKey + ' exists but could not create PR: ' + createErr.toString();
                 try { jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Review cancelled._' }); } catch (e) {}
                 return false;


### PR DESCRIPTION
- prepareTestPRForReview.js: detect 'No commits between main and test/...' and finalize the Test Case as Passed/Failed instead of looping on review.
- prepareTestPRForReview.js: clear stale review outputs so cached pr_review.json cannot cause false approve/rework loops.
- postTestReviewComments.js: normalize PASS/PASSED -> APPROVE and FAIL/FAILED -> BLOCK so test automation reviews using test-result wording still trigger merge.