### PR TITLE
fix(agents): allow PR APPROVE verdict to stand when only SUGGESTIONs remain

### DIFF
--- a/pr_review.json
+++ b/pr_review.json
@@ -17,7 +17,8 @@
     "preCliJSAction": "agents/js/preparePRForReview.js",
     "postJSAction": "agents/js/postPRReviewComments.js",
     "customParams": {
-      "removeLabel": "sm_story_review_triggered"
+      "removeLabel": "sm_story_review_triggered",
+      "allowApproveWithSuggestions": true
     },
     "inputJql": "key = JD-107",
     "cliPrompts": [


### PR DESCRIPTION
The review instructions classify SUGGESTION as optional and non-blocking, but postPRReviewComments.js overrode an APPROVE recommendation whenever any issueCount was non-zero, including suggestions. This forced the ticket back to rework and created infinite review/rework loops for tickets like TS-1374 where the only remaining feedback was a repeated optional suggestion.