### PR TITLE
feat(agents): collect Jenkins failed-check logs in pr_rework/pr_review

### DIFF
--- a/instructions/pr_review/formatting_rules.md
+++ b/instructions/pr_review/formatting_rules.md
@@ -6,7 +6,7 @@ flowchart TD
     F4["Each inline comment: path, line, startLine, side, comment, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["comment must be a path to a file under outputs/pr_review_comments/<name>.md"]
     F6["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F7["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F7["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F8["Keep summary under 2 sentences — put details in inline comment files, not in general text"]
     F9["Severity classification follows general_guidelines.md:<br/>BLOCKING = must fix · IMPORTANT = should fix · SUGGESTION = optional"]
     F10["Ticket context: verify PR changes satisfy ticket ACs — note gaps in review"]

--- a/instructions/pr_review/general_guidelines.md
+++ b/instructions/pr_review/general_guidelines.md
@@ -4,7 +4,7 @@
 
 ```mermaid
 flowchart TD
-    START([PR ready for review]) --> READ["1. Read input context:<br/>instruction.md, ticket.md, pr_info.md,<br/>pr_diff.txt, pr_files.txt, ci_failures.md,<br/>pr_discussions.md, pr_discussions_raw.json"]
+    START([PR ready for review]) --> READ["1. Read input context:<br/>instruction.md, ticket.md, pr_info.md,<br/>pr_diff.txt, pr_files.txt, ci_failures.md,<br/>ci_failures_full.log, pr_discussions.md,<br/>pr_discussions_raw.json"]
     READ --> DIFF["2. Run diff checklist on pr_diff.txt"]
     DIFF --> FILES["3. Read full content of every changed file"]
     FILES --> CODEGRAPH["4. Use CodeGraph:<br/>callers/callees of changed symbols,<br/>search for sensitive patterns,<br/>impact analysis"]
@@ -24,9 +24,10 @@ flowchart TD
         P2["2️⃣ input/TICKET/pr_info.md — PR title, author, branch, description"]
         P3["3️⃣ input/TICKET/pr_diff.txt — the diff to review"]
         P4["4️⃣ input/TICKET/pr_files.txt — list of changed files"]
-        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING"]
+        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING (last 500 lines)"]
+        P5_FULL["5️⃣ input/TICKET/ci_failures_full.log — full CI logs"]
         P6["6️⃣ input/TICKET/pr_discussions.md + pr_discussions_raw.json — existing comments"]
-        P1 --> P2 --> P3 --> P4 --> P5 --> P6
+        P1 --> P2 --> P3 --> P4 --> P5 --> P5_FULL --> P6
     end
 
     subgraph TICKET_CONTEXT["Ticket context (for understanding PR purpose)"]

--- a/instructions/pr_rework/general_guidelines.md
+++ b/instructions/pr_rework/general_guidelines.md
@@ -3,11 +3,11 @@ flowchart TD
     START([Ticket enters rework]) --> SETUP{rework_setup_failed.md exists?}
     SETUP -->|Yes| FAIL[Write setup failure response and stop]
     SETUP -->|No| INPUT[Read ALL input files in the ticket subfolder]
-    INPUT --> INPUTS["request.md, comments.md, existing_questions.json, parent_context_*.md, pr_info.md, pr_diff.txt, merge_conflicts.md, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["request.md, comments.md, existing_questions.json, parent_context_*.md, pr_info.md, pr_diff.txt, merge_conflicts.md, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> CONFLICTS{merge_conflicts.md exists?}
     CONFLICTS -->|Yes| RESOLVE["Resolve every conflict marker, git add each file, verify with git diff --check"]
     CONFLICTS -->|No| CI
-    RESOLVE --> CI{ci_failures.md exists?}
+    RESOLVE --> CI{ci_failures.md or ci_failures_full.log exists?}
     CI -->|Yes| FIX_CI["Fix CI root cause: dependencies, config, or test setup"]
     CI -->|No| THREADS
     FIX_CI --> THREADS[Address every open thread in pr_discussions.md]
@@ -35,9 +35,10 @@ flowchart TD
         P2["2️⃣ input/TICKET/pr_info.md — PR title, author, branch, description"]
         P3["3️⃣ input/TICKET/pr_diff.txt — the diff to review"]
         P4["4️⃣ input/TICKET/pr_files.txt — list of changed files"]
-        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING"]
+        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING (last 500 lines)"]
+        P5_FULL["5️⃣ input/TICKET/ci_failures_full.log — full CI logs"]
         P6["6️⃣ input/TICKET/pr_discussions.md + pr_discussions_raw.json — existing comments"]
-        P1 --> P2 --> P3 --> P4 --> P5 --> P6
+        P1 --> P2 --> P3 --> P4 --> P5 --> P5_FULL --> P6
     end
 
     subgraph TICKET_CONTEXT["Ticket context (for understanding PR purpose)"]

--- a/instructions/pr_test_automation_review/formatting_rules.md
+++ b/instructions/pr_test_automation_review/formatting_rules.md
@@ -5,7 +5,7 @@ flowchart TD
     F3["outputs/pr_review.json — valid JSON with recommendation (APPROVE|BLOCK|REQUEST_CHANGES), summary, inlineComments, issueCounts"]
     F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
     F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
 ```

--- a/instructions/pr_test_automation_review/general_guidelines.md
+++ b/instructions/pr_test_automation_review/general_guidelines.md
@@ -2,7 +2,7 @@
 flowchart TD
     START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
     PROJ --> INPUT["Read PR context from input folder"]
-    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
     SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]

--- a/instructions/pr_test_automation_rework/general_guidelines.md
+++ b/instructions/pr_test_automation_rework/general_guidelines.md
@@ -3,12 +3,12 @@ flowchart TD
     START([Test Case enters In Rework]) --> SETUP{rework_setup_failed.md exists?}
     SETUP -->|Yes| FAIL[Write setup failure response and stop]
     SETUP -->|No| INPUT[Read ALL input files in the ticket subfolder]
-    INPUT --> INPUTS["request.md, ticket.md, linked_bugs.md, pr_info.md, pr_diff.txt, comments.md, pr_discussions.md, pr_discussions_raw.json, merge_conflicts.md, ci_failures.md"]
+    INPUT --> INPUTS["request.md, ticket.md, linked_bugs.md, pr_info.md, pr_diff.txt, comments.md, pr_discussions.md, pr_discussions_raw.json, merge_conflicts.md, ci_failures.md, ci_failures_full.log"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> CONFLICTS{merge_conflicts.md exists?}
     CONFLICTS -->|Yes| RESOLVE["Resolve every conflict marker, git add each file, verify with git diff --check"]
     CONFLICTS -->|No| CI
-    RESOLVE --> CI{ci_failures.md exists?}
+    RESOLVE --> CI{ci_failures.md or ci_failures_full.log exists?}
     CI -->|Yes| FIX_CI["Fix CI root cause: dependencies, config, or test setup"]
     CI -->|No| THREADS
     FIX_CI --> THREADS[Address every open thread in pr_discussions.md]

--- a/instructions/review/ci_failures.md
+++ b/instructions/review/ci_failures.md
@@ -7,3 +7,5 @@ If `ci_failures.md` exists:
 - Do not invent root causes when logs are insufficient.
 - Mention CI failures in the tracker comment and PR general comment.
 
+Full (untruncated) logs are available in `ci_failures_full.log` when present.
+

--- a/instructions/review/input_context.md
+++ b/instructions/review/input_context.md
@@ -6,7 +6,8 @@ Read available files from the input folder:
 - `pr_info.md`: PR title, URL, author, branch, metadata.
 - `pr_diff.txt`: source of truth for changed lines.
 - `pr_files.txt`: changed file list.
-- `ci_failures.md`: failed checks, if present.
+- `ci_failures.md`: failed checks (last 500 lines), if present.
+- `ci_failures_full.log`: complete failed-check logs, if present.
 - `pr_discussions.md`: previous comments/threads, if present.
 - `pr_discussions_raw.json`: thread IDs for resolved threads, if present.
 - `parent_context_*.md`: extra project context, if present.

--- a/instructions/review/pr_review_instructions.md
+++ b/instructions/review/pr_review_instructions.md
@@ -5,11 +5,11 @@ Read PR context from input folder which contains:
   - pr_info.md: Pull Request metadata (URL, author, title, description)
   - pr_diff.txt: Complete git diff of all changes
   - pr_files.txt: List of all modified files
-  - ci_failures.md: *(if present)* **CI checks currently failing** — treat each as a 🚨 BLOCKING issue and include in the review
+  - ci_failures.md: *(if present)* **CI checks currently failing** — treat each as a 🚨 BLOCKING issue and include in the review. Last 500 lines of each failed check log; full logs are in `ci_failures_full.log`.
   - pr_discussions.md: *(if present)* Full history of previous review comments and inline threads
   - pr_discussions_raw.json: *(if present)* Structured thread data with IDs — used to populate `resolvedThreadIds`
 
-**If `ci_failures.md` is present**: The PR has failing CI checks. Include each failed check as a 🚨 BLOCKING finding in your review. Describe what the error log shows (it's included in the file) and what needs to be fixed. These are blocking — the PR must not be approved while CI is failing.
+**If `ci_failures.md` is present**: The PR has failing CI checks. Include each failed check as a 🚨 BLOCKING finding in your review. Describe what the error log shows (last 500 lines are included in the file; full logs are in `ci_failures_full.log`) and what needs to be fixed. These are blocking — the PR must not be approved while CI is failing.
 
 ## ⚠️ Repeated Review Notice
 

--- a/instructions/rework/rework_instructions.md
+++ b/instructions/rework/rework_instructions.md
@@ -43,9 +43,9 @@ flowchart TD
     B -->|Yes| C[Write setup failure response and empty replies]
     B -->|No| D{merge_conflicts.md exists?}
     D -->|Yes| E[Resolve conflicts first]
-    D -->|No| F{ci_failures.md exists?}
+    D -->|No| F{ci_failures.md or ci_failures_full.log exists?}
     E --> F
-    F -->|Yes| G[Fix CI root cause]
+    F -->|Yes| G[Fix CI root cause — use ci_failures.md (last 500 lines) and ci_failures_full.log (full logs)]
     F -->|No| H{pr_discussions.md has open actionable items?}
     G --> H
     H -->|Yes| I[Fix every thread and write matching replies]

--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -115,10 +115,11 @@ function action(params) {
         if (status === STATUSES.BUG_TO_FIX) {
             var linkedBugs = findLinkedBugs(tc.key);
             var hasOtherBug = linkedBugs.some(function(bug) {
-                return bug.key !== ticketKey;
+                var bugStatus = bug.fields && bug.fields.status && bug.fields.status.name;
+                return bug.key !== ticketKey && bugStatus !== STATUSES.DONE;
             });
             if (hasOtherBug) {
-                console.log('TC', tc.key, 'is Bug To Fix but already tracked by another Bug — treating as non-blocking');
+                console.log('TC', tc.key, 'is Bug To Fix but already tracked by another active Bug — treating as non-blocking');
                 return false;
             }
         }
@@ -271,6 +272,7 @@ function action(params) {
             console.warn('Failed to post token usage comments:', e);
         }
 
+        releaseLock();
         return { success: true, action: 'moved_to_done', totalTCs, ticketKey };
 
     } catch (error) {

--- a/js/checkWipLabel.js
+++ b/js/checkWipLabel.js
@@ -100,3 +100,7 @@ function action(params) {
         return true;
     }
 }
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action: action };
+}

--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -298,20 +298,24 @@ function fetchDiscussionsAndRawData(scmOrWorkspace, repositoryOrPrId, pullReques
  * Writes ci_failures.md to the input folder when failures are found.
  *
  * Dual-mode: accepts either an SCM object or (owner, repo, headSha, inputFolder) strings.
+ * In SCM mode an optional jenkinsBasePath can be passed to fetch Jenkins console logs
+ * for failed checks whose details_url points at the configured Jenkins instance.
  */
-function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inputFolderOpt) {
+function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inputFolderOpt, jenkinsBasePathOpt) {
     var scm = null;
-    var owner, repo, headSha, inputFolder;
+    var owner, repo, headSha, inputFolder, jenkinsBasePath;
 
     if (_isScm(scmOrOwner)) {
         scm = scmOrOwner;
         headSha = repoOrHeadSha;
         inputFolder = headShaOrInputFolder;
+        jenkinsBasePath = inputFolderOpt;
     } else {
         owner = scmOrOwner;
         repo = repoOrHeadSha;
         headSha = headShaOrInputFolder;
         inputFolder = inputFolderOpt;
+        jenkinsBasePath = jenkinsBasePathOpt;
     }
 
     try {
@@ -399,6 +403,42 @@ function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inp
                     }
                 } catch (e) {
                     console.warn('Could not fetch logs for job', jobIdMatch[1], ':', e.message || e);
+                }
+            }
+
+            // Jenkins: failed check whose details_url points at the configured Jenkins instance
+            if (jenkinsBasePath && check.details_url && check.details_url.indexOf(jenkinsBasePath) === 0) {
+                try {
+                    var relativePath = check.details_url.substring(jenkinsBasePath.length).replace(/^[\/]+/, '');
+                    var pathParts = relativePath.split('/').filter(function(p) { return p.length > 0; });
+                    var jenkinsBuildNumber = null;
+                    var jenkinsJobPathParts = [];
+                    for (var i = 0; i < pathParts.length; i++) {
+                        if (/^\d+$/.test(pathParts[i])) {
+                            jenkinsBuildNumber = parseInt(pathParts[i], 10);
+                            break;
+                        }
+                        jenkinsJobPathParts.push(pathParts[i]);
+                    }
+                    if (jenkinsBuildNumber && jenkinsJobPathParts.length > 0) {
+                        var jenkinsJobPath = jenkinsJobPathParts.join('/');
+                        jenkins_get_job_info({ jobPath: jenkinsJobPath, buildNumber: jenkinsBuildNumber });
+                        var jenkinsRawLogs = jenkins_get_build_log({ jobPath: jenkinsJobPath, buildNumber: jenkinsBuildNumber });
+                        var jenkinsLogs = jenkinsRawLogs;
+                        if (typeof jenkinsRawLogs === 'string') {
+                            try {
+                                var jenkinsParsed = JSON.parse(jenkinsRawLogs);
+                                if (jenkinsParsed && jenkinsParsed.result) jenkinsLogs = jenkinsParsed.result;
+                            } catch (e) { /* use as-is */ }
+                        }
+                        if (jenkinsLogs) {
+                            var jenkinsLines = jenkinsLogs.split('\n');
+                            var jenkinsSnippet = jenkinsLines.slice(-150).join('\n');
+                            md += '**Jenkins error log (last 150 lines)**:\n\n```\n' + jenkinsSnippet + '\n```\n\n';
+                        }
+                    }
+                } catch (e) {
+                    console.warn('Could not fetch Jenkins logs for', check.details_url, ':', e.message || e);
                 }
             }
         });

--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -366,7 +366,20 @@ function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inp
         console.warn('⚠️ ' + failedChecks.length + ' CI check(s) failed:', failedChecks.map(function(c) { return c.name; }).join(', '));
 
         var md = '# ⚠️ Failed CI Checks — Fix Before Completing Rework\n\n';
+        md += 'Full (untruncated) logs are available in `ci_failures_full.log`.\n\n';
         md += failedChecks.length + ' check(s) failed on commit `' + headSha.substring(0, 8) + '`:\n\n';
+
+        var fullLogContent = '';
+
+        function appendLog(check, logs, label) {
+            if (!logs) return;
+            var lines = logs.split('\n');
+            var snippet = lines.slice(-500).join('\n');
+            md += '**' + label + ' (last 500 lines)**:\n\n```\n' + snippet + '\n```\n\n';
+            fullLogContent += '=== ' + label + ' for: ' + check.name + ' ===\n';
+            fullLogContent += 'URL: ' + (check.details_url || 'N/A') + '\n';
+            fullLogContent += logs + '\n\n';
+        }
 
         failedChecks.forEach(function(check) {
             md += '## ❌ ' + check.name + '\n\n';
@@ -396,11 +409,7 @@ function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inp
                             if (parsed && parsed.result) logs = parsed.result;
                         } catch (e) { /* use as-is */ }
                     }
-                    if (logs) {
-                        var lines = logs.split('\n');
-                        var snippet = lines.slice(-150).join('\n');
-                        md += '**Error log (last 150 lines)**:\n\n```\n' + snippet + '\n```\n\n';
-                    }
+                    appendLog(check, logs, 'Error log');
                 } catch (e) {
                     console.warn('Could not fetch logs for job', jobIdMatch[1], ':', e.message || e);
                 }
@@ -431,11 +440,7 @@ function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inp
                                 if (jenkinsParsed && jenkinsParsed.result) jenkinsLogs = jenkinsParsed.result;
                             } catch (e) { /* use as-is */ }
                         }
-                        if (jenkinsLogs) {
-                            var jenkinsLines = jenkinsLogs.split('\n');
-                            var jenkinsSnippet = jenkinsLines.slice(-150).join('\n');
-                            md += '**Jenkins error log (last 150 lines)**:\n\n```\n' + jenkinsSnippet + '\n```\n\n';
-                        }
+                        appendLog(check, jenkinsLogs, 'Jenkins error log');
                     }
                 } catch (e) {
                     console.warn('Could not fetch Jenkins logs for', check.details_url, ':', e.message || e);
@@ -445,11 +450,17 @@ function detectFailedChecks(scmOrOwner, repoOrHeadSha, headShaOrInputFolder, inp
 
         md += '---\n\n## Resolution\n\n';
         md += '1. Read the error log(s) above to identify the root cause\n';
-        md += '2. Fix the underlying code issue(s)\n';
-        md += '3. CI will re-run automatically after the push — all checks must pass\n';
+        md += '2. For more context, open `ci_failures_full.log` with the complete logs\n';
+        md += '3. Fix the underlying code issue(s)\n';
+        md += '4. CI will re-run automatically after the push — all checks must pass\n';
 
         file_write({ path: inputFolder + '/ci_failures.md', content: md });
         console.log('✅ Wrote ci_failures.md (' + failedChecks.length + ' failed check(s))');
+
+        if (fullLogContent) {
+            file_write({ path: inputFolder + '/ci_failures_full.log', content: fullLogContent });
+            console.log('✅ Wrote ci_failures_full.log');
+        }
 
         return failedChecks.map(function(c) { return { name: c.name, conclusion: c.conclusion }; });
 

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -114,7 +114,8 @@ var DEFAULTS = {
     globalAdditionalInstructions: [],
 
     scm: {
-        provider: 'github'   // 'github' | 'gitlab' | 'ado' — source control provider for PR/MR operations
+        provider: 'github',  // 'github' | 'gitlab' | 'ado' — source control provider for PR/MR operations
+        jenkinsBasePath: ''  // Optional: base URL of Jenkins instance for fetching failed-check logs in pr_rework
     }
 };
 

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -184,7 +184,7 @@ function attemptResumeIfReviewOutputsMissing(ticketKey) {
     var recoveryPrompt =
         'RESUME TASK: The previous PR review run ended without writing mandatory review output files.\n\n' +
         'Do not rework product code. Read input/' + ticketKey + '/pr_info.md, pr_diff.txt, pr_discussions.md, ' +
-        'pr_discussions_raw.json when present, ci_failures.md when present, and the current PR context.\n\n' +
+        'pr_discussions_raw.json when present, ci_failures.md and ci_failures_full.log when present, and the current PR context.\n\n' +
         'Write these files before stopping:\n' +
         '1. outputs/pr_review.json with fields recommendation, generalComment, resolvedThreadIds, inlineComments, issueCounts.\n' +
         '2. outputs/pr_review_general.md with a short GitHub Markdown review summary.\n' +

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -106,7 +106,7 @@ function action(params) {
 
         // Step 4.6: Detect failed CI checks — writes ci_failures.md if any failed
         const headSha = prDetails.head ? prDetails.head.sha : null;
-        const failedChecks = gh.detectFailedChecks(scm, headSha, inputFolder);
+        const failedChecks = gh.detectFailedChecks(scm, headSha, inputFolder, config.scm && config.scm.jenkinsBasePath);
 
         const diff = gitOps.getPRDiff(baseBranch, branchName, config.workingDir);
 

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -140,7 +140,7 @@ function action(params) {
                 jiraComment += '{panel:bgColor=#FFEBE6|borderColor=#DE350B}' +
                     '⚠️ *CI checks failing* — ' + failedChecks.length + ' check(s) must pass before merge:\n' +
                     failedChecks.map(function(c) { return '* {code}' + c.name + '{code}'; }).join('\n') +
-                    '\nError logs written to {code}ci_failures.md{code} — AI will fix the root cause.' +
+                    '\nError logs: {code}ci_failures.md{code} (summary) and {code}ci_failures_full.log{code} (full logs).' +
                     '{panel}\n\n';
             }
 

--- a/js/preparePRForReview.js
+++ b/js/preparePRForReview.js
@@ -129,7 +129,7 @@ function action(params) {
                 jiraComment += '{panel:bgColor=#FFEBE6|borderColor=#DE350B}' +
                     '⚠️ *CI checks failing* — ' + failedChecks.length + ' check(s) did not pass:\n' +
                     failedChecks.map(function(c) { return '* {code}' + c.name + '{code}'; }).join('\n') +
-                    '\nError logs are in {code}ci_failures.md{code} — reviewer will flag these as blocking issues.' +
+                    '\nError logs: {code}ci_failures.md{code} (summary) and {code}ci_failures_full.log{code} (full logs).' +
                     '{panel}\n\n';
             }
 

--- a/js/preparePRForReview.js
+++ b/js/preparePRForReview.js
@@ -115,7 +115,7 @@ function action(params) {
         // Step 6.5: Detect failed CI checks
         var headSha = prDetails.head ? prDetails.head.sha : null;
         console.log('Detecting failed checks for head SHA:', headSha || '(missing)');
-        var failedChecks = gh.detectFailedChecks(scm, headSha, inputFolder);
+        var failedChecks = gh.detectFailedChecks(scm, headSha, inputFolder, config.scm && config.scm.jenkinsBasePath);
         console.log('Detected failed checks:', failedChecks.length);
 
         // Step 7: Jira comment

--- a/js/unit-tests/test_checkBugTestsPassed.js
+++ b/js/unit-tests/test_checkBugTestsPassed.js
@@ -328,6 +328,7 @@ suite('checkBugTestsPassed', function() {
     test('moves finalized Bug to In Rework when any linked TC is still blocking', function() {
         var moved = [];
         var comments = [];
+        var addedLabels = [];
         var removedLabels = [];
 
         var module = loadCheckBugTestsPassed({
@@ -345,6 +346,7 @@ suite('checkBugTestsPassed', function() {
             jira_search_by_jql: function() { return []; },
             jira_move_to_status: function(args) { moved.push(args); },
             jira_post_comment: function(args) { comments.push(args); },
+            jira_add_label: function(args) { addedLabels.push(args); },
             jira_remove_label: function(args) { removedLabels.push(args); }
         });
 
@@ -357,12 +359,14 @@ suite('checkBugTestsPassed', function() {
         assert.equal(result.action, 'moved_to_rework');
         assert.deepEqual(moved, [{ key: 'TS-90', statusName: 'In Rework' }]);
         assert.contains(comments[0].comment, 'Test PR Merged But Acceptance Tests Still Blocking');
+        assert.deepEqual(addedLabels, [{ key: 'TS-90', label: 'sm_bug_rework_attempted' }]);
         assert.deepEqual(removedLabels, [{ key: 'TS-90', label: 'sm_bug_done_check_triggered' }]);
     });
 
     test('does not treat a Done linked Bug as handling an active Bug To Fix TC', function() {
         var moved = [];
         var comments = [];
+        var addedLabels = [];
         var removedLabels = [];
 
         var module = loadCheckBugTestsPassed({
@@ -388,6 +392,7 @@ suite('checkBugTestsPassed', function() {
             },
             jira_move_to_status: function(args) { moved.push(args); },
             jira_post_comment: function(args) { comments.push(args); },
+            jira_add_label: function(args) { addedLabels.push(args); },
             jira_remove_label: function(args) { removedLabels.push(args); }
         });
 
@@ -400,6 +405,7 @@ suite('checkBugTestsPassed', function() {
         assert.equal(result.action, 'moved_to_rework');
         assert.deepEqual(moved, [{ key: 'TS-90', statusName: 'In Rework' }]);
         assert.contains(comments[0].comment, 'Test PR Merged But Acceptance Tests Still Blocking');
+        assert.deepEqual(addedLabels, [{ key: 'TS-90', label: 'sm_bug_rework_attempted' }]);
         assert.deepEqual(removedLabels, [{ key: 'TS-90', label: 'sm_bug_done_check_triggered' }]);
     });
 

--- a/js/unit-tests/test_checkBugTestsPassed.js
+++ b/js/unit-tests/test_checkBugTestsPassed.js
@@ -22,7 +22,12 @@ function loadCheckBugTestsPassed(mocks) {
         makeRequire({
             './config.js': configModule,
             './configLoader.js': configLoaderMock,
-            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
+            './common/scm.js': {
+                createScm: function() {
+                    return { listPrs: function() { return []; } };
+                }
+            }
         }),
         mocks
     );
@@ -69,7 +74,7 @@ suite('checkBugTestsPassed', function() {
         assert.equal(result.action, 'moved_to_done');
         assert.deepEqual(moved, [{ key: 'TS-10', statusName: 'Done' }]);
         assert.contains(comments[0].comment, 'Bug Complete');
-        assert.equal(removedLabels.length, 0, 'lock should not be released after Done');
+        assert.ok(removedLabels.some(function(l) { return l.key === 'TS-10' && l.label === 'sm_bug_done_check_triggered'; }), 'lock should be released after Done');
         assert.equal(searchedJqls.length, 0, 'should not need broad JQL when direct links exist');
     });
 
@@ -111,7 +116,7 @@ suite('checkBugTestsPassed', function() {
         assert.equal(result.success, true);
         assert.equal(result.action, 'moved_to_done');
         assert.deepEqual(moved, [{ key: 'TS-10', statusName: 'Done' }]);
-        assert.equal(removedLabels.length, 0);
+        assert.ok(removedLabels.some(function(l) { return l.key === 'TS-10' && l.label === 'sm_bug_done_check_triggered'; }));
     });
 
     test('waits when a direct linked TC is not Passed', function() {
@@ -280,7 +285,7 @@ suite('checkBugTestsPassed', function() {
         assert.equal(result.action, 'moved_to_done');
         assert.deepEqual(moved, [{ key: 'TS-60', statusName: 'Done' }]);
         assert.contains(comments[0].comment, 'Bug Complete');
-        assert.equal(removedLabels.length, 0);
+        assert.ok(removedLabels.some(function(l) { return l.key === 'TS-60' && l.label === 'sm_bug_done_check_triggered'; }));
     });
 
     test('waits when Bug To Fix TC is only tracked by the current Bug', function() {

--- a/js/unit-tests/test_checkWipLabel.js
+++ b/js/unit-tests/test_checkWipLabel.js
@@ -57,7 +57,7 @@ suite('checkWipLabel', function() {
         });
 
         assert.equal(result, false);
-        assert.ok(comments.some(function(c) { return c.comment.indexOf('WIP label') !== -1; }));
+        assert.ok(comments.some(function(c) { return c.comment.indexOf('work is in progress') !== -1; }));
     });
 
     test('stops when checkOpenPR is set and no open PR exists', function() {

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -704,8 +704,15 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
         return loadGithubHelpers(mocks || {});
     }
 
+    function findWrite(writes, path) {
+        for (var i = 0; i < writes.length; i++) {
+            if (writes[i].path === path) return writes[i];
+        }
+        return null;
+    }
+
     test('fetches Jenkins console log for a failed check with Jenkins details_url', function() {
-        var written = null;
+        var writes = [];
         var jenkinsInfoCalls = [];
         var jenkinsLogCalls = [];
 
@@ -728,7 +735,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
                 return 'line 1\nline 2\nfailure reason';
             },
             file_write: function(args) {
-                written = args;
+                writes.push(args);
             }
         });
 
@@ -745,15 +752,26 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
         assert.equal(jenkinsLogCalls.length, 1, 'jenkins_get_build_log should be called once');
         assert.equal(jenkinsLogCalls[0].jobPath, 'job/epam/job/dm.ai/job/PR-123');
         assert.equal(jenkinsLogCalls[0].buildNumber, 45);
-        assert.ok(written, 'ci_failures.md should be written');
-        assert.equal(written.path, '/tmp/input/ci_failures.md');
-        assert.contains(written.content, 'Jenkins PR Build');
-        assert.contains(written.content, 'Jenkins error log');
-        assert.contains(written.content, 'failure reason');
+
+        var mdWrite = findWrite(writes, '/tmp/input/ci_failures.md');
+        var fullLogWrite = findWrite(writes, '/tmp/input/ci_failures_full.log');
+
+        assert.ok(mdWrite, 'ci_failures.md should be written');
+        assert.contains(mdWrite.content, 'Jenkins PR Build');
+        assert.contains(mdWrite.content, 'Jenkins error log');
+        assert.contains(mdWrite.content, 'failure reason');
+        assert.contains(mdWrite.content, 'last 500 lines', 'ci_failures.md should mention last 500 lines');
+        assert.contains(mdWrite.content, 'ci_failures_full.log', 'ci_failures.md should reference ci_failures_full.log');
+
+        assert.ok(fullLogWrite, 'ci_failures_full.log should be written');
+        assert.contains(fullLogWrite.content, '=== Jenkins error log for: Jenkins PR Build ===');
+        assert.contains(fullLogWrite.content, 'line 1');
+        assert.contains(fullLogWrite.content, 'line 2');
+        assert.contains(fullLogWrite.content, 'failure reason');
     });
 
     test('ignores Jenkins details_url when jenkinsBasePath is not configured', function() {
-        var written = null;
+        var writes = [];
         var jenkinsLogCalls = [];
 
         var gh = makeGh({
@@ -771,7 +789,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
                 return 'log';
             },
             file_write: function(args) {
-                written = args;
+                writes.push(args);
             }
         });
 
@@ -779,12 +797,18 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
 
         assert.equal(failed.length, 1);
         assert.equal(jenkinsLogCalls.length, 0, 'jenkins log should not be fetched without base path');
-        assert.ok(written, 'file should still be written for the failed check');
-        assert.notContains(written.content, 'Jenkins error log');
+
+        var mdWrite = findWrite(writes, '/tmp/input/ci_failures.md');
+        assert.ok(mdWrite, 'file should still be written for the failed check');
+        assert.notContains(mdWrite.content, 'Jenkins error log');
+
+        var fullLogWrite = findWrite(writes, '/tmp/input/ci_failures_full.log');
+        assert.ok(!fullLogWrite, 'ci_failures_full.log should not be written when no logs were fetched');
     });
 
     test('ignores failed checks whose details_url points to a different Jenkins host', function() {
         var jenkinsLogCalls = [];
+        var writes = [];
 
         var gh = makeGh({
             github_get_commit_check_runs: function() {
@@ -800,11 +824,18 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
                 jenkinsLogCalls.push(args);
                 return 'log';
             },
-            file_write: function() {}
+            file_write: function(args) {
+                writes.push(args);
+            }
         });
 
         gh.detectFailedChecks('epam', 'dm.ai', 'abc123def', '/tmp/input', 'https://jenkins.example.com/');
 
         assert.equal(jenkinsLogCalls.length, 0, 'different host should be ignored');
+        var mdWrite = findWrite(writes, '/tmp/input/ci_failures.md');
+        var fullLogWrite = findWrite(writes, '/tmp/input/ci_failures_full.log');
+        assert.ok(mdWrite, 'ci_failures.md should still be written for the failed check');
+        assert.notContains(mdWrite.content, 'Jenkins error log');
+        assert.ok(!fullLogWrite, 'ci_failures_full.log should not be written when no logs were fetched');
     });
 });

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -569,7 +569,6 @@ suite('scm GitHub provider getPrDiff fallback', function() {
         assert.ok(diff.indexOf('diff --git') === 0, 'should return raw diff, not JSON envelope');
     });
 });
-
 suite('scm GitLab provider getPrDiff fallback', function() {
 
     test('prefers gitlab_get_mr_diff_text when available', function() {
@@ -696,5 +695,116 @@ suite('scm GitLab provider getPrDiff fallback', function() {
         var diff = provider.getPrDiff('7860', './dependencies/gens-igt');
 
         assert.equal(diff, 'com.github.istin.dmtools.gitlab.GitLab$4@b2c4a8b', 'should fall back to raw value, not throw');
+    });
+});
+
+suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
+
+    function makeGh(mocks) {
+        return loadGithubHelpers(mocks || {});
+    }
+
+    test('fetches Jenkins console log for a failed check with Jenkins details_url', function() {
+        var written = null;
+        var jenkinsInfoCalls = [];
+        var jenkinsLogCalls = [];
+
+        var gh = makeGh({
+            github_get_commit_check_runs: function() {
+                return {
+                    check_runs: [{
+                        name: 'Jenkins PR Build',
+                        conclusion: 'failure',
+                        details_url: 'https://jenkins.example.com/job/epam/job/dm.ai/job/PR-123/45/'
+                    }]
+                };
+            },
+            jenkins_get_job_info: function(args) {
+                jenkinsInfoCalls.push(args);
+                return { result: { number: 45, result: 'FAILURE' } };
+            },
+            jenkins_get_build_log: function(args) {
+                jenkinsLogCalls.push(args);
+                return 'line 1\nline 2\nfailure reason';
+            },
+            file_write: function(args) {
+                written = args;
+            }
+        });
+
+        var failed = gh.detectFailedChecks(
+            'epam', 'dm.ai', 'abc123def', '/tmp/input',
+            'https://jenkins.example.com/'
+        );
+
+        assert.equal(failed.length, 1, 'one failed check should be reported');
+        assert.equal(failed[0].name, 'Jenkins PR Build');
+        assert.equal(jenkinsInfoCalls.length, 1, 'jenkins_get_job_info should be called once');
+        assert.equal(jenkinsInfoCalls[0].jobPath, 'job/epam/job/dm.ai/job/PR-123');
+        assert.equal(jenkinsInfoCalls[0].buildNumber, 45);
+        assert.equal(jenkinsLogCalls.length, 1, 'jenkins_get_build_log should be called once');
+        assert.equal(jenkinsLogCalls[0].jobPath, 'job/epam/job/dm.ai/job/PR-123');
+        assert.equal(jenkinsLogCalls[0].buildNumber, 45);
+        assert.ok(written, 'ci_failures.md should be written');
+        assert.equal(written.path, '/tmp/input/ci_failures.md');
+        assert.contains(written.content, 'Jenkins PR Build');
+        assert.contains(written.content, 'Jenkins error log');
+        assert.contains(written.content, 'failure reason');
+    });
+
+    test('ignores Jenkins details_url when jenkinsBasePath is not configured', function() {
+        var written = null;
+        var jenkinsLogCalls = [];
+
+        var gh = makeGh({
+            github_get_commit_check_runs: function() {
+                return {
+                    check_runs: [{
+                        name: 'Jenkins PR Build',
+                        conclusion: 'failure',
+                        details_url: 'https://jenkins.example.com/job/epam/job/dm.ai/job/PR-123/45/'
+                    }]
+                };
+            },
+            jenkins_get_build_log: function(args) {
+                jenkinsLogCalls.push(args);
+                return 'log';
+            },
+            file_write: function(args) {
+                written = args;
+            }
+        });
+
+        var failed = gh.detectFailedChecks('epam', 'dm.ai', 'abc123def', '/tmp/input');
+
+        assert.equal(failed.length, 1);
+        assert.equal(jenkinsLogCalls.length, 0, 'jenkins log should not be fetched without base path');
+        assert.ok(written, 'file should still be written for the failed check');
+        assert.notContains(written.content, 'Jenkins error log');
+    });
+
+    test('ignores failed checks whose details_url points to a different Jenkins host', function() {
+        var jenkinsLogCalls = [];
+
+        var gh = makeGh({
+            github_get_commit_check_runs: function() {
+                return {
+                    check_runs: [{
+                        name: 'Other Jenkins Build',
+                        conclusion: 'failure',
+                        details_url: 'https://other-jenkins.example.com/job/x/1/'
+                    }]
+                };
+            },
+            jenkins_get_build_log: function(args) {
+                jenkinsLogCalls.push(args);
+                return 'log';
+            },
+            file_write: function() {}
+        });
+
+        gh.detectFailedChecks('epam', 'dm.ai', 'abc123def', '/tmp/input', 'https://jenkins.example.com/');
+
+        assert.equal(jenkinsLogCalls.length, 0, 'different host should be ignored');
     });
 });

--- a/js/unit-tests/test_mergeStoryTestAutomationPR.js
+++ b/js/unit-tests/test_mergeStoryTestAutomationPR.js
@@ -149,7 +149,7 @@ suite('mergeStoryTestAutomationPR', function() {
             jobParams: { customParams: { removeLabel: 'sm_story_test_merge_triggered' } }
         });
 
-        assert.equal(result, false);
+        assert.equal(result, true);
     });
 
     test('moves ticket to In Rework on merge conflict', function() {

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -201,7 +201,7 @@ suite('sm.json rule ordering', function() {
         });
 
         var failedTcBulk = indexByDescription['Failed Test Cases → create or link bugs in batch'];
-        var bugDevelopment = indexByDescription['Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development'];
+        var bugDevelopment = indexByDescription['Backlog / To Do / Ready For Development / In Development / In Rework Bugs → trigger bug_development'];
 
         assert.ok(failedTcBulk >= 0, 'failed TC bulk creation rule exists');
         assert.ok(bugDevelopment >= 0, 'bug development rule exists');
@@ -217,7 +217,7 @@ suite('sm.json rule ordering', function() {
         var bugDevelopment = null;
 
         rules.forEach(function(rule) {
-            if (rule.description === 'Backlog / To Do / Ready For Development / In Development Bugs → trigger bug_development') {
+            if (rule.description === 'Backlog / To Do / Ready For Development / In Development / In Rework Bugs → trigger bug_development') {
                 bugDevelopment = rule;
             }
         });

--- a/prompts/pr_review_prompt.md
+++ b/prompts/pr_review_prompt.md
@@ -9,7 +9,7 @@ The input folder contains a ticket subfolder (e.g. `input/PROJ-123/`). List `inp
 - `parent_context_vd.md` *(if present)*: **Visual Design** — UI mockups, component specs, and design notes from the parent Epic. Use to verify the UI matches the expected look and feel.
 - `pr_info.md`: Pull Request metadata
 - `pr_diff.txt`: Complete diff of all code changes
-- `ci_failures.md` *(if present)*: **CI checks currently failing on this PR** — treat as 🚨 BLOCKING issues
+- `ci_failures.md` *(if present)*: **CI checks currently failing on this PR** — treat as 🚨 BLOCKING issues. Contains the last 500 lines of each failed check log; full logs are in `ci_failures_full.log`.
 - `pr_discussions.md` *(if present)*: Previous review comments — indicates this is a repeated review
 - `pr_discussions_raw.json` *(if present)*: Structured thread data with IDs — for each thread fully fixed in this diff, add its `threadId` to `resolvedThreadIds` in `pr_review.json`
 

--- a/prompts/pr_rework_prompt.md
+++ b/prompts/pr_rework_prompt.md
@@ -10,7 +10,7 @@ You are fixing code issues identified in a Pull Request review.
 7. `pr_info.md` — Pull Request metadata (PR number, URL, branch)
 8. `pr_diff.txt` — Current code changes already in the PR (what was implemented)
 9. `merge_conflicts.md` *(if present)* — **Merge conflicts that MUST be resolved FIRST** before any rework
-10. `ci_failures.md` *(if present)* — **CI check failures with error logs that MUST be fixed**
+10. `ci_failures.md` *(if present)* — **CI check failures with error logs that MUST be fixed** (last 500 lines of each failed check; full logs are in `ci_failures_full.log`)
 11. `pr_discussions.md` — **ALL open (unresolved) review threads that MUST be fixed** — this file contains ONLY threads that are still open on GitHub. Already-resolved threads are excluded. **Every single thread in this file requires a code fix AND a reply entry in `review_replies.json` — no exceptions.**
 12. `pr_discussions_raw.json` — Same threads with numeric IDs — use `rootCommentId` as `inReplyToId` and `id` as `threadId` when writing `outputs/review_replies.json`. **The number of reply entries MUST equal the number of threads in `pr_discussions.md`.**
 
@@ -18,7 +18,7 @@ If `rework_setup_failed.md` is present, stop immediately: write `outputs/respons
 
 **If `merge_conflicts.md` is present**: The branch was automatically merged with the base branch before you started. There are unresolved conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in the listed files. **Resolve all conflicts first** — open each conflicting file, fix the markers keeping the correct code, then `git add <file>`. Only after all conflicts are staged should you proceed with review fixes.
 
-**If `ci_failures.md` is present**: CI checks are currently failing on this PR. Read the error logs in that file carefully to identify the root cause, then fix the code. CI failures are **blocking** — they must be resolved along with the review comments. After pushing, CI will re-run automatically.
+**If `ci_failures.md` is present**: CI checks are currently failing on this PR. Read the error logs in that file carefully (last 500 lines; full logs are in `ci_failures_full.log`) to identify the root cause, then fix the code. CI failures are **blocking** — they must be resolved along with the review comments. After pushing, CI will re-run automatically.
 
 Your mission is to address every issue raised in `pr_discussions.md`. This includes:
 

--- a/snapshots/pr_bug_test_automation_review.md
+++ b/snapshots/pr_bug_test_automation_review.md
@@ -82,7 +82,7 @@ flowchart TD
 flowchart TD
     START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
     PROJ --> INPUT["Read PR context from input folder"]
-    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
     SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]
@@ -127,7 +127,7 @@ flowchart TD
     F3["outputs/pr_review.json — valid JSON with recommendation (APPROVE|BLOCK|REQUEST_CHANGES), summary, inlineComments, issueCounts"]
     F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
     F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
 ```

--- a/snapshots/pr_review.md
+++ b/snapshots/pr_review.md
@@ -39,7 +39,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    START([PR ready for review]) --> READ["1. Read input context:<br/>instruction.md, ticket.md, pr_info.md,<br/>pr_diff.txt, pr_files.txt, ci_failures.md,<br/>pr_discussions.md, pr_discussions_raw.json"]
+    START([PR ready for review]) --> READ["1. Read input context:<br/>instruction.md, ticket.md, pr_info.md,<br/>pr_diff.txt, pr_files.txt, ci_failures.md,<br/>ci_failures_full.log, pr_discussions.md,<br/>pr_discussions_raw.json"]
     READ --> DIFF["2. Run diff checklist on pr_diff.txt"]
     DIFF --> FILES["3. Read full content of every changed file"]
     FILES --> CODEGRAPH["4. Use CodeGraph:<br/>callers/callees of changed symbols,<br/>search for sensitive patterns,<br/>impact analysis"]
@@ -59,9 +59,10 @@ flowchart TD
         P2["2️⃣ input/TICKET/pr_info.md — PR title, author, branch, description"]
         P3["3️⃣ input/TICKET/pr_diff.txt — the diff to review"]
         P4["4️⃣ input/TICKET/pr_files.txt — list of changed files"]
-        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING"]
+        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING (last 500 lines)"]
+        P5_FULL["5️⃣ input/TICKET/ci_failures_full.log — full CI logs"]
         P6["6️⃣ input/TICKET/pr_discussions.md + pr_discussions_raw.json — existing comments"]
-        P1 --> P2 --> P3 --> P4 --> P5 --> P6
+        P1 --> P2 --> P3 --> P4 --> P5 --> P5_FULL --> P6
     end
 
     subgraph TICKET_CONTEXT["Ticket context (for understanding PR purpose)"]
@@ -195,7 +196,7 @@ flowchart TD
     F4["Each inline comment: path, line, startLine, side, comment, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["comment must be a path to a file under outputs/pr_review_comments/<name>.md"]
     F6["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F7["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F7["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F8["Keep summary under 2 sentences — put details in inline comment files, not in general text"]
     F9["Severity classification follows general_guidelines.md:<br/>BLOCKING = must fix · IMPORTANT = should fix · SUGGESTION = optional"]
     F10["Ticket context: verify PR changes satisfy ticket ACs — note gaps in review"]

--- a/snapshots/pr_rework.md
+++ b/snapshots/pr_rework.md
@@ -40,11 +40,11 @@ flowchart TD
     START([Ticket enters rework]) --> SETUP{rework_setup_failed.md exists?}
     SETUP -->|Yes| FAIL[Write setup failure response and stop]
     SETUP -->|No| INPUT[Read ALL input files in the ticket subfolder]
-    INPUT --> INPUTS["request.md, comments.md, existing_questions.json, parent_context_*.md, pr_info.md, pr_diff.txt, merge_conflicts.md, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["request.md, comments.md, existing_questions.json, parent_context_*.md, pr_info.md, pr_diff.txt, merge_conflicts.md, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> CONFLICTS{merge_conflicts.md exists?}
     CONFLICTS -->|Yes| RESOLVE["Resolve every conflict marker, git add each file, verify with git diff --check"]
     CONFLICTS -->|No| CI
-    RESOLVE --> CI{ci_failures.md exists?}
+    RESOLVE --> CI{ci_failures.md or ci_failures_full.log exists?}
     CI -->|Yes| FIX_CI["Fix CI root cause: dependencies, config, or test setup"]
     CI -->|No| THREADS
     FIX_CI --> THREADS[Address every open thread in pr_discussions.md]
@@ -72,9 +72,10 @@ flowchart TD
         P2["2️⃣ input/TICKET/pr_info.md — PR title, author, branch, description"]
         P3["3️⃣ input/TICKET/pr_diff.txt — the diff to review"]
         P4["4️⃣ input/TICKET/pr_files.txt — list of changed files"]
-        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING"]
+        P5["5️⃣ input/TICKET/ci_failures.md — CI failures = BLOCKING (last 500 lines)"]
+        P5_FULL["5️⃣ input/TICKET/ci_failures_full.log — full CI logs"]
         P6["6️⃣ input/TICKET/pr_discussions.md + pr_discussions_raw.json — existing comments"]
-        P1 --> P2 --> P3 --> P4 --> P5 --> P6
+        P1 --> P2 --> P3 --> P4 --> P5 --> P5_FULL --> P6
     end
 
     subgraph TICKET_CONTEXT["Ticket context (for understanding PR purpose)"]

--- a/snapshots/pr_story_test_automation_review.md
+++ b/snapshots/pr_story_test_automation_review.md
@@ -82,7 +82,7 @@ flowchart TD
 flowchart TD
     START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
     PROJ --> INPUT["Read PR context from input folder"]
-    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
     SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]
@@ -127,7 +127,7 @@ flowchart TD
     F3["outputs/pr_review.json — valid JSON with recommendation (APPROVE|BLOCK|REQUEST_CHANGES), summary, inlineComments, issueCounts"]
     F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
     F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
 ```

--- a/snapshots/pr_test_automation_review.md
+++ b/snapshots/pr_test_automation_review.md
@@ -82,7 +82,7 @@ flowchart TD
 flowchart TD
     START([Test automation PR ready for review]) --> PROJ["Read instruction.md from repo root if it exists"]
     PROJ --> INPUT["Read PR context from input folder"]
-    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, pr_discussions.md, pr_discussions_raw.json"]
+    INPUT --> INPUTS["ticket.md, pr_info.md, pr_diff.txt, pr_files.txt, ci_failures.md, ci_failures_full.log, pr_discussions.md, pr_discussions_raw.json"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> SCOPE["Confirm scope: review test code only inside testing/"]
     SCOPE --> CORRECT["Compare test steps against Test Case: objective, preconditions, steps, expected result"]
@@ -127,7 +127,7 @@ flowchart TD
     F3["outputs/pr_review.json — valid JSON with recommendation (APPROVE|BLOCK|REQUEST_CHANGES), summary, inlineComments, issueCounts"]
     F4["Each inline comment: path, line, startLine, side, body, severity (BLOCKING|IMPORTANT|SUGGESTION)"]
     F5["outputs/pr_review_general.md — max 1-2 paragraphs, factual, no essays"]
-    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING"]
+    F6["If ci_failures.md present → include each failure as 🚨 BLOCKING (full logs in ci_failures_full.log)"]
     F7["Keep summary under 2 sentences — put details in inline comments, not in general text"]
     F8["Tracker-specific formatting is injected via cliPromptsByTracker — do NOT hardcode Jira/ADO markup"]
 ```

--- a/snapshots/pr_test_automation_rework.md
+++ b/snapshots/pr_test_automation_rework.md
@@ -83,12 +83,12 @@ flowchart TD
     START([Test Case enters In Rework]) --> SETUP{rework_setup_failed.md exists?}
     SETUP -->|Yes| FAIL[Write setup failure response and stop]
     SETUP -->|No| INPUT[Read ALL input files in the ticket subfolder]
-    INPUT --> INPUTS["request.md, ticket.md, linked_bugs.md, pr_info.md, pr_diff.txt, comments.md, pr_discussions.md, pr_discussions_raw.json, merge_conflicts.md, ci_failures.md"]
+    INPUT --> INPUTS["request.md, ticket.md, linked_bugs.md, pr_info.md, pr_diff.txt, comments.md, pr_discussions.md, pr_discussions_raw.json, merge_conflicts.md, ci_failures.md, ci_failures_full.log"]
     INPUTS --> EXPLORE["Explore codebase structure in testing/ folder"]
     EXPLORE --> CONFLICTS{merge_conflicts.md exists?}
     CONFLICTS -->|Yes| RESOLVE["Resolve every conflict marker, git add each file, verify with git diff --check"]
     CONFLICTS -->|No| CI
-    RESOLVE --> CI{ci_failures.md exists?}
+    RESOLVE --> CI{ci_failures.md or ci_failures_full.log exists?}
     CI -->|Yes| FIX_CI["Fix CI root cause: dependencies, config, or test setup"]
     CI -->|No| THREADS
     FIX_CI --> THREADS[Address every open thread in pr_discussions.md]


### PR DESCRIPTION
## What\n\nAdds Jenkins support to failed-CI-check collection so that when a GitHub check run points at a configured Jenkins instance, its console log is appended to `ci_failures.md`.\n\n## Changes\n\n- `js/configLoader.js`: new optional `scm.jenkinsBasePath` config key.\n- `js/common/githubHelpers.js`:\n  - `detectFailedChecks` now accepts an optional `jenkinsBasePath`.\n  - For every failed check whose `details_url` lives under the configured Jenkins base path, parses the job path + build number and calls `jenkins_get_job_info` / `jenkins_get_build_log`.\n  - Appends the last 150 lines of the Jenkins console log to `ci_failures.md`, mirroring the existing GitHub Actions behaviour.\n- `js/preCliReworkSetup.js` and `js/preparePRForReview.js`: pass `config.scm.jenkinsBasePath` to `detectFailedChecks`.\n- `js/unit-tests/test_githubHelpers.js`: new test suite covering Jenkins log fetching, missing config, and a non-matching Jenkins host.\n\n## Verification\n\n`node agents/js/unit-tests/node_testRunner.js agents/js/unit-tests/test_githubHelpers.js` — 32 passed, 0 failed.