### PR TITLE
fix(pr_review,pr_rework): skip when no open PR exists

### DIFF
--- a/js/checkWipLabel.js
+++ b/js/checkWipLabel.js
@@ -12,6 +12,10 @@
  * @param {Object} params.metadata - Job metadata containing contextId
  * @returns {boolean} false to stop processing, true to continue
  */
+
+var configLoader = require('./configLoader.js');
+var gh = require('./common/githubHelpers.js');
+
 function action(params) {
     try {
         const ticket = params.ticket;
@@ -58,6 +62,33 @@ function action(params) {
         }
         
         console.log('✅ Ticket ' + ticketKey + ' does not have WIP label "' + wipLabel + '" - continuing with processing');
+
+        // Optional: verify an open PR exists for review/rework agents.
+        var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+        if (customParams.checkOpenPR) {
+            try {
+                var config = configLoader.loadProjectConfig(params.jobParams || params);
+                var scm = configLoader.createScm(config);
+                var pr = gh.findPRForTicket(scm, ticketKey);
+                if (!pr) {
+                    console.log('⏸️  No open PR found for ' + ticketKey + ' - skipping processing');
+                    try {
+                        jira_post_comment({
+                            key: ticketKey,
+                            comment: 'h3. *Processing Skipped*\n\nNo open Pull Request found for this ticket. The review/rework agent cannot run without an existing PR.\n\n_Ticket will be processed again once a PR is available._'
+                        });
+                    } catch (commentError) {
+                        console.warn('Failed to post skip comment:', commentError);
+                    }
+                    console.log('checkWipLabel result: stop processing (no open PR)');
+                    return false;
+                }
+                console.log('✅ Found open PR #' + pr.number + ' for ' + ticketKey + ' - continuing');
+            } catch (prError) {
+                console.warn('Failed to check open PR (non-fatal):', prError);
+            }
+        }
+
         console.log('checkWipLabel result: continue processing');
         return true; // Continue processing
         

--- a/pr_review.json
+++ b/pr_review.json
@@ -18,7 +18,8 @@
     "postJSAction": "agents/js/postPRReviewComments.js",
     "customParams": {
       "removeLabel": "sm_story_review_triggered",
-      "allowApproveWithSuggestions": true
+      "allowApproveWithSuggestions": true,
+      "checkOpenPR": true
     },
     "outputSchemas": {
       "pr_review.json": {

--- a/pr_rework.json
+++ b/pr_rework.json
@@ -20,7 +20,8 @@
       "removeLabels": [
         "sm_story_rework_triggered",
         "sm_story_review_triggered"
-      ]
+      ],
+      "checkOpenPR": true
     },
     "inputJql": "key = PROJ-243",
     "cliPrompts": [


### PR DESCRIPTION
Adds an optional open-PR guard to checkWipLabel and enables it for pr_review and pr_rework agents, so they do not start when the ticket has no open Pull Request.