### PR TITLE
fix(bug_test_automation): trigger review after test automation completes

### DIFF
--- a/bug_test_automation.json
+++ b/bug_test_automation.json
@@ -11,7 +11,9 @@
       "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
     },
     "customParams": {
-      "removeLabel": "sm_bug_test_automation_triggered"
+      "removeLabel": "sm_bug_test_automation_triggered",
+      "autoStartReview": true,
+      "autoStartReviewConfigFile": "agents/pr_bug_test_automation_review.json"
     },
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",


### PR DESCRIPTION
Adds `autoStartReview` to `bug_test_automation.json` so that after a Bug's tests are automated, the dedicated `pr_bug_test_automation_review` agent reviews the test PR and drives merge/rework.

Without this, Bugs such as TS-1371 remain in *In Testing* with an open, unreviewed `test/TS-1371` PR and no follow-up AI Teammate run, which the stagnation monitor reports as stagnant.