### PR TITLE
fix(test-automation): disable context expansion for test-automation rework

### DIFF
--- a/bug_test_automation_rework.json
+++ b/bug_test_automation_rework.json
@@ -4,7 +4,7 @@
     "metadata": { "contextId": "bug_test_automation_rework" },
     "cliCommands": ["./agents/scripts/run-agent.sh"],
     "outputType": "none",
-    "ticketContextDepth": 1,
+    "ticketContextDepth": 0,
     "skipAIProcessing": true,
     "alwaysPostComments": true,
     "preJSAction": "agents/js/checkWipLabel.js",

--- a/story_test_automation_rework.json
+++ b/story_test_automation_rework.json
@@ -4,7 +4,7 @@
     "metadata": { "contextId": "story_test_automation_rework" },
     "cliCommands": ["./agents/scripts/run-agent.sh"],
     "outputType": "none",
-    "ticketContextDepth": 1,
+    "ticketContextDepth": 0,
     "skipAIProcessing": true,
     "alwaysPostComments": true,
     "preJSAction": "agents/js/checkWipLabel.js",


### PR DESCRIPTION
Sets `ticketContextDepth: 0` for story/bug test-automation rework so the preCli linked-test-case fetch does not recursively expand 60+ linked issues and risk timing out.