### PR TITLE
fix(test-automation): add and remove test_pr_rework_needed label for review/rework loop

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -64,6 +64,7 @@ const LABELS = {
     NEEDS_CORE_IMPLEMENTATION: 'needs_core_implementation',
     AI_TEST_AUTOMATION: 'ai_test_automation',
     PR_APPROVED: 'pr_approved',             // Added to PR and ticket when AI approves, removed after merge attempt
+    TEST_PR_REWORK_NEEDED: 'test_pr_rework_needed', // Added when test-automation review requests changes; removed after rework
     AI_TESTS_GENERATED: 'ai_tests_generated' // Added after TestCasesGenerator runs — guards against re-generation on re-approval
 };
 

--- a/js/postStoryTestAutomationReview.js
+++ b/js/postStoryTestAutomationReview.js
@@ -326,6 +326,19 @@ function action(params) {
                 } catch (e) {
                     console.warn('Failed to add pr_approved to Jira Story:', e);
                 }
+            } else {
+                try {
+                    scm.addLabel(prNumber, LABELS.TEST_PR_REWORK_NEEDED);
+                    console.log('✅ Added test_pr_rework_needed label to GitHub PR');
+                } catch (e) {
+                    console.warn('Failed to add test_pr_rework_needed to GitHub PR:', e);
+                }
+                try {
+                    jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED });
+                    console.log('✅ Added test_pr_rework_needed label to Jira Story');
+                } catch (e) {
+                    console.warn('Failed to add test_pr_rework_needed to Jira Story:', e);
+                }
             }
         } else {
             console.warn('No PR number found — skipping GitHub comments');

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -144,6 +144,11 @@ function action(params) {
                 console.log('✅ Removed SM label:', removeLabel);
             } catch (e) {}
         }
+        try {
+            const { LABELS } = require('./config.js');
+            jira_remove_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED });
+            console.log('✅ Removed test_pr_rework_needed label');
+        } catch (e) {}
     }
 
     try {


### PR DESCRIPTION
- postStoryTestAutomationReview now adds `test_pr_rework_needed` when review requests changes.\n- storyTestAutomationRework now removes `test_pr_rework_needed` after rework so SM can re-trigger review.