### PR TITLE
fix(agents): clear stale outputs before test automation and guard against mismatched result JSON

### DIFF
--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -32,6 +32,18 @@ function readOutputFile(relativePath, workingDir, ticketKey) {
     });
 }
 
+function resultBelongsToTicket(parsed, ticketKey) {
+    if (!parsed || typeof parsed !== 'object') return true;
+    var keys = [parsed.ticketKey, parsed.storyKey, parsed.testCaseKey, parsed.issueKey];
+    for (var i = 0; i < keys.length; i++) {
+        if (keys[i] && keys[i] !== ticketKey) {
+            console.warn('outputs/test_automation_result.json belongs to ' + keys[i] + ', not ' + ticketKey + ' — treating as stale');
+            return false;
+        }
+    }
+    return true;
+}
+
 function readResultJson(workingDir, ticketKey) {
     try {
         const raw = readOutputFile('test_automation_result.json', workingDir, ticketKey);
@@ -40,6 +52,9 @@ function readResultJson(workingDir, ticketKey) {
             return null;
         }
         const parsed = JSON.parse(raw);
+        if (!resultBelongsToTicket(parsed, ticketKey)) {
+            return null;
+        }
         console.log('Test result status:', parsed.status);
         return parsed;
     } catch (e) {

--- a/js/preCliTestAutomationSetup.js
+++ b/js/preCliTestAutomationSetup.js
@@ -182,6 +182,15 @@ function action(params) {
             console.error('Branch checkout failed (non-fatal):', e);
         }
 
+        // Step 2b: Clear stale output files from previous runs so the post-action
+        // does not accidentally read a result JSON belonging to a different ticket.
+        try {
+            runGit('bash -c "rm -f outputs/test_automation_result.json outputs/story_test_automation_result.json outputs/tracker_comment.md outputs/comment.md outputs/jira_comment.md outputs/response.md outputs/pr_body.md outputs/bug_description.md outputs/failed_description_*.md"', config.workingDir || null);
+            console.log('✅ Cleared stale output files');
+        } catch (e) {
+            console.warn('Could not clear stale output files (non-fatal):', e);
+        }
+
         // Step 3: Fetch linked bugs (with fix comments) into input folder
         // This gives the test agent context about HOW bugs were fixed (timing, delays, etc.)
         try {


### PR DESCRIPTION
## Problem
Test_case_automation for TS-1373 picked up a stale `outputs/test_automation_result.json` that actually belonged to TS-684. The post-action then moved TS-1373 to `Failed` based on the wrong result, blocking TS-1371 in `In Testing`.

## Fix
1. `preCliTestAutomationSetup.js` now deletes leftover output files (result JSON, comments, PR body, failed descriptions, bug description) before the CLI agent runs.
2. `postTestAutomationResults.js` now validates that the result JSON's `ticketKey` / `storyKey` / `testCaseKey` matches the current ticket; if it belongs to a different ticket, it is treated as missing.

## Verification
- Full JS unit suite still passes (458 passed, 3 pre-existing unrelated failures).