### PR TITLE
fix(agents): use direct issue links in bug done check to avoid transitive blocks

### DIFF
--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -2,7 +2,12 @@
  * Check Bug Tests Passed — postJSAction for bug_done_check agent.
  *
  * Runs on every SM cycle for each Bug in "In Testing".
- * - If all linked Test Cases are in "Passed" status → moves the Bug to Done.
+ * - Looks at *directly* linked Test Cases only (avoids blocking a bug on
+ *   unrelated Test Cases that happen to be connected through a parent Story
+ *   or other transitive links).
+ * - If all directly linked Test Cases are in "Passed" status → moves the Bug to Done.
+ * - If there are no direct Test Case links → falls back to the broad
+ *   linkedIssues query for backward compatibility.
  * - Otherwise → removes the SM idempotency label so the SM re-triggers
  *   this check on the next cycle.
  */
@@ -32,19 +37,64 @@ function action(params) {
         }
     }
 
+    function findDirectLinkedTCs() {
+        try {
+            const ticket = jira_get_ticket({ key: ticketKey });
+            const issueLinks = ticket && ticket.fields && ticket.fields.issuelinks;
+            if (!Array.isArray(issueLinks) || issueLinks.length === 0) {
+                return [];
+            }
+            const tcs = [];
+            issueLinks.forEach(function(link) {
+                var other = link.outwardIssue || link.inwardIssue;
+                if (!other || !other.fields || !other.fields.issuetype) return;
+                if (other.fields.issuetype.name === testCaseType) {
+                    tcs.push(other);
+                }
+            });
+            return tcs;
+        } catch (e) {
+            console.warn('Failed to read direct issue links for', ticketKey, ':', e);
+            return [];
+        }
+    }
+
+    function findAllLinkedTCs() {
+        try {
+            return jira_search_by_jql({
+                jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "' + testCaseType + '"',
+                maxResults: 100
+            }) || [];
+        } catch (e) {
+            console.warn('Failed to fetch linked Test Cases via JQL:', e);
+            return [];
+        }
+    }
+
+    function hasNotPassedTC(tcList) {
+        return tcList.some(function(tc) {
+            var status = tc.fields && tc.fields.status && tc.fields.status.name;
+            return status !== STATUSES.PASSED && status !== STATUSES.SKIPPED && status !== STATUSES.IRRELEVANT;
+        });
+    }
+
     try {
         if (!ticketKey) throw new Error('params.ticket.key is missing');
         console.log('=== Bug done check for', ticketKey, '===');
 
-        // Step 1: Find all linked Test Cases for this bug
-        // jira_search_by_jql returns a plain array
-        const allTCs = jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "' + testCaseType + '"',
-            maxResults: 100
-        }) || [];
+        // Step 1: Prefer directly linked Test Cases so a bug is only held up by
+        // its own acceptance tests, not by every Test Case connected to a parent Story.
+        var allTCs = findDirectLinkedTCs();
+        var linkSource = 'direct';
+
+        if (allTCs.length === 0) {
+            console.log('No direct Test Case links found — falling back to linkedIssues query');
+            allTCs = findAllLinkedTCs();
+            linkSource = 'linkedIssues';
+        }
 
         const totalTCs = allTCs.length;
-        console.log('Linked Test Cases:', totalTCs);
+        console.log('Linked Test Cases (' + linkSource + '):', totalTCs);
 
         if (totalTCs === 0) {
             console.log('No linked Test Cases found — releasing lock, will re-check next cycle');
@@ -52,14 +102,13 @@ function action(params) {
             return { success: true, action: 'no_test_cases', ticketKey };
         }
 
-        // Step 2: Find linked Test Cases that are NOT yet Passed.
+        // Step 2: Check whether any linked Test Case is not yet Passed.
         // Skipped and Irrelevant Test Cases are intentionally non-blocking
         // (same as checkStoryTestsPassed).
-        const notPassedTCs = jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "' + testCaseType + '" AND status not in ("Passed", "Skipped", "Irrelevant")',
-            maxResults: 1
-        }) || [];
-
+        const notPassedTCs = allTCs.filter(function(tc) {
+            var status = tc.fields && tc.fields.status && tc.fields.status.name;
+            return status !== STATUSES.PASSED && status !== STATUSES.SKIPPED && status !== STATUSES.IRRELEVANT;
+        });
         const notPassedCount = notPassedTCs.length;
 
         console.log('Test Cases not yet Passed:', notPassedCount, '/', totalTCs);

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -33,6 +33,7 @@
         "js/unit-tests/test_postBugCreation.js",
         "js/unit-tests/test_postBulkBugsCreation.js",
         "js/unit-tests/test_checkStoryTestsPassed.js",
+        "js/unit-tests/test_checkBugTestsPassed.js",
         "js/unit-tests/test_checkBugToFixReady.js",
         "js/unit-tests/test_finishTestCasesGeneration.js",
         "js/unit-tests/test_preCliStoryTestAutomationSetup.js",

--- a/js/unit-tests/run_checkBugTestsPassed.json
+++ b/js/unit-tests/run_checkBugTestsPassed.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_checkBugTestsPassed.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_checkBugTestsPassed.js
+++ b/js/unit-tests/test_checkBugTestsPassed.js
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for js/checkBugTestsPassed.js
+ */
+
+function loadCheckBugTestsPassed(mocks) {
+    mocks = mocks || {};
+    var configLoaderMock = {
+        loadProjectConfig: function() {
+            return {
+                jira: {
+                    issueTypes: {
+                        TEST_CASE: 'Test Case'
+                    }
+                }
+            };
+        }
+    };
+
+    return loadModule(
+        'js/checkBugTestsPassed.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': configLoaderMock,
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+        }),
+        mocks
+    );
+}
+
+function makeTc(key, status) {
+    return { key: key, fields: { status: { name: status }, issuetype: { name: 'Test Case' } } };
+}
+
+suite('checkBugTestsPassed', function() {
+
+    test('moves Bug to Done when all directly linked TCs are Passed', function() {
+        var moved = [];
+        var comments = [];
+        var removedLabels = [];
+        var searchedJqls = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function(args) {
+                assert.equal(args.key, 'TS-10');
+                return {
+                    fields: {
+                        issuelinks: [
+                            { outwardIssue: makeTc('TS-11', 'Passed') }
+                        ]
+                    }
+                };
+            },
+            jira_search_by_jql: function(args) {
+                searchedJqls.push(args.jql);
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-10' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_done');
+        assert.deepEqual(moved, [{ key: 'TS-10', statusName: 'Done' }]);
+        assert.contains(comments[0].comment, 'Bug Complete');
+        assert.equal(removedLabels.length, 0, 'lock should not be released after Done');
+        assert.equal(searchedJqls.length, 0, 'should not need broad JQL when direct links exist');
+    });
+
+    test('ignores transitive linked TCs and moves Bug to Done', function() {
+        var moved = [];
+        var comments = [];
+        var removedLabels = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function() {
+                return {
+                    fields: {
+                        issuelinks: [
+                            { outwardIssue: makeTc('TS-11', 'Passed') }
+                        ]
+                    }
+                };
+            },
+            jira_search_by_jql: function(args) {
+                // Broad query would return unrelated failed TCs (simulating linkedIssues transitivity)
+                if (args.jql.indexOf('issuetype = "Test Case"') !== -1) {
+                    return [
+                        makeTc('TS-11', 'Passed'),
+                        makeTc('TS-12', 'Failed')
+                    ];
+                }
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-10' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_done');
+        assert.deepEqual(moved, [{ key: 'TS-10', statusName: 'Done' }]);
+        assert.equal(removedLabels.length, 0);
+    });
+
+    test('waits when a direct linked TC is not Passed', function() {
+        var moved = [];
+        var removedLabels = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function() {
+                return {
+                    fields: {
+                        issuelinks: [
+                            { outwardIssue: makeTc('TS-21', 'In Review - Passed') }
+                        ]
+                    }
+                };
+            },
+            jira_search_by_jql: function() { return []; },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function() {},
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-20' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'waiting');
+        assert.deepEqual(moved, []);
+        assert.deepEqual(removedLabels, [{ key: 'TS-20', label: 'sm_bug_done_check_triggered' }]);
+    });
+
+    test('treats Skipped and Irrelevant direct TCs as non-blocking', function() {
+        var moved = [];
+        var comments = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function() {
+                return {
+                    fields: {
+                        issuelinks: [
+                            { outwardIssue: makeTc('TS-31', 'Passed') },
+                            { outwardIssue: makeTc('TS-32', 'Skipped') },
+                            { inwardIssue: makeTc('TS-33', 'Irrelevant') }
+                        ]
+                    }
+                };
+            },
+            jira_search_by_jql: function() { return []; },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_remove_label: function() {}
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-30' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_done');
+        assert.deepEqual(moved, [{ key: 'TS-30', statusName: 'Done' }]);
+        assert.contains(comments[0].comment, 'Bug Complete');
+    });
+
+    test('falls back to linkedIssues when no direct Test Case links exist', function() {
+        var moved = [];
+        var comments = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function() {
+                return {
+                    fields: {
+                        issuelinks: [
+                            { outwardIssue: { key: 'TS-S1', fields: { issuetype: { name: 'Story' } } } }
+                        ]
+                    }
+                };
+            },
+            jira_search_by_jql: function(args) {
+                if (args.jql.indexOf('issuetype = "Test Case"') !== -1) {
+                    return [makeTc('TS-41', 'Passed')];
+                }
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_remove_label: function() {}
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-40' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_done');
+        assert.deepEqual(moved, [{ key: 'TS-40', statusName: 'Done' }]);
+    });
+
+    test('waits when falling back and a linked TC is not Passed', function() {
+        var moved = [];
+        var removedLabels = [];
+
+        var module = loadCheckBugTestsPassed({
+            jira_get_ticket: function() {
+                return { fields: { issuelinks: [] } };
+            },
+            jira_search_by_jql: function(args) {
+                if (args.jql.indexOf('issuetype = "Test Case"') !== -1) {
+                    return [makeTc('TS-51', 'Passed'), makeTc('TS-52', 'Backlog')];
+                }
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function() {},
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-50' },
+            jobParams: { customParams: { removeLabel: 'sm_bug_done_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'waiting');
+        assert.deepEqual(moved, []);
+        assert.deepEqual(removedLabels, [{ key: 'TS-50', label: 'sm_bug_done_check_triggered' }]);
+    });
+
+});


### PR DESCRIPTION
## Problem
`bug_done_check` used the broad `linkedIssues()` JQL query, which in this project returns Test Cases that are only transitively connected to a Bug through a parent Story. This created deadlocks: TS-1356 could not move to `Done` because regression Test Cases TS-501 and TS-252 (linked to the parent Story) were in `Bug To Fix`, and those Test Cases could not return to `Backlog` until TS-1356 was `Done`.

## Fix
- `checkBugTestsPassed.js` now reads the Bug's own `issuelinks` and only considers directly linked Test Cases.
- Skipped/Irrelevant Test Cases remain non-blocking.
- Falls back to the previous `linkedIssues` behavior only when a Bug has no direct Test Case links, preserving backward compatibility.
- Added unit tests and a dedicated runner config.

## Verification
- `dmtools run js/unit-tests/run_checkBugTestsPassed.json` passes (6/6).
- Full unit suite was run; new tests are included and the unrelated 3 pre-existing failures are unchanged.