### PR TITLE
fix(test-automation): cap discussion context and stop rework reply flood

### DIFF
--- a/js/postStoryTestAutomationReview.js
+++ b/js/postStoryTestAutomationReview.js
@@ -10,6 +10,7 @@
 
 const { LABELS } = require('./config.js');
 const scmModule = require('./common/scm.js');
+const ghHelpers = require('./common/githubHelpers.js');
 const autoStart = require('./common/autoStart.js');
 const configLoader = require('./configLoader.js');
 const outputFiles = require('./common/outputFiles.js');
@@ -220,6 +221,55 @@ function resolveApprovedThreads(scm, prNumber, resolvedThreadIds) {
     });
 }
 
+function getRepoInfo(config) {
+    if (config && config.repository && config.repository.owner && config.repository.repo) {
+        return { owner: config.repository.owner, repo: config.repository.repo };
+    }
+    try {
+        return ghHelpers.getGitHubRepoInfo();
+    } catch (e) {
+        console.warn('Could not determine repo info:', e.message || e);
+        return null;
+    }
+}
+
+function resolveExistingBotReviewThreads(scm, prNumber, repoInfo) {
+    if (!repoInfo || !repoInfo.owner || !repoInfo.repo || !prNumber) return;
+    try {
+        var discussions = ghHelpers.fetchDiscussionsAndRawData(repoInfo.owner, repoInfo.repo, prNumber);
+        if (!discussions || !discussions.rawThreads || !discussions.rawThreads.threads) return;
+
+        var botThreads = discussions.rawThreads.threads.filter(function(t) {
+            return t.bot === true && t.threadId && !t.resolved;
+        });
+        if (botThreads.length === 0) return;
+
+        console.log('Resolving ' + botThreads.length + ' stale bot-authored review thread(s) before posting new feedback...');
+        botThreads.forEach(function(t) {
+            try {
+                scm.resolveThread(prNumber, { threadId: t.threadId });
+                console.log('✅ Resolved stale bot thread', t.threadId);
+            } catch (e) {
+                console.warn('Failed to resolve stale bot thread', t.threadId + ':', e.message || e);
+            }
+        });
+    } catch (e) {
+        console.warn('Could not resolve stale bot review threads:', e.message || e);
+    }
+}
+
+function countOpenReviewThreads(scm, prNumber, repoInfo) {
+    if (!repoInfo || !repoInfo.owner || !repoInfo.repo || !prNumber) return 0;
+    try {
+        var discussions = ghHelpers.fetchDiscussionsAndRawData(repoInfo.owner, repoInfo.repo, prNumber);
+        if (!discussions || !discussions.rawThreads || !discussions.rawThreads.threads) return 0;
+        return discussions.rawThreads.threads.filter(function(t) { return !t.resolved; }).length;
+    } catch (e) {
+        console.warn('Could not count open review threads:', e.message || e);
+        return 0;
+    }
+}
+
 function triggerMerge(storyKey, config, customParams) {
     if (!customParams || !customParams.autoStartMerge || !customParams.autoStartMergeConfigFile) {
         return false;
@@ -299,8 +349,11 @@ function action(params) {
         console.log('Review recommendation:', reviewData.recommendation);
 
         const { prNumber, prUrl } = getPRNumber(params, storyKey, scm);
+        const repoInfo = getRepoInfo(config);
 
         if (prNumber) {
+            resolveExistingBotReviewThreads(scm, prNumber, repoInfo);
+
             if (reviewData.generalComment) {
                 postGeneralComment(scm, prNumber, reviewData.generalComment, storyKey, workingDir);
             }

--- a/js/postTestReworkResults.js
+++ b/js/postTestReworkResults.js
@@ -346,27 +346,36 @@ function postThreadReplies(scm, pullRequestId) {
     if (replies.length === 0) return 0;
 
     let posted = 0;
+    let resolved = 0;
     replies.forEach(function(item) {
-        try {
-            scm.replyToThread(pullRequestId, {
-                rootCommentId: item.inReplyToId,
-                threadId: item.threadId || item.discussionId
-            }, item.reply || '✅ Addressed.');
-            posted++;
-        } catch (e) {
-            console.warn('Failed to reply to comment #' + item.inReplyToId + ':', e);
+        const thread = {
+            rootCommentId: item.inReplyToId,
+            threadId: item.threadId || item.discussionId
+        };
+        const replyText = item.reply ? String(item.reply).trim() : '';
+
+        // Only post a reply when the agent explicitly wrote one. Default "✅ Addressed."
+        // replies to every unresolved thread quickly exhaust GitHub's secondary rate limit.
+        if (replyText) {
+            try {
+                scm.replyToThread(pullRequestId, thread, replyText);
+                posted++;
+            } catch (e) {
+                console.warn('Failed to reply to comment #' + item.inReplyToId + ':', e);
+            }
         }
 
         if (item.threadId) {
             try {
                 scm.resolveThread(pullRequestId, { threadId: item.threadId });
+                resolved++;
             } catch (e) {
                 console.warn('Failed to resolve thread', item.threadId + ':', e);
             }
         }
     });
 
-    console.log('Posted ' + posted + '/' + replies.length + ' thread replies');
+    console.log('Resolved ' + resolved + '/' + replies.length + ' review thread(s); posted ' + posted + ' explicit reply(ies)');
     return posted;
 }
 

--- a/js/preCliStoryTestAutomationSetup.js
+++ b/js/preCliStoryTestAutomationSetup.js
@@ -20,6 +20,21 @@ function cleanCommandOutput(output) {
     }).join('\n').trim();
 }
 
+var MAX_DISCUSSION_THREADS = 100;
+
+function trimDiscussionsMarkdown(markdown, maxThreads) {
+    if (!markdown || maxThreads <= 0) return markdown;
+    var marker = '\n### Thread ';
+    var idx = markdown.indexOf(marker);
+    if (idx === -1) return markdown;
+    var header = markdown.substring(0, idx);
+    var rest = markdown.substring(idx + marker.length);
+    var sections = rest.split(marker);
+    if (sections.length <= maxThreads) return markdown;
+    var kept = sections.slice(sections.length - maxThreads);
+    return header + marker + kept.join(marker);
+}
+
 function runGit(command, workingDir) {
     var args = { command: command };
     if (workingDir) args.workingDirectory = workingDir;
@@ -239,11 +254,20 @@ function writePrContext(storyKey, scm, pr) {
     try {
         var discussions = scm.fetchDiscussions(pr.number);
         if (discussions && discussions.markdown) {
-            file_write({ path: inputDir + '/pr_discussions.md', content: discussions.markdown });
+            var trimmedMarkdown = trimDiscussionsMarkdown(discussions.markdown, MAX_DISCUSSION_THREADS);
+            if (trimmedMarkdown !== discussions.markdown) {
+                console.warn('⚠️ PR discussions markdown truncated from full history to last ' + MAX_DISCUSSION_THREADS + ' threads to keep agent context bounded');
+            }
+            file_write({ path: inputDir + '/pr_discussions.md', content: trimmedMarkdown });
             console.log('✅ Wrote pr_discussions.md');
         }
         if (discussions && discussions.rawThreads && discussions.rawThreads.threads) {
-            var replies = discussions.rawThreads.threads
+            var rawThreads = discussions.rawThreads.threads;
+            if (rawThreads.length > MAX_DISCUSSION_THREADS) {
+                console.warn('⚠️ PR discussions raw threads truncated from ' + rawThreads.length + ' to last ' + MAX_DISCUSSION_THREADS + ' for review replies');
+                rawThreads = rawThreads.slice(rawThreads.length - MAX_DISCUSSION_THREADS);
+            }
+            var replies = rawThreads
                 .filter(function(t) { return !t.resolved && t.body; })
                 .map(function(t) {
                     return {

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -9,6 +9,15 @@ var prHelper = require('./common/pullRequest.js');
 const { STATUSES } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
+function smLabelForContext(contextId) {
+    if (!contextId) return null;
+    var map = {
+        'story_test_automation_rework': 'sm_story_test_rework_triggered',
+        'bug_test_automation_rework': 'sm_bug_test_rework_triggered'
+    };
+    return map[contextId] || null;
+}
+
 function cleanCommandOutput(output) {
     if (!output) return '';
     return output.split('\n').filter(function(line) {
@@ -197,13 +206,18 @@ function action(params) {
     const config = configLoader.loadProjectConfig(params.jobParams || params);
     const scm = configLoader.createScm(config);
     const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
-    const removeLabel = customParams.removeLabel;
-    const wipLabel = actualParams.metadata && actualParams.metadata.contextId
-        ? actualParams.metadata.contextId + '_wip'
-        : 'story_test_automation_rework_wip';
+    const contextId = actualParams.metadata && actualParams.metadata.contextId;
+    const removeLabel = customParams.removeLabel || smLabelForContext(contextId);
+    const wipLabel = contextId ? contextId + '_wip' : null;
 
     function releaseWipLock() {
-        try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+        if (wipLabel) {
+            try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+        } else {
+            // If contextId is missing, clean up both known WIP labels defensively.
+            try { jira_remove_label({ key: storyKey, label: 'story_test_automation_rework_wip' }); } catch (e) {}
+            try { jira_remove_label({ key: storyKey, label: 'bug_test_automation_rework_wip' }); } catch (e) {}
+        }
         if (removeLabel) {
             try {
                 jira_remove_label({ key: storyKey, label: removeLabel });


### PR DESCRIPTION
- Prevents review/rework agent from hanging by limiting PR discussion context to the last 100 threads.
- Stops the post-rework step from posting a default "✅ Addressed." reply to every unresolved thread, which exhausts GitHub's secondary rate limit. Threads are now resolved silently unless the agent wrote an explicit reply.