### PR TITLE
fix: use stdin redirect for large prompts in claude-code provider (E2BIG)

### DIFF
--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -49,13 +49,14 @@ run_claude_code() {
 
   set +e
   if [ -f "${PROMPT_ARG}" ]; then
-    echo "Running: claude --allowedTools all --model ${claude_code_model} --max-turns ${claude_code_max_turns} -p (prompt: ${PROMPT_BYTES} bytes via file)"
+    echo "Running: claude --allowedTools all --model ${claude_code_model} --max-turns ${claude_code_max_turns} -p (prompt: ${PROMPT_BYTES} bytes via stdin)"
     echo ""
+    # Use stdin redirect to avoid "Argument list too long" for large prompts (E2BIG).
     claude --allowedTools all \
       --model "${claude_code_model}" \
       --max-turns "${claude_code_max_turns}" \
-      -p "$(cat "${PROMPT_ARG}")" \
       ${PASS_ARGS[@]+"${PASS_ARGS[@]}"} \
+      -p < "${PROMPT_ARG}" \
       2>&1 | tee "${claude_code_log}"
   else
     echo "Running: claude --allowedTools all --model ${claude_code_model} --max-turns ${claude_code_max_turns} -p (inline prompt: ${PROMPT_BYTES} bytes)"


### PR DESCRIPTION
## Problem
207KB prompt passed via `-p "$(cat file)"` hits Linux `ARG_MAX` limit → `Argument list too long` (exit 126).

## Fix
Use stdin redirect `-p < "${PROMPT_ARG}"` instead of shell expansion — same approach as `copilot.sh` provider.