### PR TITLE
docs(agents): clarify test automation review recommendation values and add APPROVE example

### DIFF
--- a/instructions/pr_test_automation_review/few_shots.md
+++ b/instructions/pr_test_automation_review/few_shots.md
@@ -16,6 +16,17 @@ Example PR test automation review outputs — keep concise:
 }
 ```
 
+### outputs/pr_review.json (APPROVE example)
+```json
+{
+  "recommendation": "APPROVE",
+  "summary": "Test correctly exercises the ticket's acceptance criteria with self-sufficient data and proper architecture.",
+  "generalComment": "outputs/pr_review_general.md",
+  "inlineComments": [],
+  "issueCounts": {"blocking":0,"important":0,"suggestions":0}
+}
+```
+
 ### outputs/pr_review_general.md
 ```markdown
 ## Automated Test PR Review — BLOCK

--- a/instructions/pr_test_automation_review/formatting_rules.md
+++ b/instructions/pr_test_automation_review/formatting_rules.md
@@ -2,7 +2,7 @@
 flowchart TD
     F1["outputs/response.md — tracker-agnostic Markdown, under 20 lines, bullet-focused"]
     F2["Required sections: Summary, Correctness, Architecture, Code Quality, Framework Usage, Test Data, Recommendation"]
-    F3["outputs/pr_review.json — valid JSON with recommendation, summary, inlineComments, issueCounts"]
+    F3["outputs/pr_review.json — valid JSON with recommendation (APPROVE|BLOCK|REQUEST_CHANGES), summary, inlineComments, issueCounts"]
     F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
     F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]


### PR DESCRIPTION
- formatting_rules.md: state recommendation must be APPROVE, BLOCK, or REQUEST_CHANGES.\n- few_shots.md: add APPROVE example so the reviewer does not emit PASS/FAIL as recommendation.