### PR TITLE
perf(recover): cache open PR list to avoid GitHub rate limits

### DIFF
--- a/js/recoverDirtyReviewTestCase.js
+++ b/js/recoverDirtyReviewTestCase.js
@@ -16,20 +16,77 @@ var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var { STATUSES } = require('./config.js');
 
-function findOpenPRForTicket(scm, ticketKey) {
+var PR_CACHE_FILE = 'outputs/.recover_dirty_prs_cache.json';
+var PR_CACHE_TTL_MS = 5 * 60 * 1000;
+
+function _now() {
+    return new Date().getTime();
+}
+
+function _readCache() {
+    try {
+        var raw = file_read({ path: PR_CACHE_FILE });
+        if (raw) {
+            var parsed = JSON.parse(raw);
+            if (parsed && parsed.timestamp && (_now() - parsed.timestamp) < PR_CACHE_TTL_MS) {
+                return parsed.prList;
+            }
+        }
+    } catch (e) {
+        // ignore cache read errors
+    }
+    return null;
+}
+
+function _writeCache(prList) {
+    try {
+        file_write({ path: PR_CACHE_FILE, content: JSON.stringify({ timestamp: _now(), prList: prList }) });
+    } catch (e) {
+        // ignore cache write errors
+    }
+}
+
+function _parseJson(raw) {
+    if (typeof raw === 'string') {
+        try { return JSON.parse(raw); } catch (e) { return raw; }
+    }
+    return raw;
+}
+
+function _toArray(raw) {
+    var parsed = _parseJson(raw);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && parsed.value) return parsed.value;
+    if (parsed && parsed.items) return parsed.items;
+    return parsed ? [parsed] : [];
+}
+
+function listOpenPrsCached(scm, config) {
+    var cached = _readCache();
+    if (cached) {
+        console.log('Using cached open PR list (' + cached.length + ' PRs)');
+        return cached;
+    }
     try {
         var prList = scm.listPrs('open');
-        return (Array.isArray(prList) ? prList : []).find(function(pr) {
-            // Exact ticket match only — avoid false positives like TS-135 matching TS-1359
-            var titleMatch = pr.title && new RegExp('^' + ticketKey + '(\\b|\\s|[-:_])').test(pr.title);
-            var ref = pr.head && pr.head.ref ? pr.head.ref : '';
-            var branchMatch = ref === ticketKey || ref.endsWith('/' + ticketKey);
-            return titleMatch || branchMatch;
-        }) || null;
+        prList = _toArray(prList);
+        _writeCache(prList);
+        return prList;
     } catch (e) {
         console.error('Failed to list PRs:', e);
-        return null;
+        return [];
     }
+}
+
+function findOpenPRForTicket(scm, config, ticketKey) {
+    var prList = listOpenPrsCached(scm, config);
+    return prList.find(function(pr) {
+        // Exact ticket match only — avoid false positives like TS-135 matching TS-1359
+        var titleMatch = pr.title && new RegExp('^' + ticketKey + '(\\b|\\s|[-:_])').test(pr.title);
+        var ref = pr.head && pr.head.ref ? pr.head.ref : '';
+        var branchMatch = ref === ticketKey || ref.endsWith('/' + ticketKey);
+        return titleMatch || branchMatch;
+    }) || null;
 }
 
 function action(params) {
@@ -44,7 +101,7 @@ function action(params) {
     console.log('Recovering dirty-review Test Case:', ticketKey);
 
     var scm = scmModule.createScm(config);
-    var pr = findOpenPRForTicket(scm, ticketKey);
+    var pr = findOpenPRForTicket(scm, config, ticketKey);
 
     if (!pr) {
         console.log('No open PR found for', ticketKey, '— nothing to recover');
@@ -54,11 +111,16 @@ function action(params) {
     console.log('Found open PR #' + pr.number + ': ' + pr.title);
 
     var prDetail;
-    try {
-        prDetail = scm.getPr(pr.number);
-    } catch (e) {
-        console.error('Failed to get PR details:', e);
+    // Avoid an extra API call if the PR list already returned mergeability info
+    if (pr.mergeable !== undefined || pr.mergeableState || pr.mergeable_state) {
         prDetail = pr;
+    } else {
+        try {
+            prDetail = scm.getPr(pr.number);
+        } catch (e) {
+            console.error('Failed to get PR details:', e);
+            prDetail = pr;
+        }
     }
 
     var mergeableState = prDetail && (prDetail.mergeable_state || prDetail.mergeableState || '');


### PR DESCRIPTION
Caches the open PR list across per-ticket recovery calls and skips redundant getPr calls when mergeability info is already present.