### PR TITLE
fix(story-test-automation): resolve stale agent review threads and robustly clean SM rework labels

### DIFF
--- a/js/postStoryTestAutomationReview.js
+++ b/js/postStoryTestAutomationReview.js
@@ -10,6 +10,7 @@
 
 const { LABELS } = require('./config.js');
 const scmModule = require('./common/scm.js');
+const ghHelpers = require('./common/githubHelpers.js');
 const autoStart = require('./common/autoStart.js');
 const configLoader = require('./configLoader.js');
 const outputFiles = require('./common/outputFiles.js');
@@ -220,6 +221,55 @@ function resolveApprovedThreads(scm, prNumber, resolvedThreadIds) {
     });
 }
 
+function getRepoInfo(config) {
+    if (config && config.repository && config.repository.owner && config.repository.repo) {
+        return { owner: config.repository.owner, repo: config.repository.repo };
+    }
+    try {
+        return ghHelpers.getGitHubRepoInfo();
+    } catch (e) {
+        console.warn('Could not determine repo info:', e.message || e);
+        return null;
+    }
+}
+
+function resolveExistingBotReviewThreads(scm, prNumber, repoInfo) {
+    if (!repoInfo || !repoInfo.owner || !repoInfo.repo || !prNumber) return;
+    try {
+        var discussions = ghHelpers.fetchDiscussionsAndRawData(repoInfo.owner, repoInfo.repo, prNumber);
+        if (!discussions || !discussions.rawThreads || !discussions.rawThreads.threads) return;
+
+        var botThreads = discussions.rawThreads.threads.filter(function(t) {
+            return t.bot === true && t.threadId && !t.resolved;
+        });
+        if (botThreads.length === 0) return;
+
+        console.log('Resolving ' + botThreads.length + ' stale bot-authored review thread(s) before posting new feedback...');
+        botThreads.forEach(function(t) {
+            try {
+                scm.resolveThread(prNumber, { threadId: t.threadId });
+                console.log('✅ Resolved stale bot thread', t.threadId);
+            } catch (e) {
+                console.warn('Failed to resolve stale bot thread', t.threadId + ':', e.message || e);
+            }
+        });
+    } catch (e) {
+        console.warn('Could not resolve stale bot review threads:', e.message || e);
+    }
+}
+
+function countOpenReviewThreads(scm, prNumber, repoInfo) {
+    if (!repoInfo || !repoInfo.owner || !repoInfo.repo || !prNumber) return 0;
+    try {
+        var discussions = ghHelpers.fetchDiscussionsAndRawData(repoInfo.owner, repoInfo.repo, prNumber);
+        if (!discussions || !discussions.rawThreads || !discussions.rawThreads.threads) return 0;
+        return discussions.rawThreads.threads.filter(function(t) { return !t.resolved; }).length;
+    } catch (e) {
+        console.warn('Could not count open review threads:', e.message || e);
+        return 0;
+    }
+}
+
 function triggerMerge(storyKey, config, customParams) {
     if (!customParams || !customParams.autoStartMerge || !customParams.autoStartMergeConfigFile) {
         return false;
@@ -299,8 +349,11 @@ function action(params) {
         console.log('Review recommendation:', reviewData.recommendation);
 
         const { prNumber, prUrl } = getPRNumber(params, storyKey, scm);
+        const repoInfo = getRepoInfo(config);
 
         if (prNumber) {
+            resolveExistingBotReviewThreads(scm, prNumber, repoInfo);
+
             if (reviewData.generalComment) {
                 postGeneralComment(scm, prNumber, reviewData.generalComment, storyKey, workingDir);
             }

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -9,6 +9,15 @@ var prHelper = require('./common/pullRequest.js');
 const { STATUSES } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
+function smLabelForContext(contextId) {
+    if (!contextId) return null;
+    var map = {
+        'story_test_automation_rework': 'sm_story_test_rework_triggered',
+        'bug_test_automation_rework': 'sm_bug_test_rework_triggered'
+    };
+    return map[contextId] || null;
+}
+
 function cleanCommandOutput(output) {
     if (!output) return '';
     return output.split('\n').filter(function(line) {
@@ -197,13 +206,18 @@ function action(params) {
     const config = configLoader.loadProjectConfig(params.jobParams || params);
     const scm = configLoader.createScm(config);
     const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
-    const removeLabel = customParams.removeLabel;
-    const wipLabel = actualParams.metadata && actualParams.metadata.contextId
-        ? actualParams.metadata.contextId + '_wip'
-        : 'story_test_automation_rework_wip';
+    const contextId = actualParams.metadata && actualParams.metadata.contextId;
+    const removeLabel = customParams.removeLabel || smLabelForContext(contextId);
+    const wipLabel = contextId ? contextId + '_wip' : null;
 
     function releaseWipLock() {
-        try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+        if (wipLabel) {
+            try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+        } else {
+            // If contextId is missing, clean up both known WIP labels defensively.
+            try { jira_remove_label({ key: storyKey, label: 'story_test_automation_rework_wip' }); } catch (e) {}
+            try { jira_remove_label({ key: storyKey, label: 'bug_test_automation_rework_wip' }); } catch (e) {}
+        }
         if (removeLabel) {
             try {
                 jira_remove_label({ key: storyKey, label: removeLabel });


### PR DESCRIPTION
- postStoryTestAutomationReview.js resolves previous ai-teammate/bot review threads before posting new feedback, preventing unbounded comment accumulation on story/bug test-automation PRs.\n- storyTestAutomationRework.js falls back to contextId-derived WIP/SM labels when runtime customParams are not passed.\n- githubHelpers.js and scm.js now include thread author in rawThreads so post-actions can identify agent-authored threads.