### PR TITLE
feat(smAgent): add forceLocalTeammate CLI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,22 @@ fills in anything missing from `./dmtools.env` (same `KEY=VALUE` format
 `JIRA_API_TOKEN`, `JIRA_BASE_PATH`, `GH_TOKEN`/`PAT_TOKEN`, plus whatever the configured
 `AI_AGENT_PROVIDER` needs (e.g. `COPILOT_GITHUB_TOKEN`).
 
+**Switching an entire SM run to local without editing any rule:** rather than adding
+`localTeammate: true` to every rule in `sm.json`/`.dmtools/config.js`, pass a CLI JSON
+override (dmtools deep-merges this into `jobParams`) when invoking the SM job:
+
+```bash
+dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'
+```
+
+With `forceLocalTeammate: true`, every default-dispatch rule for that run behaves as if
+it had `localTeammate: true` — no GitHub Actions dispatch, everything runs through
+`scripts/run-teammate-local.sh` sequentially. Rules already using `localExecution: true`
+are untouched (they never dispatched in the first place), and any rule can still opt out
+of the override with an explicit `localTeammate: false`. Without the override, the SM job
+runs exactly as before — default dispatch to `ai-teammate.yml` — so this is purely an
+opt-in, per-invocation switch; nothing in `sm.json` or `.dmtools/config.js` needs to change.
+
 ### Bootstrapping a Local/Cloud Dev Session
 
 `scripts/warmup-session.sh` prepares a fresh machine (cloud dev-environment session,

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -21,6 +21,11 @@
  *   jobParams.maxTriggeredWorkflows (or maxWorkflowsPerRun) limits total active plus newly
  *   dispatched workflows across all non-local rules.
  *   Override priority: config.smMaxWorkflows (from .dmtools/config.js) > sm.json value.
+ *   jobParams.forceLocalTeammate — set via a CLI JSON override (e.g.
+ *   `dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'`) to switch
+ *   EVERY default-dispatch rule to the local teammate pipeline for that run, without
+ *   editing sm.json/.dmtools/config.js. Rules with localExecution:true are unaffected;
+ *   a rule can still opt out with an explicit `localTeammate: false`.
  *
  * Rule fields:
  *   jql            (required) — JQL to find tickets (supports {jiraProject}, {parentTicket})
@@ -749,6 +754,30 @@ function action(params) {
             console.log('SM Agent: Patched rule "' + (rule.description || rule.configFile) + '" with override:', JSON.stringify(patch));
             return patched;
         });
+    }
+
+    // Global "run everything locally" override — set via a CLI JSON override, e.g.:
+    //   dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'
+    // Forces every default-dispatch rule to run through the local teammate pipeline
+    // (as if it had localTeammate:true) instead of a GitHub Actions workflow_dispatch —
+    // no env var needed; dmtools' own CLI JSON-override mechanism (deep-merged into
+    // jobParams) is the switch. Rules already using localExecution:true (pure-JS, no
+    // checkout/AI CLI) are left untouched. A rule can opt out even while the override is
+    // active by setting `localTeammate: false` explicitly.
+    if (p.forceLocalTeammate && rules) {
+        var forcedCount = 0;
+        rules = rules.map(function(rule) {
+            if (rule.localExecution || rule.localTeammate === false || rule.localTeammate) {
+                return rule;
+            }
+            forcedCount++;
+            var forced = {};
+            Object.keys(rule).forEach(function(k) { forced[k] = rule[k]; });
+            forced.localTeammate = true;
+            return forced;
+        });
+        console.log('SM Agent: forceLocalTeammate override active — ' + forcedCount +
+            ' rule(s) switched from dispatch to local execution');
     }
 
     // Targeted mode: bypass all JQL rules and dispatch a single agent to a single ticket.

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -804,6 +804,86 @@ suite('smAgent: localTeammate execution mode', function() {
 
 });
 
+suite('smAgent: forceLocalTeammate CLI override', function() {
+
+    test('switches a default-dispatch rule to local execution', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject} AND status = 'Ready'", {
+                configFile: 'agents/story_development.json'
+            })
+        ]);
+        params.jobParams.forceLocalTeammate = true;
+
+        sm.action(params);
+
+        assert.equal(sm.capturedTriggers.length, 0, 'no GitHub Actions workflow should be dispatched');
+        assert.equal(localRunCommands(sm).length, 1, 'rule runs locally instead of dispatching');
+    });
+
+    test('leaves localExecution:true rules untouched', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };',
+                'agents/test.json': MINIMAL_AGENT_CONFIG
+            },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", { localExecution: true })
+        ]);
+        params.jobParams.forceLocalTeammate = true;
+
+        sm.action(params);
+
+        assert.equal(localRunCommands(sm).length, 0, 'localExecution rules do not go through run-teammate-local.sh');
+        assert.equal(sm.capturedTriggers.length, 0, 'localExecution rules never dispatch either');
+    });
+
+    test('respects an explicit localTeammate:false opt-out', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_development.json',
+                localTeammate: false
+            })
+        ]);
+        params.jobParams.forceLocalTeammate = true;
+
+        sm.action(params);
+
+        assert.equal(localRunCommands(sm).length, 0, 'opted-out rule must not run locally');
+        assert.equal(sm.capturedTriggers.length, 1, 'opted-out rule dispatches as normal');
+    });
+
+    test('is a no-op when not set (default remote dispatch)', function() {
+        var sm = makeSmAgent({
+            fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        var params = baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", { configFile: 'agents/story_development.json' })
+        ]);
+        // forceLocalTeammate intentionally omitted
+
+        sm.action(params);
+
+        assert.equal(sm.capturedTriggers.length, 1, 'default behavior still dispatches to GitHub Actions');
+        assert.equal(localRunCommands(sm).length, 0);
+    });
+
+});
+
 // ── localExecution module loading ─────────────────────────────────────────────
 
 suite('smAgent: localExecution module loading', function() {


### PR DESCRIPTION
Adds `jobParams.forceLocalTeammate`, set via dmtools' CLI JSON-override mechanism:

```
dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'
```

Switches every default-dispatch rule to the local teammate pipeline for that run (no GitHub Actions dispatch), without editing `sm.json`/`.dmtools/config.js`. `localExecution:true` rules are untouched; a rule can opt out with `localTeammate: false`. No override = unchanged default behavior.

4 new unit tests. `node --check` clean. `run_all.json`: 596 passed/18 failed vs main baseline 592/18 (0 regressions).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>