### PR TITLE
feat(sm): merge test-automation PR before moving bug to Done

### DIFF
--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -19,6 +19,7 @@
 const { STATUSES, LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+const mergeTestAutomationPR = require('./mergeStoryTestAutomationPR.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
@@ -202,8 +203,29 @@ function action(params) {
             return { success: true, action: 'waiting', totalTCs, blockingCount, blockingTCs: blockingTCs.map(function(tc) { return tc.key; }), ticketKey };
         }
 
-        // Step 3: All blocking Test Cases are resolved — move Bug to Done
-        console.log('All', totalTCs, 'linked Test Case(s) resolved — moving', ticketKey, 'to Done');
+        // Step 3: All blocking Test Cases are resolved.
+        // Before moving the Bug to Done, ensure any open test-automation PR is
+        // merged/finalized so it does not become an orphaned open PR.
+        console.log('All', totalTCs, 'linked Test Case(s) resolved — checking test-automation PR before Done');
+
+        var mergeResult = mergeTestAutomationPR.attemptMerge(params);
+        if (!mergeResult.success) {
+            console.log('Test-automation PR not ready to merge (' + (mergeResult.reason || 'unknown') + ') — keeping', ticketKey, 'in In Testing');
+            releaseLock();
+            return {
+                success: true,
+                action: 'waiting_for_test_pr_merge',
+                reason: mergeResult.reason,
+                prNumber: mergeResult.prNumber,
+                prUrl: mergeResult.prUrl,
+                totalTCs,
+                ticketKey
+            };
+        }
+        console.log('Test-automation PR resolved:', mergeResult.reason, mergeResult.prNumber || 'none');
+
+        // Step 4: Move Bug to Done
+        console.log('Moving', ticketKey, 'to Done');
 
         jira_move_to_status({
             key: ticketKey,

--- a/js/mergeStoryTestAutomationPR.js
+++ b/js/mergeStoryTestAutomationPR.js
@@ -1,13 +1,12 @@
 /**
- * Merge Story Test Automation PR
- * Merges the PR on branch test/{STORY_KEY} and moves all linked Test Cases
+ * Merge Story/Bug Test Automation PR
+ * Merges the PR on branch test/{TICKET_KEY} and moves all linked Test Cases
  * from In Review - Passed/Failed to Passed/Failed.
  */
 
 const { STATUSES, LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
-var autoStart = require('./common/autoStart.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function findPRForStory(scm, storyKey) {
@@ -67,23 +66,6 @@ function checkCiStatus(scm, headSha) {
         console.warn('Could not determine CI status:', e);
     }
     return result;
-}
-
-function triggerReworkDueToCIFailure(storyKey, prNumber, prUrl, scm, customParams, failedNames, issueType) {
-    console.log('CI checks failed — moving ticket to test-automation rework');
-    try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
-    try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
-    try { jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED }); } catch (e) {}
-    // Remove the SM skip label so the rework rule can actually trigger on the next cycle.
-    var reworkSkipLabel = issueType === 'Bug' ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
-    try { jira_remove_label({ key: storyKey, label: reworkSkipLabel }); } catch (e) {}
-    releaseLock(storyKey, customParams);
-    var checksList = failedNames && failedNames.length ? failedNames.join(', ') : 'unknown';
-    jira_post_comment({
-        key: storyKey,
-        comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *CI CHECKS FAILED* — PR #' + prNumber + ' is approved but required checks failed: ' + checksList + '. Moving to test-automation rework.\n\n[View PR|' + prUrl + ']{panel}'
-    });
-    return true;
 }
 
 function fetchLinkedTestCases(storyKey, testCaseType) {
@@ -157,8 +139,6 @@ function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, custom
         console.warn('Could not add test_pr_finalized label:', e);
     }
 
-    releaseLock(storyKey, customParams);
-
     var ticketLabel = issueType || 'Story';
     jira_post_comment({
         key: storyKey,
@@ -176,11 +156,24 @@ function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, custom
     return true;
 }
 
-function action(params) {
+/**
+ * Attempts to merge/finalize the test-automation PR for the given ticket.
+ * Does NOT move the ticket to a different status and does NOT release SM locks.
+ *
+ * Returns an object:
+ *   { success: true, noPr: true }                              — no PR found, nothing to do
+ *   { success: true, alreadyMerged: true, prNumber, prUrl }    — PR already merged, finalized
+ *   { success: true, reason: 'merged', prNumber, prUrl, tcResult } — PR merged now
+ *   { success: false, reason: 'missing_key'|'no_repo'|'no_pr'|     — could not proceed
+ *                             'ci_running'|'not_ready'|'behind'|
+ *                             'conflict'|'ci_failed'|'merge_failed',
+ *     prNumber?, prUrl?, failedNames?, error? }
+ */
+function attemptMerge(params) {
     const storyKey = params.ticket && params.ticket.key;
     if (!storyKey) {
         console.error('No storyKey provided');
-        return false;
+        return { success: false, reason: 'missing_key' };
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
@@ -196,19 +189,24 @@ function action(params) {
     const repoInfo = scm.getRemoteRepoInfo();
     if (!repoInfo) {
         console.error('Could not determine owner/repo');
-        releaseLock(storyKey, customParams);
-        return false;
+        return { success: false, reason: 'no_repo' };
     }
 
     const found = findPRForStory(scm, storyKey);
     if (!found) {
-        console.warn('No open or merged PR found for story', storyKey, '— releasing lock');
-        releaseLock(storyKey, customParams);
-        return false;
+        console.log('No open or merged PR found for', storyKey, '— nothing to merge');
+        return { success: true, noPr: true };
     }
 
     if (found.merged) {
-        return finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams);
+        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams);
+        return {
+            success: true,
+            alreadyMerged: true,
+            prNumber: found.pr.number,
+            prUrl: found.pr.html_url,
+            reason: 'already_merged'
+        };
     }
 
     const pr = found.pr;
@@ -240,14 +238,15 @@ function action(params) {
         mergeableState === 'ci_still_running') {
         const ci = checkCiStatus(scm, headSha);
         if (ci.failed) {
-            return triggerReworkDueToCIFailure(storyKey, prNumber, prUrl, scm, customParams, ci.failedNames, issueType);
+            console.log('PR #' + prNumber + ' CI checks failed');
+            return { success: false, reason: 'ci_failed', prNumber, prUrl, failedNames: ci.failedNames };
         }
         if (ci.inProgress || ci.total === 0) {
-            console.log('PR not ready to merge (' + mergeableState + ') — checks still running or unknown — will retry next cycle');
-            return false;
+            console.log('PR not ready to merge (' + mergeableState + ') — checks still running or unknown — will retry');
+            return { success: false, reason: 'ci_running', prNumber, prUrl };
         }
-        console.log('PR not ready to merge (' + mergeableState + ') — will retry next cycle');
-        return false;
+        console.log('PR not ready to merge (' + mergeableState + ') — will retry');
+        return { success: false, reason: 'not_ready', prNumber, prUrl };
     }
 
     if (mergeableState === 'behind') {
@@ -261,22 +260,14 @@ function action(params) {
         } catch (updateErr) {
             console.warn('Could not update branch:', updateErr);
         }
-        return false;
+        return { success: false, reason: 'behind', prNumber, prUrl };
     }
 
     if ((mergeable === false && mergeableState === 'dirty') ||
         mergeableState === 'cannot_be_merged' ||
         mergeableState === 'conflict') {
-        console.log('PR has merge conflict — moving Story to In Rework');
-        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
-        try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
-        releaseLock(storyKey, customParams);
-        jira_post_comment({
-            key: storyKey,
-            comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE CONFLICT* — PR #' + prNumber + ' has a merge conflict with main.\n\n[View PR|' + prUrl + ']{panel}'
-        });
-        jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
-        return true;
+        console.log('PR #' + prNumber + ' has merge conflict');
+        return { success: false, reason: 'conflict', prNumber, prUrl };
     }
 
     try {
@@ -285,17 +276,13 @@ function action(params) {
 
         try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
 
-        // Move linked Test Cases to final status before removing Jira pr_approved label
         var tcResult = moveLinkedTestCases(storyKey, testCaseType);
 
-        // Bug stays In Testing; bug_done_check will move it to Done only when all
-        // directly linked Test Cases are Passed. Story stays In Testing;
-        // story_done_check will move it to Done when all TCs are Passed
         try {
             jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
-            console.log('Removed pr_approved label from Jira Story');
+            console.log('Removed pr_approved label from Jira ticket');
         } catch (e) {
-            console.warn('Could not remove pr_approved from Jira Story:', e);
+            console.warn('Could not remove pr_approved from Jira ticket:', e);
         }
         try {
             jira_remove_label({ key: storyKey, label: LABELS.TEST_PR_MERGED });
@@ -308,8 +295,6 @@ function action(params) {
         } catch (e) {
             console.warn('Could not add test_pr_finalized label:', e);
         }
-
-        releaseLock(storyKey, customParams);
 
         var ticketLabel = issueType || 'Story';
         jira_post_comment({
@@ -325,7 +310,7 @@ function action(params) {
             console.warn('Failed to post token usage comments:', e);
         }
 
-        return true;
+        return { success: true, reason: 'merged', prNumber, prUrl, tcResult };
 
     } catch (mergeErr) {
         console.warn('Merge failed:', mergeErr);
@@ -336,29 +321,80 @@ function action(params) {
         if (!isConflict && (isCIBlocking || errMsg === '')) {
             const ci = checkCiStatus(scm, headSha);
             if (ci.failed) {
-                return triggerReworkDueToCIFailure(storyKey, prNumber, prUrl, scm, customParams, ci.failedNames, issueType);
+                return { success: false, reason: 'ci_failed', prNumber, prUrl, failedNames: ci.failedNames };
             }
             if (ci.inProgress || ci.total === 0) {
-                console.log('Merge blocked temporarily — checks still running or unknown — will retry next cycle');
-                return false;
+                console.log('Merge blocked temporarily — checks still running or unknown — will retry');
+                return { success: false, reason: 'ci_running', prNumber, prUrl };
             }
-            console.log('Merge blocked temporarily — will retry next cycle');
-            return false;
         }
 
-        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
-        try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
-        releaseLock(storyKey, customParams);
-        const reason = isConflict ? 'merge conflict' : 'CI checks failing or PR not mergeable';
-        jira_post_comment({
-            key: storyKey,
-            comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE FAILED* — Could not merge PR #' + prNumber + ': ' + reason + '.\n\n[View PR|' + prUrl + ']{panel}'
-        });
-        jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
-        return true;
+        return { success: false, reason: isConflict ? 'conflict' : 'merge_failed', prNumber, prUrl, error: errMsg };
     }
 }
 
+function action(params) {
+    const storyKey = params.ticket && params.ticket.key;
+    if (!storyKey) {
+        console.error('No storyKey provided');
+        return false;
+    }
+
+    var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
+    var issueType = params.ticket && params.ticket.fields &&
+        params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
+
+    var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var scm = scmModule.createScm(config);
+
+    const mergeResult = attemptMerge(params);
+
+    if (mergeResult.success) {
+        releaseLock(storyKey, customParams);
+        return true;
+    }
+
+    const prNumber = mergeResult.prNumber;
+    const prUrl = mergeResult.prUrl;
+
+    if (mergeResult.reason === 'ci_running' || mergeResult.reason === 'behind' || mergeResult.reason === 'not_ready') {
+        // Keep lock; SM will retry on the next cycle.
+        return false;
+    }
+
+    if (mergeResult.reason === 'missing_key' || mergeResult.reason === 'no_repo') {
+        releaseLock(storyKey, customParams);
+        return false;
+    }
+
+    // Conflict, CI failure, or other merge failure — move ticket to test-automation rework.
+    console.log('Test-automation PR merge failed (' + mergeResult.reason + ') — moving ticket to In Rework');
+
+    if (prNumber) {
+        try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
+    }
+    try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
+    try { jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED }); } catch (e) {}
+    var reworkSkipLabel = issueType === 'Bug' ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
+    try { jira_remove_label({ key: storyKey, label: reworkSkipLabel }); } catch (e) {}
+
+    releaseLock(storyKey, customParams);
+
+    var checksList = mergeResult.failedNames && mergeResult.failedNames.length ? mergeResult.failedNames.join(', ') : 'unknown';
+    var isConflict = mergeResult.reason === 'conflict';
+    var panelTitle = isConflict ? 'MERGE CONFLICT' : 'MERGE FAILED';
+    var reasonText = isConflict ? 'merge conflict' : 'CI checks failing or PR not mergeable';
+    if (mergeResult.reason === 'ci_failed' && mergeResult.failedNames) {
+        reasonText = 'required checks failed: ' + checksList;
+    }
+    jira_post_comment({
+        key: storyKey,
+        comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *' + panelTitle + '* — Could not merge PR #' + (prNumber || 'unknown') + ': ' + reasonText + '.\n\n' + (prUrl ? '[View PR|' + prUrl + ']' : '') + '{panel}'
+    });
+    jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+    return true;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action };
+    module.exports = { action, attemptMerge };
 }

--- a/js/test/bug_done_and_test_pr_merge.test.js
+++ b/js/test/bug_done_and_test_pr_merge.test.js
@@ -1,0 +1,365 @@
+/**
+ * Unit tests for:
+ *  - mergeStoryTestAutomationPR.attemptMerge
+ *  - checkBugTestsPassed.action
+ *
+ * Runs with plain Node.js. Mocks DMTools globals and the scm/configLoader
+ * dependencies so no network calls or real Jira/GitHub state is touched.
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+const AGENT_JS_DIR = path.resolve(__dirname, '..');
+
+// ---- test state collectors -------------------------------------------------
+const calls = {
+    jiraMove: [],
+    jiraAddLabel: [],
+    jiraRemoveLabel: [],
+    jiraPostComment: [],
+    jiraSearch: [],
+    githubMerge: [],
+    githubListPrs: [],
+    githubGetPr: [],
+    githubGetCommitChecks: [],
+    cliExecute: []
+};
+
+function resetCalls() {
+    for (const k of Object.keys(calls)) calls[k] = [];
+}
+
+// ---- DMTools globals used by the modules -----------------------------------
+global.jira_get_ticket = function(opts) {
+    return opts && opts.__ticket ? opts.__ticket : {};
+};
+global.jira_move_to_status = function(opts) {
+    calls.jiraMove.push(opts);
+};
+global.jira_add_label = function(opts) {
+    calls.jiraAddLabel.push(opts);
+};
+global.jira_remove_label = function(opts) {
+    calls.jiraRemoveLabel.push(opts);
+};
+global.jira_post_comment = function(opts) {
+    calls.jiraPostComment.push(opts);
+};
+global.jira_search_by_jql = function(opts) {
+    calls.jiraSearch.push(opts);
+    return opts && opts.__results ? opts.__results : [];
+};
+
+global.github_merge_pr = function(opts) {
+    calls.githubMerge.push(opts);
+    if (opts && opts.__throw) throw new Error(opts.__throw);
+    return { merged: true };
+};
+global.github_list_prs = function(opts) {
+    calls.githubListPrs.push(opts);
+    return opts && opts.__results ? opts.__results : [];
+};
+global.github_get_pr = function(opts) {
+    calls.githubGetPr.push(opts);
+    return opts && opts.__pr ? opts.__pr : {};
+};
+global.github_get_commit_check_runs = function(opts) {
+    calls.githubGetCommitChecks.push(opts);
+    return opts && opts.__checks ? opts.__checks : [];
+};
+global.cli_execute_command = function(opts) {
+    calls.cliExecute.push(opts);
+    if (opts && opts.__return !== undefined) return opts.__return;
+    return '';
+};
+global.file_read = function() { return ''; };
+
+// ---- dependency mocks ------------------------------------------------------
+const fakeProjectConfig = {
+    jira: {
+        issueTypes: {
+            TEST_CASE: 'Test Case',
+            BUG: 'Bug'
+        }
+    }
+};
+
+function fakeScmFor(scenario) {
+    scenario = scenario || {};
+    return {
+        getRemoteRepoInfo: function() {
+            return { owner: 'IstiN', repo: 'trackstate' };
+        },
+        listPrs: function(state) {
+            const list = state === 'open' ? (scenario.openPrs || []) : (scenario.closedPrs || []);
+            return JSON.parse(JSON.stringify(list));
+        },
+        getPr: function(id) {
+            return JSON.parse(JSON.stringify(scenario.prDetail || {}));
+        },
+        getCommitCheckRuns: function(sha) {
+            return JSON.parse(JSON.stringify(scenario.checkRuns || []));
+        },
+        mergePr: function(id, method) {
+            calls.githubMerge.push({ pullRequestId: id, mergeMethod: method });
+            if (scenario.mergeThrows) throw new Error(scenario.mergeThrows);
+            return { merged: true };
+        },
+        removeLabel: function(id, label) {
+            calls.jiraRemoveLabel.push({ pr: id, label: label });
+        },
+        addLabel: function(id, label) {
+            calls.jiraAddLabel.push({ pr: id, label: label });
+        },
+        updateBranch: function(id) {
+            scenario.updated = true;
+        }
+    };
+}
+
+function installMocks(scenario) {
+    const scmMock = { createScm: function() { return fakeScmFor(scenario); } };
+    const configLoaderMock = { loadProjectConfig: function() { return fakeProjectConfig; } };
+    const tokenUsageMock = { postTokenUsageComments: function() {} };
+
+    setModuleMock(path.join(AGENT_JS_DIR, 'common', 'scm.js'), scmMock);
+    setModuleMock(path.join(AGENT_JS_DIR, 'configLoader.js'), configLoaderMock);
+    setModuleMock(path.join(AGENT_JS_DIR, 'common', 'tokenUsageComment.js'), tokenUsageMock);
+}
+
+function setModuleMock(file, exports) {
+    const mod = {
+        id: file,
+        filename: file,
+        loaded: true,
+        exports: exports,
+        children: [],
+        paths: []
+    };
+    require.cache[file] = mod;
+}
+
+function requireFresh(modulePath) {
+    const absPath = require.resolve(path.join(AGENT_JS_DIR, modulePath));
+    delete require.cache[absPath];
+    return require(absPath);
+}
+
+// ---- tests -----------------------------------------------------------------
+
+function runTests() {
+    console.log('Running JS unit tests for bug_done + test-automation PR merge\n');
+
+    // ------------------------------------------------------------------------
+    test('attemptMerge: no test-automation PR => success/noPr', function() {
+        resetCalls();
+        installMocks({ openPrs: [], closedPrs: [] });
+        const merger = requireFresh('./mergeStoryTestAutomationPR.js');
+        const result = merger.attemptMerge(makeParams('TS-9999'));
+        assert.strictEqual(result.success, true, 'should succeed');
+        assert.strictEqual(result.noPr, true, 'should report no PR');
+        assert.strictEqual(calls.githubMerge.length, 0, 'should not attempt merge');
+    });
+
+    test('attemptMerge: already merged PR => finalizes labels', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [],
+            closedPrs: [{ number: 2001, html_url: 'http://pr/2001', head: { ref: 'test/TS-1000' }, merged_at: '2026-01-01' }]
+        };
+        installMocks(scenario);
+        const merger = requireFresh('./mergeStoryTestAutomationPR.js');
+        const result = merger.attemptMerge(makeParams('TS-1000'));
+        assert.strictEqual(result.success, true, 'should succeed');
+        assert.strictEqual(result.alreadyMerged, true, 'should report already merged');
+        assertLabelAdded('TS-1000', 'test_pr_finalized');
+    });
+
+    test('attemptMerge: CI still running => blocks merge', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [{ number: 2002, html_url: 'http://pr/2002', head: { ref: 'test/TS-1001' } }],
+            prDetail: { mergeable: true, mergeable_state: 'blocked', head: { sha: 'abc' } },
+            checkRuns: [{ name: 'Flutter checks', status: 'in_progress', conclusion: null }]
+        };
+        installMocks(scenario);
+        const merger = requireFresh('./mergeStoryTestAutomationPR.js');
+        const result = merger.attemptMerge(makeParams('TS-1001'));
+        assert.strictEqual(result.success, false, 'should fail');
+        assert.strictEqual(result.reason, 'ci_running', 'should report CI running');
+        assert.strictEqual(calls.githubMerge.length, 0, 'should not attempt merge');
+    });
+
+    test('attemptMerge: clean PR => merges and finalizes', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [{ number: 2003, html_url: 'http://pr/2003', head: { ref: 'test/TS-1002' } }],
+            prDetail: { mergeable: true, mergeable_state: 'clean', head: { sha: 'def' } },
+            checkRuns: [{ name: 'Flutter checks', status: 'completed', conclusion: 'success' }]
+        };
+        installMocks(scenario);
+        const merger = requireFresh('./mergeStoryTestAutomationPR.js');
+        const result = merger.attemptMerge(makeParams('TS-1002'));
+        assert.strictEqual(result.success, true, 'should succeed');
+        assert.strictEqual(result.reason, 'merged', 'should report merged');
+        assert.strictEqual(result.prNumber, 2003, 'should return PR number');
+        assertLabelAdded('TS-1002', 'test_pr_finalized');
+        assert.strictEqual(calls.githubMerge.length, 1, 'should call github_merge_pr');
+    });
+
+    test('attemptMerge: merge conflict => reports conflict without status change', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [{ number: 2004, html_url: 'http://pr/2004', head: { ref: 'test/TS-1003' } }],
+            prDetail: { mergeable: false, mergeable_state: 'dirty', head: { sha: 'ghi' } },
+            checkRuns: []
+        };
+        installMocks(scenario);
+        const merger = requireFresh('./mergeStoryTestAutomationPR.js');
+        const result = merger.attemptMerge(makeParams('TS-1003'));
+        assert.strictEqual(result.success, false, 'should fail');
+        assert.strictEqual(result.reason, 'conflict', 'should report conflict');
+        assert.strictEqual(calls.jiraMove.length, 0, 'should not move Jira ticket');
+    });
+
+    // ------------------------------------------------------------------------
+    test('checkBugTestsPassed: all TCs passed + PR merged => moves bug to Done', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [{ number: 2005, html_url: 'http://pr/2005', head: { ref: 'test/TS-2000' } }],
+            prDetail: { mergeable: true, mergeable_state: 'clean', head: { sha: 'jkl' } },
+            checkRuns: [{ name: 'Flutter checks', status: 'completed', conclusion: 'success' }]
+        };
+        installMocks(scenario);
+        requireFresh('./mergeStoryTestAutomationPR.js');
+        const doneCheck = requireFresh('./checkBugTestsPassed.js');
+
+        const params = makeParams('TS-2000', {
+            directTCs: [{ key: 'TS-5000', fields: { status: { name: 'Passed' } } }]
+        });
+        const result = doneCheck.action(params);
+
+        assert.strictEqual(result.action, 'moved_to_done', 'should move to Done');
+        assertJiraMovedTo('TS-2000', 'Done');
+        assertLabelAdded('TS-2000', 'test_pr_finalized');
+    });
+
+    test('checkBugTestsPassed: all TCs passed but PR not ready => keeps bug in In Testing', function() {
+        resetCalls();
+        const scenario = {
+            openPrs: [{ number: 2006, html_url: 'http://pr/2006', head: { ref: 'test/TS-2001' } }],
+            prDetail: { mergeable: true, mergeable_state: 'blocked', head: { sha: 'mno' } },
+            checkRuns: [{ name: 'Flutter checks', status: 'in_progress', conclusion: null }]
+        };
+        installMocks(scenario);
+        requireFresh('./mergeStoryTestAutomationPR.js');
+        const doneCheck = requireFresh('./checkBugTestsPassed.js');
+
+        const params = makeParams('TS-2001', {
+            directTCs: [{ key: 'TS-5001', fields: { status: { name: 'Passed' } } }]
+        });
+        const result = doneCheck.action(params);
+
+        assert.strictEqual(result.action, 'waiting_for_test_pr_merge', 'should wait for PR merge');
+        assert.strictEqual(calls.jiraMove.length, 0, 'should not move Jira ticket');
+    });
+
+    test('checkBugTestsPassed: blocking TC => does not merge or move to Done', function() {
+        resetCalls();
+        installMocks({ openPrs: [], closedPrs: [] });
+        requireFresh('./mergeStoryTestAutomationPR.js');
+        const doneCheck = requireFresh('./checkBugTestsPassed.js');
+
+        const params = makeParams('TS-2002', {
+            directTCs: [{ key: 'TS-5002', fields: { status: { name: 'Failed' } } }]
+        });
+        const result = doneCheck.action(params);
+
+        assert.strictEqual(result.action, 'waiting', 'should wait for TCs');
+        assert.strictEqual(calls.jiraMove.length, 0, 'should not move Jira ticket');
+        assert.strictEqual(calls.githubMerge.length, 0, 'should not attempt PR merge');
+    });
+
+    console.log('\n✅ All JS unit tests passed');
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeParams(ticketKey, opts) {
+    opts = opts || {};
+    const ticket = {
+        key: ticketKey,
+        fields: {
+            issuetype: { name: 'Bug' },
+            labels: [],
+            issuelinks: (opts.directTCs || []).map(function(tc) {
+                return { outwardIssue: tc };
+            })
+        }
+    };
+
+    const params = {
+        ticket: ticket,
+        jobParams: {
+            customParams: {
+                removeLabel: 'sm_bug_done_check_triggered'
+            }
+        }
+    };
+
+    // Patch jira_get_ticket to return our ticket for this params object only.
+    const originalGetTicket = global.jira_get_ticket;
+    global.jira_get_ticket = function() { return ticket; };
+
+    // Patch jira_search_by_jql to return direct TCs for linkedIssues fallback.
+    const originalSearch = global.jira_search_by_jql;
+    global.jira_search_by_jql = function(q) {
+        if (q && q.jql && q.jql.indexOf('linkedIssues') !== -1 && q.jql.indexOf('issuetype = "Test Case"') !== -1) {
+            return opts.directTCs || [];
+        }
+        if (q && q.jql && q.jql.indexOf('issuetype = "Bug"') !== -1) {
+            return [];
+        }
+        return [];
+    };
+
+    // Restore originals after action returns.
+    const cleanup = function() {
+        global.jira_get_ticket = originalGetTicket;
+        global.jira_search_by_jql = originalSearch;
+    };
+    params.__cleanup = cleanup;
+    return params;
+}
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log('  ✅', name);
+    } catch (e) {
+        console.error('  ❌', name);
+        console.error(e.stack || e.message);
+        process.exitCode = 1;
+    } finally {
+        // Restore patched globals if params had cleanup.
+        // Tests that use makeParams should not need it because we patched globals directly,
+        // but this is a safety net.
+    }
+}
+
+function assertLabelAdded(ticketKey, label) {
+    const found = calls.jiraAddLabel.some(function(c) {
+        return c.key === ticketKey && c.label === label;
+    });
+    assert.ok(found, 'expected label ' + label + ' to be added to ' + ticketKey);
+}
+
+function assertJiraMovedTo(ticketKey, status) {
+    const found = calls.jiraMove.some(function(c) {
+        return c.key === ticketKey && c.statusName === status;
+    });
+    assert.ok(found, 'expected ' + ticketKey + ' to be moved to ' + status);
+}
+
+runTests();


### PR DESCRIPTION
- Refactors "mergeStoryTestAutomationPR.js" to expose "attemptMerge()" which performs merge/finalization without changing ticket status or releasing SM locks.\n- Updates "bug_done_check" to call "attemptMerge()" before moving a bug to Done; blocks Done if the test-automation PR is not ready.\n- Adds JS unit tests for the new behavior.