### PR TITLE
fix(assignForReview): correct require path for tokenUsageComment.js

### DIFF
--- a/assignForReview.js
+++ b/assignForReview.js
@@ -5,7 +5,7 @@
 
 // Import common Jira helper functions
 const { assignForReview } = require('./common/jiraHelpers.js');
-const tokenUsageComment = require('./common/tokenUsageComment.js');
+const tokenUsageComment = require('./js/common/tokenUsageComment.js');
 
 function action(params) {
     try {


### PR DESCRIPTION
## Summary
- `assignForReview.js` was requiring `./common/tokenUsageComment.js` which resolves to `agents/common/` — a path that doesn't exist
- The file lives at `agents/js/common/tokenUsageComment.js`, consistent with all other scripts under `agents/js/`
- Fixed by updating the require path to `./js/common/tokenUsageComment.js`

## Root Cause
`tokenUsageComment.js` was added to `js/common/` but `assignForReview.js` (a root-level script) referenced the wrong relative path `./common/`, causing a runtime `JavaScript file not found` error in dmtools.

## Test plan
- [ ] Trigger `story_description` agent on an AITS ticket and verify `assignForReview.js` runs without module load errors