### PR TITLE
feat: add claude-code provider + fix assignForReview tokenUsageComment path

### DIFF
--- a/assignForReview.js
+++ b/assignForReview.js
@@ -5,7 +5,7 @@
 
 // Import common Jira helper functions
 const { assignForReview } = require('./common/jiraHelpers.js');
-const tokenUsageComment = require('./common/tokenUsageComment.js');
+const tokenUsageComment = require('./js/common/tokenUsageComment.js');
 
 function action(params) {
     try {

--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # Claude Code provider for run-agent.sh
-# Uses Anthropic Claude Code CLI (claude -p) via ANTHROPIC_BASE_URL proxy.
+# Uses Anthropic Claude Code CLI (claude -p) via Bedrock proxy.
 #
-# Required env vars:
-#   ANTHROPIC_API_KEY     - API key for the proxy
-#   ANTHROPIC_BASE_URL    - Base URL of the proxy (e.g. https://host/api/agent_name)
+# Required env vars (all CLAUDE_CODE_ prefixed):
+#   CLAUDE_CODE_API_KEY   - API key for the Bedrock proxy
+#   CLAUDE_CODE_BASE_URL  - Base URL of the proxy (e.g. https://host/api/agent_name)
 # Optional:
-#   ANTHROPIC_MODEL       - Model ID (default: claude-sonnet-4-6)
+#   CLAUDE_CODE_MODEL     - Model ID (default: claude-sonnet-4-6)
 #   CLAUDE_CODE_MAX_TURNS - Max agentic turns (default: 10)
+#
+# Note: ANTHROPIC_* vars are set locally inside this script only (required by Claude Code SDK).
+# They are never exported at the workflow level to avoid conflicts with DMTools ANTHROPIC_* vars.
 
 run_claude_code() {
   if [ -z "${CLAUDE_CODE_API_KEY:-}" ]; then
@@ -20,58 +23,57 @@ run_claude_code() {
     return 1
   fi
 
-  local claude_model="${CLAUDE_CODE_MODEL:-claude-sonnet-4-6}"
-  local max_turns="${CLAUDE_CODE_MAX_TURNS:-10}"
+  local claude_code_model="${CLAUDE_CODE_MODEL:-claude-sonnet-4-6}"
+  local claude_code_max_turns="${CLAUDE_CODE_MAX_TURNS:-10}"
 
   if ! command -v claude >/dev/null 2>&1; then
     echo "Error: claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code" >&2
     return 1
   fi
 
-  # Map CLAUDE_CODE_* → ANTHROPIC_* only for this subprocess.
-  # Never set ANTHROPIC_* in the parent workflow to avoid conflicts with DMTools vars.
+  # Map CLAUDE_CODE_* → ANTHROPIC_* required by Claude Code SDK (subprocess scope only).
   export ANTHROPIC_BASE_URL="${CLAUDE_CODE_BASE_URL}"
   export ANTHROPIC_API_KEY="${CLAUDE_CODE_API_KEY}"
-  export ANTHROPIC_MODEL="${claude_model}"
+  export ANTHROPIC_MODEL="${claude_code_model}"
 
   echo "Claude Code Configuration:"
-  echo "  Model:       ${claude_model}"
+  echo "  Model:       ${claude_code_model}"
   echo "  Base URL:    ${CLAUDE_CODE_BASE_URL}"
-  echo "  Max turns:   ${max_turns}"
+  echo "  Max turns:   ${claude_code_max_turns}"
   echo "Working directory: $(pwd)"
   echo ""
 
-  local exit_code=0
-  local claude_log
-  claude_log="$(mktemp)"
+  local claude_code_exit_code=0
+  local claude_code_log
+  claude_code_log="$(mktemp)"
 
   set +e
   if [ -f "${PROMPT_ARG}" ]; then
-    echo "Running: claude --allowedTools all --model ${claude_model} --max-turns ${max_turns} -p (prompt: ${PROMPT_BYTES} bytes via file)"
+    echo "Running: claude --allowedTools all --model ${claude_code_model} --max-turns ${claude_code_max_turns} -p (prompt: ${PROMPT_BYTES} bytes via file)"
     echo ""
     claude --allowedTools all \
-      --model "${claude_model}" \
-      --max-turns "${max_turns}" \
+      --model "${claude_code_model}" \
+      --max-turns "${claude_code_max_turns}" \
       -p "$(cat "${PROMPT_ARG}")" \
       ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} \
-      2>&1 | tee "${claude_log}"
+      2>&1 | tee "${claude_code_log}"
   else
-    echo "Running: claude --allowedTools all --model ${claude_model} --max-turns ${max_turns} -p (inline prompt: ${PROMPT_BYTES} bytes)"
+    echo "Running: claude --allowedTools all --model ${claude_code_model} --max-turns ${claude_code_max_turns} -p (inline prompt: ${PROMPT_BYTES} bytes)"
     echo ""
     claude --allowedTools all \
-      --model "${claude_model}" \
-      --max-turns "${max_turns}" \
+      --model "${claude_code_model}" \
+      --max-turns "${claude_code_max_turns}" \
       -p "${PROMPT}" \
       ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} \
-      2>&1 | tee "${claude_log}"
+      2>&1 | tee "${claude_code_log}"
   fi
-  exit_code=${PIPESTATUS[0]}
+  claude_code_exit_code=${PIPESTATUS[0]}
   set -e
 
-  record_codegraph_usage "${claude_log}"
-  rm -f "${claude_log}"
+  record_codegraph_usage "${claude_code_log}"
+  rm -f "${claude_code_log}"
 
   echo ""
-  echo "=== Agent completed with exit code: $exit_code ==="
-  return $exit_code
+  echo "=== Agent completed with exit code: $claude_code_exit_code ==="
+  return $claude_code_exit_code
 }

--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Claude Code provider for run-agent.sh
+# Uses Anthropic Claude Code CLI (claude -p) via ANTHROPIC_BASE_URL proxy.
+#
+# Required env vars:
+#   ANTHROPIC_API_KEY     - API key for the proxy
+#   ANTHROPIC_BASE_URL    - Base URL of the proxy (e.g. https://host/api/agent_name)
+# Optional:
+#   ANTHROPIC_MODEL       - Model ID (default: claude-sonnet-4-6)
+#   CLAUDE_CODE_MAX_TURNS - Max agentic turns (default: 10)
+
+run_claude_code() {
+  if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "Error: ANTHROPIC_API_KEY environment variable is required for claude-code provider" >&2
+    echo "Set ANTHROPIC_API_KEY (proxy key) in the workflow or dmtools.env" >&2
+    return 1
+  fi
+
+  if [ -z "${ANTHROPIC_BASE_URL:-}" ]; then
+    echo "Error: ANTHROPIC_BASE_URL environment variable is required for claude-code provider" >&2
+    echo "Set ANTHROPIC_BASE_URL to your proxy base URL" >&2
+    return 1
+  fi
+
+  local claude_model="${ANTHROPIC_MODEL:-${CLAUDE_CODE_MODEL:-claude-sonnet-4-6}}"
+  local max_turns="${CLAUDE_CODE_MAX_TURNS:-10}"
+
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "Error: claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code" >&2
+    return 1
+  fi
+
+  echo "Claude Code Configuration:"
+  echo "  Model:       ${claude_model}"
+  echo "  Base URL:    ${ANTHROPIC_BASE_URL}"
+  echo "  Max turns:   ${max_turns}"
+  echo "Working directory: $(pwd)"
+  echo ""
+
+  local exit_code=0
+  local claude_log
+  claude_log="$(mktemp)"
+
+  set +e
+  if [ -f "${PROMPT_ARG}" ]; then
+    echo "Running: claude --allowedTools all --model ${claude_model} --max-turns ${max_turns} -p (prompt: ${PROMPT_BYTES} bytes via file)"
+    echo ""
+    claude --allowedTools all \
+      --model "${claude_model}" \
+      --max-turns "${max_turns}" \
+      -p "$(cat "${PROMPT_ARG}")" \
+      ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} \
+      2>&1 | tee "${claude_log}"
+  else
+    echo "Running: claude --allowedTools all --model ${claude_model} --max-turns ${max_turns} -p (inline prompt: ${PROMPT_BYTES} bytes)"
+    echo ""
+    claude --allowedTools all \
+      --model "${claude_model}" \
+      --max-turns "${max_turns}" \
+      -p "${PROMPT}" \
+      ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} \
+      2>&1 | tee "${claude_log}"
+  fi
+  exit_code=${PIPESTATUS[0]}
+  set -e
+
+  record_codegraph_usage "${claude_log}"
+  rm -f "${claude_log}"
+
+  echo ""
+  echo "=== Agent completed with exit code: $exit_code ==="
+  return $exit_code
+}

--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -10,19 +10,17 @@
 #   CLAUDE_CODE_MAX_TURNS - Max agentic turns (default: 10)
 
 run_claude_code() {
-  if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "Error: ANTHROPIC_API_KEY environment variable is required for claude-code provider" >&2
-    echo "Set ANTHROPIC_API_KEY (proxy key) in the workflow or dmtools.env" >&2
+  if [ -z "${CLAUDE_CODE_API_KEY:-}" ]; then
+    echo "Error: CLAUDE_CODE_API_KEY environment variable is required for claude-code provider" >&2
     return 1
   fi
 
-  if [ -z "${ANTHROPIC_BASE_URL:-}" ]; then
-    echo "Error: ANTHROPIC_BASE_URL environment variable is required for claude-code provider" >&2
-    echo "Set ANTHROPIC_BASE_URL to your proxy base URL" >&2
+  if [ -z "${CLAUDE_CODE_BASE_URL:-}" ]; then
+    echo "Error: CLAUDE_CODE_BASE_URL environment variable is required for claude-code provider" >&2
     return 1
   fi
 
-  local claude_model="${ANTHROPIC_MODEL:-${CLAUDE_CODE_MODEL:-claude-sonnet-4-6}}"
+  local claude_model="${CLAUDE_CODE_MODEL:-claude-sonnet-4-6}"
   local max_turns="${CLAUDE_CODE_MAX_TURNS:-10}"
 
   if ! command -v claude >/dev/null 2>&1; then
@@ -30,9 +28,15 @@ run_claude_code() {
     return 1
   fi
 
+  # Map CLAUDE_CODE_* → ANTHROPIC_* only for this subprocess.
+  # Never set ANTHROPIC_* in the parent workflow to avoid conflicts with DMTools vars.
+  export ANTHROPIC_BASE_URL="${CLAUDE_CODE_BASE_URL}"
+  export ANTHROPIC_API_KEY="${CLAUDE_CODE_API_KEY}"
+  export ANTHROPIC_MODEL="${claude_model}"
+
   echo "Claude Code Configuration:"
   echo "  Model:       ${claude_model}"
-  echo "  Base URL:    ${ANTHROPIC_BASE_URL}"
+  echo "  Base URL:    ${CLAUDE_CODE_BASE_URL}"
   echo "  Max turns:   ${max_turns}"
   echo "Working directory: $(pwd)"
   echo ""

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/providers/_common.sh"
 # shellcheck source=/dev/null
+source "${SCRIPT_DIR}/providers/claude.sh"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/providers/codemie.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/providers/copilot.sh"
@@ -23,10 +25,11 @@ Runs the configured AI agent with the provided prompt.
 Provider is controlled by AI_AGENT_PROVIDER environment variable (default: cursor).
 
 Providers:
-  cursor   - Uses cursor-agent (default)
-  codemie  - Uses codemie-claude
-  copilot  - Uses GitHub Copilot CLI (npx @github/copilot)
-  kimi     - Uses Kimi Code CLI (kimi)
+  cursor       - Uses cursor-agent (default)
+  claude-code  - Uses Claude Code CLI via Bedrock proxy (ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY)
+  codemie      - Uses codemie-claude
+  copilot      - Uses GitHub Copilot CLI (npx @github/copilot)
+  kimi         - Uses Kimi Code CLI (kimi)
 
 Example:
   $(basename "$0") "process the input folder"
@@ -125,6 +128,9 @@ echo "AI Agent Usage Name: ${AI_AGENT_USAGE_NAME}"
 
 exit_code=0
 case "$PROVIDER" in
+  claude-code)
+    run_claude_code || exit_code=$?
+    ;;
   codemie)
     run_codemie || exit_code=$?
     ;;


### PR DESCRIPTION
## Changes

- Add `scripts/providers/claude.sh`: `run_claude_code()` function using `claude -p` via Bedrock proxy (`ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY`)
- Register `claude-code` case in `run-agent.sh` case statement  
- Fix `assignForReview.js`: require path was `./common/tokenUsageComment.js` (non-existent dir), fixed to `./js/common/tokenUsageComment.js`