### PR TITLE
fix(sm): run pr_rework before test-automation merge rules

### DIFF
--- a/sm.json
+++ b/sm.json
@@ -126,6 +126,14 @@
           "enabled": true
         },
         {
+          "description": "In Rework Stories & Bugs → trigger pr_rework",
+          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Rework')",
+          "configFile": "agents/pr_rework.json",
+          "skipIfLabel": "sm_story_rework_triggered",
+          "addLabel": "sm_story_rework_triggered",
+          "enabled": true
+        },
+        {
           "description": "In Review Test Cases (pr_approved) → retry merge",
           "jql": "project = {jiraProject} AND issuetype in ('Test Case') AND status in ('In Review - Passed', 'In Review - Failed') AND labels = 'pr_approved' ORDER BY created ASC",
           "configFile": "agents/retry_merge_test.json",
@@ -144,14 +152,6 @@
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('In Testing') AND labels = 'pr_approved' ORDER BY created ASC",
           "configFile": "agents/bug_test_automation_merge.json",
           "localExecution": true,
-          "enabled": true
-        },
-        {
-          "description": "In Rework Stories & Bugs → trigger pr_rework",
-          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('In Rework')",
-          "configFile": "agents/pr_rework.json",
-          "skipIfLabel": "sm_story_rework_triggered",
-          "addLabel": "sm_story_rework_triggered",
           "enabled": true
         },
         {
@@ -193,7 +193,9 @@
           "jql": "project = {jiraProject} AND issuetype in ('Story') AND status in ('Ready For Testing')",
           "configFile": "agents/story_test_automation.json",
           "skipIfLabel": "sm_story_test_automation_triggered",
-          "skipIfLabels": ["sm_test_cases_triggered"],
+          "skipIfLabels": [
+            "sm_test_cases_triggered"
+          ],
           "addLabel": "sm_story_test_automation_triggered",
           "enabled": true
         },


### PR DESCRIPTION
Moves the In Rework Stories & Bugs → pr_rework rule ahead of test-automation merge rules so bug fixing takes priority over test automation.