### PR TITLE
feat(sm): add localTeammate execution mode — run the full pipeline locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ The SM agent (`smAgent.js`) is the central orchestrator. Every 20 minutes:
 2. For each enabled rule, runs the JQL query against Jira
 3. For each matching ticket, checks `skipIfLabel` — skips the ticket if the label is already present (lock is held)
 4. Adds `addLabel` to the ticket (acquires lock)
-5. Either dispatches a GitHub Actions `workflow_dispatch` to `ai-teammate.yml` (with `config_file` and `concurrency_key` inputs), **or** executes the JS logic locally (`localExecution: true`)
+5. Either dispatches a GitHub Actions `workflow_dispatch` to `ai-teammate.yml` (with `config_file` and `concurrency_key` inputs), executes the JS logic locally (`localExecution: true`), **or** runs the full teammate pipeline synchronously on the local machine (`localTeammate: true`)
 
 ### Execution Modes
 
 | Mode | When Used | Behavior |
 |------|-----------|----------|
 | **Dispatch** (default) | Complex AI tasks (development, review, test gen) | Triggers `ai-teammate.yml` workflow on GitHub Actions; runs asynchronously |
-| **localExecution: true** | Fast/safe operations (merge checks, status checks) | Runs the postJS directly inside the SM process; synchronous |
+| **localExecution: true** | Fast/safe operations (merge checks, status checks) | Runs the postJS directly inside the SM process; synchronous; no AI CLI, no checkout |
+| **localTeammate: true** | Running the SM/AI Teammate pipeline on a local machine instead of GitHub Actions (e.g. no self-hosted runner available, or for fast local iteration) | Runs `scripts/run-teammate-local.sh`, which calls the same `dmtools run <config_file>` entrypoint `ai-teammate.yml` uses — full checkout/branch-switch, AI CLI, PR/Jira actions — but in the calling process. Because it blocks until the script exits, tickets are always processed **one at a time**, regardless of `maxTriggeredWorkflows` (see [Local Execution Flow](#local-teammate-execution-flow-localteammate-true)) |
 
 ### Agent Types
 
@@ -751,6 +752,46 @@ SM Agent (smAgent.js)
 │           ├─ Executes synchronously
 │           └─ Transitions Jira ticket status or performs merge operation
 ```
+
+### Local Teammate Execution Flow (localTeammate: true)
+
+Runs the **full** Teammate pipeline (checkout, AI CLI, PR/Jira actions) on the machine
+that runs the SM job, instead of dispatching `ai-teammate.yml` to GitHub Actions. Useful
+when there is no GitHub Actions runner available for this workload, or for fast local
+iteration without waiting on a runner queue.
+
+```
+SM Agent (smAgent.js)
+│
+├─ 1. Run JQL → find matching Jira tickets
+├─ 2. For each ticket (processed strictly one at a time — see below):
+│     ├─ Check skipIfLabel → skip if present (no active-workflow-run recovery check;
+│     │   that logic only makes sense for async GitHub Actions dispatches)
+│     ├─ Write the rule's encoded_config to a temp file (agents/.dmtools/local-run-*.json)
+│     └─ scripts/run-teammate-local.sh --config-file <configFile> --ticket <key> ...
+│           ├─ Refuses to run if the working tree is dirty (protects uncommitted work)
+│           ├─ Syncs the base branch (git fetch + checkout + pull --ff-only)
+│           ├─ dmtools --debug run <config_file> [<encoded_config>] --inputJql "key = <key>"
+│           │     (identical entrypoint to ai-teammate.yml's "Run AI Teammate" step —
+│           │      preJS → CLI agent → postJS all run exactly as they do on a runner)
+│           └─ Fails loudly if the tree is still dirty afterwards (agent should always
+│                 commit + push everything it changed, same contract as on a runner)
+└─ 3. addLabel only after a successful local run
+```
+
+**Why sequential, not worktree-based:** `cli_execute_command()` blocks until the script
+exits, and rules with `localTeammate: true` bypass the `maxTriggeredWorkflows` budget
+entirely (that budget only bounds *outstanding* async GitHub Actions runs). The working
+copy is reused across tickets — no git worktrees — because the teammate agent's own
+`postJSAction` always commits and pushes before finishing; the next ticket simply starts
+from a freshly-synced base branch.
+
+**Secrets:** read from the calling shell's environment first; `run-teammate-local.sh`
+fills in anything missing from `./dmtools.env` (same `KEY=VALUE` format
+`scripts/run-agent.sh` already loads). Real environment variables always take priority —
+`dmtools.env` never overrides an already-exported value. Typical required vars: `JIRA_EMAIL`,
+`JIRA_API_TOKEN`, `JIRA_BASE_PATH`, `GH_TOKEN`/`PAT_TOKEN`, plus whatever the configured
+`AI_AGENT_PROVIDER` needs (e.g. `COPILOT_GITHUB_TOKEN`).
 
 ### TestCasesGenerator Flow
 

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -5,8 +5,13 @@
  * and for each rule:
  *   1. Queries Jira by rule.jql (with {jiraProject}/{parentTicket} interpolation)
  *   2. Optionally transitions each ticket to rule.targetStatus
- *   3. Triggers an ai-teammate GitHub Actions workflow for each ticket
- *      OR executes the postJSAction locally (if localExecution: true)
+ *   3. Runs the agent for each matching ticket, via one of three modes:
+ *      - dispatch (default) — triggers an ai-teammate GitHub Actions workflow (async)
+ *      - localExecution: true — runs the agent config's postJSAction directly in the
+ *        SM process (pure JS, no AI CLI, no checkout — for fast/safe operations)
+ *      - localTeammate: true — runs the FULL teammate pipeline (checkout/branch switch,
+ *        AI CLI, PR/Jira actions) synchronously on the local machine via
+ *        scripts/run-teammate-local.sh, one ticket at a time (no GitHub Actions runner)
  *
  * Configuration:
  *   Loads project config from .dmtools/config.js (via configLoader).
@@ -42,6 +47,17 @@
  *   enabled        (optional) — set to false to disable the rule entirely (default: true)
  *   limit          (optional) — max number of tickets to process per run (default: 50)
  *   localExecution (optional) — if true, run postJSAction directly (no runner, no AI/CLI)
+ *   localTeammate  (optional) — if true, run the full teammate pipeline (checkout, AI CLI,
+ *                               PR/Jira actions) synchronously in-process via
+ *                               scripts/run-teammate-local.sh instead of dispatching a
+ *                               GitHub Actions workflow_dispatch. Tickets are processed
+ *                               strictly one at a time (the local checkout is reused across
+ *                               tickets, so no concurrency/workflowBudget accounting applies).
+ *                               Secrets are read from the calling shell's environment or from
+ *                               dmtools.env (see scripts/run-agent.sh loader) — never from
+ *                               GitHub Actions secrets.
+ *   localTeammateScript (optional) — path to the local runner script
+ *                               (default: agents/scripts/run-teammate-local.sh)
  */
 
 var configLoader = require('./configLoader.js');
@@ -293,6 +309,67 @@ function triggerWorkflow(repoInfo, ticketKey, rule, effectiveConfig, workflowBud
     }
 }
 
+/**
+ * Runs the full teammate pipeline locally (synchronously) instead of dispatching a
+ * GitHub Actions workflow_dispatch. Delegates checkout/branch-switching, the AI CLI
+ * run, and PR/Jira post-actions to scripts/run-teammate-local.sh — the same
+ * agents/*.json config and dmtools `run` entrypoint used by ai-teammate.yml, just
+ * invoked on the local machine instead of a runner.
+ *
+ * Because cli_execute_command() blocks until the child process exits, calling this
+ * from the same sequential ticket loop as triggerWorkflow() naturally enforces
+ * one-ticket-at-a-time processing — no separate queue/scheduler is needed.
+ */
+function runTeammateLocally(ticketKey, rule, effectiveConfig) {
+    var resolvedCf = buildEncodedConfigModule.resolveConfigFile(rule, effectiveConfig);
+    var encodedConfig = buildEncodedConfigModule.buildEncodedConfig(ticketKey, rule, effectiveConfig);
+
+    var projectKey = rule.projectKey || '';
+    if (!projectKey && effectiveConfig && effectiveConfig._configPath) {
+        var cp = effectiveConfig._configPath;
+        var base = cp.substring(cp.lastIndexOf('/') + 1).replace(/\.js$/, '');
+        if (base && base !== 'config') projectKey = base;
+    }
+
+    var scriptPath = rule.localTeammateScript || 'agents/scripts/run-teammate-local.sh';
+    // Write the encoded config to a temp file rather than inlining it as a CLI argument —
+    // avoids shell-escaping a large/multiline JSON blob (the script reads it back with $(cat ...)).
+    var encodedConfigFile = '';
+    if (encodedConfig) {
+        var safeTicket = ticketKey.replace(/[^A-Za-z0-9_-]/g, '_');
+        encodedConfigFile = '.dmtools/local-run-encoded-config-' + safeTicket + '.json';
+        try {
+            file_write({ path: encodedConfigFile, content: encodedConfig });
+        } catch (e) {
+            console.warn('  ⚠️  Could not write encoded config file: ' + (e.message || e));
+            encodedConfigFile = '';
+        }
+    }
+
+    var cmd = 'bash ' + scriptPath +
+        ' --config-file ' + resolvedCf +
+        ' --ticket ' + ticketKey +
+        (encodedConfigFile ? ' --encoded-config-file ' + encodedConfigFile : '') +
+        (projectKey ? ' --project-key ' + projectKey : '');
+
+    console.log('  🖥️  [local] ' + cmd);
+
+    var ok = true;
+    try {
+        cli_execute_command({ command: cmd });
+        console.log('  ✅ Local run complete for ' + ticketKey);
+    } catch (e) {
+        ok = false;
+        console.error('  ❌ Local teammate run failed for ' + ticketKey + ': ' + (e.message || e));
+    }
+
+    if (encodedConfigFile) {
+        try { cli_execute_command({ command: 'rm -f ' + encodedConfigFile }); } catch (e2) {}
+    }
+
+    return ok;
+}
+
 function moveStatus(ticketKey, targetStatus) {
     try {
         jira_move_to_status({ key: ticketKey, statusName: targetStatus });
@@ -503,7 +580,9 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         return processRuleLocally(rule, globalRepoInfo, ruleIndex);
     }
 
-    if (workflowBudget && workflowBudget.remaining <= 0) {
+    // localTeammate runs synchronously in-process — the workflow cap only bounds
+    // concurrent/outstanding GitHub Actions dispatches, so it doesn't apply here.
+    if (!rule.localTeammate && workflowBudget && workflowBudget.remaining <= 0) {
         var skippedLabel = rule.description || ('Rule #' + (ruleIndex + 1));
         var workflowFile = rule.workflowFile || 'ai-teammate.yml';
         console.log('\n══ ' + skippedLabel + ' ══');
@@ -548,7 +627,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
 
     var ruleLimit = (typeof rule.limit === 'number' && rule.limit > 0) ? Math.floor(rule.limit) : null;
     var effectiveLimit = ruleLimit;
-    if (workflowBudget) {
+    if (workflowBudget && !rule.localTeammate) {
         effectiveLimit = effectiveLimit === null
             ? workflowBudget.remaining
             : Math.min(effectiveLimit, workflowBudget.remaining);
@@ -569,7 +648,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
     var skippedKeys   = [];
 
     for (var idx = 0; idx < tickets.length; idx++) {
-        if (workflowBudget && workflowBudget.remaining <= 0) {
+        if (!rule.localTeammate && workflowBudget && workflowBudget.remaining <= 0) {
             break;
         }
         if (effectiveLimit !== null && processedKeys.length >= effectiveLimit) {
@@ -580,7 +659,9 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
 
         var skipLabel = firstMatchingLabel(ticket, normalizeLabels(rule.skipIfLabel, rule.skipIfLabels));
         if (skipLabel) {
-            if (shouldRecoverStaleTriggerLabel(rule, skipLabel)) {
+            // Stale-label recovery is based on inspecting active GitHub Actions runs — not
+            // meaningful for localTeammate (there is no async run to inspect); just skip.
+            if (!rule.localTeammate && shouldRecoverStaleTriggerLabel(rule, skipLabel)) {
                 var workflowFile = rule.workflowFile || 'ai-teammate.yml';
                 var resolvedCf = buildEncodedConfigModule.resolveConfigFile(rule, effectiveConfig);
                 var scm = scmModule.createScm(effectiveConfig);
@@ -599,20 +680,22 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         }
 
         if (rule.targetStatus) {
-            if (isWorkflowBudgetExhausted(rule, effectiveConfig, workflowBudget)) {
+            if (!rule.localTeammate && isWorkflowBudgetExhausted(rule, effectiveConfig, workflowBudget)) {
                 console.log('  ⏭️  ' + key + ' skipped before transition (global workflow cap reached: ' + workflowBudget.initial + ')');
                 break;
             }
             moveStatus(key, rule.targetStatus);
         }
 
-        var triggered = triggerWorkflow(effectiveRepoInfo, key, rule, effectiveConfig, workflowBudget);
+        var triggered = rule.localTeammate
+            ? runTeammateLocally(key, rule, effectiveConfig)
+            : triggerWorkflow(effectiveRepoInfo, key, rule, effectiveConfig, workflowBudget);
 
         if (triggered) addRuleLabels(key, rule);
 
         if (triggered) {
             processedKeys.push(key);
-            if (workflowBudget) workflowBudget.remaining -= 1;
+            if (!rule.localTeammate && workflowBudget) workflowBudget.remaining -= 1;
         }
     }
 

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -35,6 +35,7 @@ function makeSmAgent(opts) {
     var capturedLabels = [];
     var capturedStatusMoves = [];
     var capturedJqls = [];
+    var capturedCliCommands = [];
 
     // Controlled file_read: config discovery paths from fileMap only; other paths from disk.
     var fileReadMock = function(readOpts) {
@@ -79,7 +80,15 @@ function makeSmAgent(opts) {
             capturedStatusMoves.push(moveOpts);
             if (opts.onMoveStatus) opts.onMoveStatus(moveOpts);
         },
-        cli_execute_command: function() { return ''; },
+        cli_execute_command: function(cmdOpts) {
+            capturedCliCommands.push(cmdOpts);
+            if (opts.onCliExecute) return opts.onCliExecute(cmdOpts);
+            return '';
+        },
+        file_write: function(writeOpts) {
+            if (opts.onFileWrite) opts.onFileWrite(writeOpts);
+            return true;
+        },
         encodeURIComponent: encodeURIComponent,
         JSON: JSON,
         eval: eval
@@ -141,7 +150,8 @@ function makeSmAgent(opts) {
         capturedTriggers: capturedTriggers,
         capturedLabels: capturedLabels,
         capturedStatusMoves: capturedStatusMoves,
-        capturedJqls: capturedJqls
+        capturedJqls: capturedJqls,
+        capturedCliCommands: capturedCliCommands
     };
 }
 
@@ -653,6 +663,143 @@ suite('smAgent: ticket dispatch', function() {
 
         assert.equal(sm.capturedTriggers.length, 0, 'duplicate active workflow should not be dispatched');
         assert.equal(sm.capturedLabels.length, 0, 'skip label should not be added for skipped duplicate');
+    });
+
+});
+
+// ── localTeammate execution mode ────────────────────────────────────────────
+
+// runTeammateLocally() issues two cli_execute_command calls per ticket: the actual
+// run-teammate-local.sh invocation, plus a best-effort `rm -f` cleanup of the temp
+// encoded-config file. Filter to just the script invocations for assertions below.
+function localRunCommands(sm) {
+    return sm.capturedCliCommands.filter(function(c) {
+        return c.command.indexOf('run-teammate-local.sh') !== -1;
+    });
+}
+
+suite('smAgent: localTeammate execution mode', function() {
+
+    test('runs local script instead of dispatching a workflow', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject} AND status = 'Ready'", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true
+            })
+        ]));
+
+        assert.equal(sm.capturedTriggers.length, 0, 'no GitHub Actions workflow should be dispatched');
+        var runs = localRunCommands(sm);
+        assert.equal(runs.length, 1, 'exactly one local run invoked');
+        var cmd = runs[0].command;
+        assert.ok(cmd.indexOf('scripts/run-teammate-local.sh') !== -1, 'invokes run-teammate-local.sh');
+        assert.ok(cmd.indexOf('--config-file agents/story_development.json') !== -1, 'passes config file');
+        assert.ok(cmd.indexOf('--ticket P-1') !== -1, 'passes ticket key');
+    });
+
+    test('adds rule labels after a successful local run', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true,
+                addLabel: 'sm_story_development_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 1);
+        assert.equal(sm.capturedLabels[0].label, 'sm_story_development_triggered');
+    });
+
+    test('does not add rule labels when the local run throws', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }],
+            onCliExecute: function() { throw new Error('script failed'); }
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true,
+                addLabel: 'sm_story_development_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 0, 'no label added when the local run fails');
+    });
+
+    test('respects skipIfLabel without checking GitHub Actions run state', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: ['sm_story_development_triggered'] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true,
+                skipIfLabel: 'sm_story_development_triggered'
+            })
+        ]));
+
+        assert.equal(localRunCommands(sm).length, 0, 'labelled ticket should be skipped, not run locally');
+    });
+
+    test('processes tickets one at a time regardless of maxTriggeredWorkflows', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [
+                { key: 'P-1', fields: { labels: [] } },
+                { key: 'P-2', fields: { labels: [] } },
+                { key: 'P-3', fields: { labels: [] } }
+            ]
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true
+            })
+        ]);
+        // A tight global cap must not throttle localTeammate rules — they run
+        // synchronously in-process, so there is no outstanding-workflow budget to spend.
+        params.jobParams.maxTriggeredWorkflows = 1;
+
+        var result = sm.action(params);
+
+        assert.equal(localRunCommands(sm).length, 3, 'all three tickets should run locally, uncapped');
+        assert.equal(result.processed, 3);
+    });
+
+    test('writes the encoded config to a temp file and passes its path', function() {
+        var writtenFiles = [];
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-7', fields: { labels: [] } }],
+            onFileWrite: function(writeOpts) { writtenFiles.push(writeOpts); }
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true
+            })
+        ]));
+
+        assert.equal(writtenFiles.length, 1, 'encoded config should be written once');
+        assert.ok(writtenFiles[0].path.indexOf('P-7') !== -1, 'temp file name includes the ticket key');
+        var cmd = sm.capturedCliCommands[0].command;
+        assert.ok(cmd.indexOf('--encoded-config-file') !== -1, 'passes the encoded config file path');
     });
 
 });

--- a/scripts/run-teammate-local.sh
+++ b/scripts/run-teammate-local.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Run the full AI Teammate pipeline locally and synchronously — no GitHub Actions
+# runner involved. Mirrors the "Install AI Teammate tools" + "Run AI Teammate" steps
+# of ai-teammate.yml, but executes `dmtools run` directly on the calling machine.
+#
+# Invoked by js/smAgent.js when a rule has `localTeammate: true` instead of
+# dispatching a workflow_dispatch. Can also be run standalone for manual/ad-hoc runs.
+#
+# Usage:
+#   run-teammate-local.sh --config-file agents/story_development.json --ticket SOHO-123 \
+#     [--encoded-config-file PATH] [--project-key myproject] [--base-branch main] \
+#     [--install-tools "java:17 node:20 dmtools:v1.7.215"] [--dmtools-bin PATH]
+#
+# Secrets:
+#   Read from the calling shell's environment first; any variable not already set is
+#   filled in from ./dmtools.env if present (same KEY=VALUE format used by
+#   scripts/run-agent.sh). Real environment variables always win — dmtools.env only
+#   fills gaps. Typical required vars: JIRA_EMAIL, JIRA_API_TOKEN, JIRA_BASE_PATH,
+#   GH_TOKEN/PAT_TOKEN, and whatever the configured AI_AGENT_PROVIDER needs
+#   (e.g. COPILOT_GITHUB_TOKEN, CURSOR_API_KEY).
+#
+# Branch handling (no git worktrees — single checkout, reused across tickets):
+#   Before every ticket this script syncs --base-branch (default: main) and REFUSES
+#   to proceed if the working tree is dirty (protects any uncommitted local work,
+#   including a previous run that failed to commit/push). The teammate agent's own
+#   postJSAction is responsible for creating/checking out the ticket branch,
+#   committing, and pushing — exactly as it does on a GitHub Actions runner. After a
+#   successful run the tree must be clean again; if it isn't, this script fails
+#   loudly instead of silently discarding or carrying over uncommitted changes into
+#   the next ticket.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../setup/_common.sh"
+
+CONFIG_FILE=""
+TICKET_KEY=""
+ENCODED_CONFIG_FILE=""
+PROJECT_KEY=""
+BASE_BRANCH="main"
+INSTALL_TOOLS=""
+DMTOOLS_BIN="${DMTOOLS_BIN:-dmtools}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --config-file PATH --ticket KEY [options]
+
+Options:
+  --config-file          PATH   agents/*.json config to run (required)
+  --ticket               KEY    Jira ticket key, e.g. SOHO-123 (required)
+  --encoded-config-file  PATH   file containing a pre-built encoded_config JSON blob (optional)
+  --project-key          KEY    project_key value for multi-project dependency setup (optional)
+  --base-branch          NAME   branch to sync before every run (default: main)
+  --install-tools        LIST   tools to pass to setup/install.sh before running,
+                                 e.g. "java:17 node:20 dmtools:v1.7.215" (optional —
+                                 by default assumes required CLIs are already on PATH)
+  --dmtools-bin          PATH   dmtools binary/command (default: dmtools, or \$DMTOOLS_BIN)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config-file)         CONFIG_FILE="$2"; shift 2 ;;
+    --ticket)               TICKET_KEY="$2"; shift 2 ;;
+    --encoded-config-file)  ENCODED_CONFIG_FILE="$2"; shift 2 ;;
+    --project-key)          PROJECT_KEY="$2"; shift 2 ;;
+    --base-branch)          BASE_BRANCH="$2"; shift 2 ;;
+    --install-tools)        INSTALL_TOOLS="$2"; shift 2 ;;
+    --dmtools-bin)          DMTOOLS_BIN="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "${CONFIG_FILE}" ] || [ -z "${TICKET_KEY}" ]; then
+  echo "❌ --config-file and --ticket are required" >&2
+  usage
+  exit 1
+fi
+
+# ── Load secrets: real env vars win; dmtools.env only fills gaps ─────────────
+if [ -f "dmtools.env" ]; then
+  echo "🔑 Loading missing secrets from dmtools.env (existing env vars are never overridden)"
+  while IFS='=' read -r k v; do
+    [[ "${k}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    if [ -z "${!k:-}" ]; then
+      export "${k}=${v}"
+    fi
+  done < <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' dmtools.env)
+fi
+
+if [ -n "${PROJECT_KEY}" ]; then
+  export AI_TEAMMATE_PROJECT_KEY="${PROJECT_KEY}"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🖥️  Local Teammate run"
+echo "   config:  ${CONFIG_FILE}"
+echo "   ticket:  ${TICKET_KEY}"
+echo "   project: ${PROJECT_KEY:-<default>}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── Guard: refuse to run on a dirty working tree ─────────────────────────────
+# See the module docstring above — protects uncommitted work (this run's own repo
+# is reused across tickets, unlike an ephemeral GitHub Actions checkout).
+if [ -n "$(git status --porcelain)" ]; then
+  echo "❌ Working tree is dirty — refusing to run (commit/stash your changes first)." >&2
+  git status --short >&2
+  exit 1
+fi
+
+# ── Sync base branch before every ticket ─────────────────────────────────────
+echo "🔄 Syncing ${BASE_BRANCH}..."
+git fetch origin "${BASE_BRANCH}"
+git checkout "${BASE_BRANCH}"
+git pull --ff-only origin "${BASE_BRANCH}"
+
+# ── Optional tool install (idempotent — reuses whatever setup/cache.sh cached) ─
+if [ -n "${INSTALL_TOOLS}" ]; then
+  # shellcheck disable=SC2086
+  bash "${SCRIPT_DIR}/../setup/install.sh" ${INSTALL_TOOLS}
+fi
+
+# ── Run the agent via dmtools (same entrypoint ai-teammate.yml uses) ────────
+mkdir -p .dmtools
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE=".dmtools/local-run-${TICKET_KEY}-${TIMESTAMP}.log"
+CI_RUN_URL="local://$(hostname)/${TICKET_KEY}/${TIMESTAMP}"
+
+ENCODED_CONFIG=""
+if [ -n "${ENCODED_CONFIG_FILE}" ] && [ -f "${ENCODED_CONFIG_FILE}" ]; then
+  ENCODED_CONFIG="$(cat "${ENCODED_CONFIG_FILE}")"
+fi
+
+DMTOOLS_ARGS=(--debug run "${CONFIG_FILE}")
+if [ -n "${ENCODED_CONFIG}" ]; then
+  DMTOOLS_ARGS+=("${ENCODED_CONFIG}")
+fi
+DMTOOLS_ARGS+=(--inputJql "key = ${TICKET_KEY}" --ciRunUrl "${CI_RUN_URL}")
+
+echo "▶ ${DMTOOLS_BIN} --debug run ${CONFIG_FILE} ... --inputJql \"key = ${TICKET_KEY}\" --ciRunUrl ${CI_RUN_URL}"
+set -o pipefail
+"${DMTOOLS_BIN}" "${DMTOOLS_ARGS[@]}" 2>&1 | tee "${LOG_FILE}"
+
+LAST_JS_RESULT="$(grep 'JavaScriptExecutor - JavaScript executed successfully:' "${LOG_FILE}" | tail -n 1 || true)"
+if [ -n "${LAST_JS_RESULT}" ] && echo "${LAST_JS_RESULT}" | grep -q '"success":false'; then
+  echo "❌ ${CONFIG_FILE} JavaScript action returned success:false. See ${LOG_FILE} for details." >&2
+  exit 1
+fi
+
+# ── Post-guard: the agent is expected to leave a clean tree (committed + pushed) ─
+if [ -n "$(git status --porcelain)" ]; then
+  echo "⚠️  Working tree is dirty after the run — ${CONFIG_FILE} may not have committed/pushed everything." >&2
+  git status --short >&2
+  echo "   Log: ${LOG_FILE}" >&2
+  exit 1
+fi
+
+echo "✅ Local run complete for ${TICKET_KEY} — log: ${LOG_FILE}"


### PR DESCRIPTION
## Summary
Adds a third SM rule execution mode, alongside `dispatch` (default, GitHub Actions `workflow_dispatch`) and `localExecution` (pure JS, no AI CLI):

- **`localTeammate: true`** — runs the **full** teammate pipeline (checkout/branch switch, AI CLI, PR/Jira post-actions) synchronously on the machine running the SM job, via a new `scripts/run-teammate-local.sh`, instead of dispatching to a GitHub Actions runner.

## Why
Useful when there's no GitHub Actions/self-hosted runner available for a given workload, or for fast local iteration without waiting on a runner queue.

## Design
- `run-teammate-local.sh` calls the exact same `dmtools --debug run <config_file> [<encoded_config>] --inputJql ... --ciRunUrl ...` entrypoint that `ai-teammate.yml`'s "Run AI Teammate" step uses — no reimplementation of preJS/CLI/postJS orchestration.
- **Sequential by construction** — `cli_execute_command()` blocks until the script exits, so calling it from the existing per-ticket loop in `smAgent.js` naturally serializes local runs one ticket at a time. No separate queue/scheduler needed.
- **No git worktrees** — the working copy is checked out to `--base-branch` (default `main`) and refreshed before every ticket. The script refuses to run on a dirty tree (both before and after the run), since the teammate agent's own `postJSAction` is expected to always commit + push before finishing (same contract it already has on a GitHub Actions runner).
- **Secrets** — read from the calling shell's environment first; anything missing is filled in from `./dmtools.env` (same loader convention `scripts/run-agent.sh` already uses). Real env vars always win over `dmtools.env`.
- `localTeammate` rules are exempt from `maxTriggeredWorkflows` accounting and from the GitHub-Actions-run-based stale-label recovery check — neither concept applies to a synchronous local run.

## Testing
- Added 6 new unit tests in `test_smAgent.js` covering: dispatch bypass, label bookkeeping on success/failure, `skipIfLabel` handling, uncapped sequential processing, and encoded-config temp-file handling.
- `dmtools run js/unit-tests/run_smAgent.json` → 63 passed, 2 failed (both pre-existing on `main`, unrelated to this change — verified via `git stash`).
- `dmtools run js/unit-tests/run_all.json` → 574 passed / 18 failed, same 18 pre-existing failures as baseline `main` (568 passed / 18 failed) — 6 new tests, 0 regressions.
- `shellcheck scripts/run-teammate-local.sh` — clean.
- `node --check` on both modified JS files — clean.