### PR TITLE
fix(pr_test_automation_rework): clear stale outputs and add JSON output instructions

### DIFF
--- a/js/preCliTestReworkSetup.js
+++ b/js/preCliTestReworkSetup.js
@@ -41,6 +41,17 @@ function action(params) {
 
         console.log('=== Test rework setup for:', ticketKey, '===');
 
+        // Clear stale output files from any previous run so the post-action
+        // never reads a result JSON that belongs to a different ticket.
+        try {
+            cli_execute_command({
+                command: 'bash -c "rm -f outputs/test_automation_result.json outputs/story_test_automation_result.json outputs/tracker_comment.md outputs/comment.md outputs/jira_comment.md outputs/response.md outputs/pr_body.md outputs/bug_description.md outputs/failed_description_*.md"'
+            });
+            console.log('Cleared stale output files before rework');
+        } catch (e) {
+            console.warn('Could not clear output files:', e);
+        }
+
         // Step 1: GitHub repo info
         var repoInfo = scm.getRemoteRepoInfo();
         if (!repoInfo) {

--- a/pr_test_automation_rework.json
+++ b/pr_test_automation_rework.json
@@ -27,6 +27,9 @@
       "./agents/instructions/common/input_context_reading.md",
       "./agents/instructions/pr_test_automation_rework/general_guidelines.md",
       "./agents/instructions/pr_test_automation_rework/formatting_rules.md",
+      "./agents/instructions/test_automation/test_automation_instructions.md",
+      "./agents/instructions/test_automation/test_automation_output_files.md",
+      "./agents/instructions/test_automation/test_automation_json_output.md",
       "./agents/instructions/common/dmtools_cli.md",
       "./agents/prompts/bash_tools.md"
     ],


### PR DESCRIPTION
## Problem\npr_test_automation_rework runs for TS-1361 repeatedly failed because the post-action could not read a fresh outputs/test_automation_result.json.\n\n## Change\n- Clear outputs/ at the start of rework setup so stale result JSON never confuses the post-action.\n- Add test_automation_json_output.md and related instructions to the rework prompt list so the agent knows it must write the structured result JSON.\n\nRelates to the repeated TS-1361 failures investigated in IstiN/trackstate.