### PR TITLE
fix(agents): remove autoStartReview from bug/story test automation configs

### DIFF
--- a/bug_test_automation.json
+++ b/bug_test_automation.json
@@ -11,9 +11,7 @@
       "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
     },
     "customParams": {
-      "removeLabel": "sm_bug_test_automation_triggered",
-      "autoStartReview": true,
-      "autoStartReviewConfigFile": "agents/pr_bug_test_automation_review.json"
+      "removeLabel": "sm_bug_test_automation_triggered"
     },
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",

--- a/story_test_automation.json
+++ b/story_test_automation.json
@@ -11,9 +11,7 @@
       "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,pytest,python3,pip3,run-agent.sh"
     },
     "customParams": {
-      "removeLabel": "sm_story_test_automation_triggered",
-      "autoStartReview": true,
-      "autoStartReviewConfigFile": "agents/pr_story_test_automation_review.json"
+      "removeLabel": "sm_story_test_automation_triggered"
     },
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliStoryTestAutomationSetup.js",


### PR DESCRIPTION
Removes autoStartReview from bug_test_automation.json and story_test_automation.json. The SM already triggers review runs via its In Testing Bugs/Stories rules; the auto-start caused duplicate review workflows.