### PR TITLE
fix(automation): sanitize commit messages to avoid shell-injection rejection

### DIFF
--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -26,6 +26,19 @@ function sanitizeTitle(title) {
         .trim();
 }
 
+/** Escape a string so it can safely be placed inside a double-quoted shell argument.
+ *  CliCommandExecutor rejects: ; \n \r ` $(...) ${...} && || | > <
+ *  Jira summaries often contain angle brackets, arrows, etc. */
+function sanitizeCommitMessage(message) {
+    return String(message || '')
+        .replace(/->/g, '→')
+        .replace(/<-/g, '←')
+        .replace(/"/g, '\\"')
+        .replace(/[<>\`\|&;$\r\n]/g, ' ')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+}
+
 function extractPrUrl(output, runCommand, branchName, workingDir) {
     var cleaned = cleanCommandOutput(output);
     var urlMatch = cleaned.match(/https:\/\/(?:github\.com|[^/\s]*gitlab[^/\s]*|git\.epam\.com)\/[^\s]+/);
@@ -424,6 +437,7 @@ function createPullRequest(options) {
 module.exports = {
     cleanCommandOutput: cleanCommandOutput,
     sanitizeTitle: sanitizeTitle,
+    sanitizeCommitMessage: sanitizeCommitMessage,
     buildOriginFetchCommand: buildOriginFetchCommand,
     readTrackedStatus: readTrackedStatus,
     readStagedDiffStat: readStagedDiffStat,

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -279,7 +279,7 @@ function performGitOperations(branchName, commitMessage, workingDir, testFilesPa
             return { success: true, branchName: branchName, noNewCommit: true };
         }
 
-        runInRepo('git commit -m "' + commitMessage.replace(/"/g, '\\"') + '"', workingDir);
+        runInRepo('git commit -m "' + prHelper.sanitizeCommitMessage(commitMessage) + '"', workingDir);
 
         try {
             runInRepo('git push -u origin ' + branchName, workingDir);

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -347,7 +347,7 @@ function performGitOperations(branchName, commitMessage, workingDir, testFilesPa
         }
 
         console.log('Committing...');
-        runInRepo('git commit -m "' + commitMessage.replace(/"/g, '\\"') + '"', workingDir);
+        runInRepo('git commit -m "' + prHelper.sanitizeCommitMessage(commitMessage) + '"', workingDir);
 
         console.log('Pushing to remote...');
         fetchRemoteBranch(branchName, workingDir);

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -223,7 +223,7 @@ function performGitOperations(branchName, commitMessage, workingDir, testFilesPa
         }
 
         console.log('Committing...');
-        runInRepo('git commit -m "' + commitMessage.replace(/"/g, '\\"') + '"', workingDir);
+        runInRepo('git commit -m "' + prHelper.sanitizeCommitMessage(commitMessage) + '"', workingDir);
 
         console.log('Pushing to remote...');
         fetchRemoteBranch(branchName, workingDir);

--- a/js/unit-tests/test_postStoryTestAutomationResults.js
+++ b/js/unit-tests/test_postStoryTestAutomationResults.js
@@ -424,4 +424,54 @@ suite('postStoryTestAutomationResults: bulk result processing', function() {
         assert.equal(resumeCommands.length, 0);
     });
 
+    test('sanitizes shell metacharacters in commit message from ticket summary', function() {
+        var commands = [];
+
+        var module = loadPostStoryTestAutomationResults({
+            file_read: function(opts) {
+                if (opts.path === 'outputs/story_test_automation_result.json') {
+                    return JSON.stringify({
+                        storyKey: 'TS-140',
+                        overall: 'passed',
+                        summary: 'Mixed',
+                        results: [
+                            { testCaseKey: 'TS-141', status: 'passed', testPath: 'testing/tests/TS-141/test.py' }
+                        ]
+                    });
+                }
+                if (opts.path === 'outputs/tracker_comment.md') return 'h3. Story Test Result';
+                if (opts.path && opts.path.indexOf('.dmtools/config') !== -1) return null;
+                return null;
+            },
+            cli_execute_command: function(opts) {
+                commands.push(opts.command);
+                if (opts.command === 'git branch --show-current') return 'test/TS-140';
+                if (opts.command === 'git status --short -- testing') return '?? testing/tests/TS-141/test.py';
+                if (opts.command === 'git diff --cached --stat') return ' testing/tests/TS-141/test.py | 1 +';
+                if (opts.command.indexOf('git ls-remote --heads origin test/TS-140') === 0) return 'abc\trefs/heads/test/TS-140';
+                if (opts.command.indexOf('gh pr list --head test/TS-140') === 0) return '';
+                if (opts.command.indexOf('gh pr create') === 0) return 'https://github.com/IstiN/trackstate/pull/140';
+                return '';
+            },
+            jira_move_to_status: function() {},
+            jira_attach_file_to_ticket: function() {},
+            jira_update_field: function() {}
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-140', fields: { summary: "README uses '<repository>' and --header instead of '<fork>' and -H" } },
+            jobParams: { customParams: { removeLabel: 'sm_story_test_automation_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        var commitCmd = commands.filter(function(c) { return c.indexOf('git commit -m') === 0; })[0];
+        assert.ok(commitCmd, 'commit command was issued');
+        assert.notContains(commitCmd, '<');
+        assert.notContains(commitCmd, '>');
+        assert.notContains(commitCmd, ';');
+        assert.notContains(commitCmd, '|');
+        assert.notContains(commitCmd, '&');
+        assert.contains(commitCmd, 'TS-140 test: automate README uses');
+    });
+
 });

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -29,6 +29,23 @@ suite('pullRequest helper', function() {
         assert.notContains(title, '`', 'removes backtick');
     });
 
+    test('sanitizes commit messages and escapes quotes', function() {
+        var pr = loadPullRequestHelper();
+        var msg = pr.sanitizeCommitMessage("TS-1 Use <repo> and --header \"bad\" -> ok\nline");
+
+        assert.notContains(msg, '<', 'removes less-than');
+        assert.notContains(msg, '>', 'removes greater-than');
+        assert.notContains(msg, '|', 'removes pipe');
+        assert.notContains(msg, '&', 'removes ampersand');
+        assert.notContains(msg, ';', 'removes semicolon');
+        assert.notContains(msg, '$', 'removes dollar');
+        assert.notContains(msg, '`', 'removes backtick');
+        assert.notContains(msg, '\n', 'removes newline');
+        assert.contains(msg, '\\"bad\\"', 'escapes internal quotes');
+        assert.contains(msg, '→ ok', 'keeps readable arrow');
+        assert.equal(msg.indexOf('  '), -1, 'collapses whitespace');
+    });
+
     test('creates PR from temp body file and returns URL', function() {
         var commands = [];
         var writes = [];


### PR DESCRIPTION
Jira summaries can contain angle brackets, pipes, ampersands, etc. DMTools CliCommandExecutor rejects shell metacharacters in "git commit -m" arguments, causing post-story/test/mobile automation result commits to fail.\n\n- Adds common/pullRequest.sanitizeCommitMessage\n- Uses it in postStoryTestAutomationResults, postTestAutomationResults, postMobileTestAutomationResults\n- Adds unit + integration tests