### PR TITLE
fix(checkBugToFixReady): consider pending bugs linked to linked Test Cases

### DIFF
--- a/js/checkBugToFixReady.js
+++ b/js/checkBugToFixReady.js
@@ -9,9 +9,9 @@
  * - Otherwise → releases the SM idempotency label so the check re-runs next cycle.
  *
  * Story:
- * - Finds all linked Bugs.
- * - If all linked Bugs are in "Done" → moves Story to "Ready For Testing" to trigger
- *   a full re-test of all linked Test Cases.
+ * - Finds all linked Bugs AND all Bugs linked to linked Test Cases.
+ * - If every linked Bug (direct or through a Test Case) is in "Done" → moves Story
+ *   to "Ready For Testing" to trigger a full re-test of all linked Test Cases.
  * - Otherwise → releases the SM idempotency label so the check re-runs next cycle.
  */
 
@@ -36,18 +36,40 @@ function action(params) {
         }
     }
 
-    function findLinkedBugs() {
+    function findLinkedBugs(entityKey) {
+        var key = entityKey || ticketKey;
         return jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug',
+            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug',
             maxResults: 50
         }) || [];
     }
 
-    function findNotDoneBugs() {
+    function findNotDoneBugs(entityKey) {
+        var key = entityKey || ticketKey;
         return jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status != "Done"',
-            maxResults: 1
+            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug AND status != "Done"',
+            maxResults: 50
         }) || [];
+    }
+
+    function findLinkedTestCases() {
+        return jira_search_by_jql({
+            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "Test Case"',
+            maxResults: 100
+        }) || [];
+    }
+
+    function findPendingBugsInLinkedTestCases() {
+        var testCases = findLinkedTestCases();
+        var pending = [];
+        testCases.forEach(function(tc) {
+            var tcKey = tc.key;
+            var notDone = findNotDoneBugs(tcKey);
+            notDone.forEach(function(bug) {
+                pending.push({ tcKey: tcKey, bugKey: bug.key, status: bug.fields && bug.fields.status && bug.fields.status.name });
+            });
+        });
+        return pending;
     }
 
     try {
@@ -75,6 +97,18 @@ function action(params) {
         }
 
         if (issueType === 'Story') {
+            // Also check bugs linked to linked Test Cases before allowing the Story to re-test.
+            const pendingTcBugs = findPendingBugsInLinkedTestCases();
+            if (pendingTcBugs.length > 0) {
+                var details = pendingTcBugs.map(function(item) {
+                    return '* ' + item.bugKey + ' (' + item.status + ') via Test Case ' + item.tcKey;
+                }).join('\n');
+                console.log('Found', pendingTcBugs.length, 'pending Bug(s) linked to linked Test Cases — keeping Story in Bug To Fix');
+                console.log(details);
+                releaseLock();
+                return { success: true, action: 'waiting_for_tc_bugs', issueType, pendingTcBugs: pendingTcBugs, ticketKey };
+            }
+
             // All linked Bugs are Done → move Story back to Ready For Testing for re-test
             console.log('All', totalBugs, 'linked Bug(s) are Done — moving Story', ticketKey, 'to Ready For Testing');
 

--- a/js/unit-tests/test_checkBugToFixReady.js
+++ b/js/unit-tests/test_checkBugToFixReady.js
@@ -113,4 +113,50 @@ suite('checkBugToFixReady', function() {
         assert.deepEqual(removedLabels, [{ key: 'TS-90', label: 'sm_bug_to_fix_check_triggered' }]);
     });
 
+    test('keeps Story in Bug To Fix when a linked Test Case has a pending Bug', function() {
+        var moved = [];
+        var comments = [];
+        var removedLabels = [];
+
+        var module = loadCheckBugToFixReady({
+            jira_search_by_jql: function(args) {
+                var jql = args.jql;
+                // Direct linked bugs of the Story: one Done bug.
+                if (jql.indexOf('linkedIssues("TS-90")') !== -1 && jql.indexOf('issuetype = Bug') !== -1) {
+                    if (jql.indexOf('status != "Done"') !== -1) {
+                        return [];
+                    }
+                    return [{ key: 'TS-92', fields: { status: { name: 'Done' } } }];
+                }
+                // Linked Test Cases of the Story.
+                if (jql.indexOf('linkedIssues("TS-90")') !== -1 && jql.indexOf('issuetype = "Test Case"') !== -1) {
+                    return [{ key: 'TS-TC-1', fields: { status: { name: 'Bug To Fix' } } }];
+                }
+                // Bugs linked to the Test Case: one not-Done bug.
+                if (jql.indexOf('linkedIssues("TS-TC-1")') !== -1 && jql.indexOf('issuetype = Bug') !== -1) {
+                    if (jql.indexOf('status != "Done"') !== -1) {
+                        return [{ key: 'TS-95', fields: { status: { name: 'Ready For Testing' } } }];
+                    }
+                    return [
+                        { key: 'TS-95', fields: { status: { name: 'Ready For Testing' } } }
+                    ];
+                }
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_remove_label: function(args) { removedLabels.push(args); }
+        });
+
+        var result = module.action({
+            ticket: makeTicket('TS-90', 'Story'),
+            jobParams: { customParams: { removeLabel: 'sm_bug_to_fix_check_triggered' } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'waiting_for_tc_bugs');
+        assert.deepEqual(moved, []);
+        assert.deepEqual(removedLabels, [{ key: 'TS-90', label: 'sm_bug_to_fix_check_triggered' }]);
+    });
+
 });


### PR DESCRIPTION
Story should stay in Bug To Fix until all direct linked Bugs AND all Bugs linked to its linked Test Cases are Done. Prevents premature Ready For Testing while Test Cases are still blocked by open Bugs.