### PR TITLE
refactor(agents): make JS action files tracker-agnostic (Jira/ADO/Rally)

### DIFF
--- a/js/assignForSolutionArchitecture.js
+++ b/js/assignForSolutionArchitecture.js
@@ -10,6 +10,7 @@ const configLoader = require('./configLoader.js');
 const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 const ACCEPTANCE_CRITERIA_TRIGGER_LABELS = [
     'sm_story_acceptance_criteria_triggered',
@@ -24,13 +25,13 @@ function action(params) {
             ? params.metadata.contextId + '_wip'
             : null;
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = projectConfig.jira;
+        var trackerConfig = projectConfig.tracker;
         var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
 
         // Assign to initiator (skip if accountId is not available)
         if (initiatorId) {
             try {
-                jira_assign_ticket_to({
+                tracker_assign_ticket({
                     key: ticketKey,
                     accountId: initiatorId
                 });
@@ -41,9 +42,9 @@ function action(params) {
 
         // Move to Solution Architecture — trigger labels are only removed on success
         try {
-            jira_move_to_status({
+            tracker_move_to_status({
                 key: ticketKey,
-                statusName: jiraConfig.statuses.SOLUTION_ARCHITECTURE
+                statusName: trackerConfig.statuses.SOLUTION_ARCHITECTURE
             });
         } catch (statusError) {
             console.error('Failed to move ' + ticketKey + ' to Solution Architecture — trigger labels NOT removed:', statusError);
@@ -53,7 +54,7 @@ function action(params) {
 
         // Add ai_generated label
         try {
-            jira_add_label({ key: ticketKey, label: LABELS.AI_GENERATED });
+            trackerHelper.addLabel(ticketKey, LABELS.AI_GENERATED);
         } catch (e) {
             console.warn('Failed to add ai_generated label:', e);
         }
@@ -61,7 +62,7 @@ function action(params) {
         // Remove WIP label if present
         if (wipLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: wipLabel });
+                trackerHelper.removeLabel(ticketKey, wipLabel);
                 console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
             } catch (e) {
                 console.warn('Failed to remove WIP label:', e);
@@ -70,7 +71,7 @@ function action(params) {
 
         ACCEPTANCE_CRITERIA_TRIGGER_LABELS.forEach(function(label) {
             try {
-                jira_remove_label({ key: ticketKey, label: label });
+                trackerHelper.removeLabel(ticketKey, label);
                 console.log('Removed trigger label "' + label + '" from ' + ticketKey);
             } catch (e) {
                 console.warn('Failed to remove trigger label "' + label + '":', e);

--- a/js/assignForSolutionArchitecture.js
+++ b/js/assignForSolutionArchitecture.js
@@ -5,7 +5,7 @@
  */
 
 const { extractTicketKey } = require('./common/jiraHelpers.js');
-const { LABELS, STATUSES } = require('./config.js');
+const { LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
@@ -24,6 +24,7 @@ function action(params) {
             ? params.metadata.contextId + '_wip'
             : null;
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
 
         // Assign to initiator (skip if accountId is not available)
@@ -38,11 +39,16 @@ function action(params) {
             }
         }
 
-        // Move to Solution Architecture
-        jira_move_to_status({
-            key: ticketKey,
-            statusName: STATUSES.SOLUTION_ARCHITECTURE
-        });
+        // Move to Solution Architecture — trigger labels are only removed on success
+        try {
+            jira_move_to_status({
+                key: ticketKey,
+                statusName: jiraConfig.statuses.SOLUTION_ARCHITECTURE
+            });
+        } catch (statusError) {
+            console.error('Failed to move ' + ticketKey + ' to Solution Architecture — trigger labels NOT removed:', statusError);
+            throw statusError;
+        }
         console.log('Moved ' + ticketKey + ' to Solution Architecture');
 
         // Add ai_generated label

--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -16,7 +16,7 @@
  *   this check on the next cycle.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 const scmModule = require('./common/scm.js');
@@ -28,8 +28,9 @@ function action(params) {
 
     // Load project config to get issue types (default: "Test Case" / "Bug")
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const testCaseType = projectConfig.jira.issueTypes.TEST_CASE || 'Test Case';
-    const bugType = projectConfig.jira.issueTypes.BUG || 'Bug';
+    const jiraConfig = projectConfig.jira;
+    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
 
     // Helper: remove SM label so the check re-runs on the next SM cycle
     function releaseLock() {
@@ -101,7 +102,7 @@ function action(params) {
         var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
         // Passed / intentionally skipped / no longer applicable are always non-blocking.
-        if (status === STATUSES.PASSED || status === STATUSES.SKIPPED || status === STATUSES.IRRELEVANT) {
+        if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
             return false;
         }
 
@@ -112,7 +113,7 @@ function action(params) {
         // regression TCs TS-501/TS-252 were Bug To Fix). We count *any* other
         // linked Bug (even Done) so stale TCs that were already addressed do not
         // hold the current Bug hostage.
-        if (status === STATUSES.BUG_TO_FIX) {
+        if (status === jiraConfig.statuses.BUG_TO_FIX) {
             var linkedBugs = findLinkedBugs(tc.key);
             var hasOtherBug = linkedBugs.some(function(bug) {
                 var bugStatus = bug.fields && bug.fields.status && bug.fields.status.name;
@@ -173,7 +174,7 @@ function action(params) {
                 var reworkAttempted = labels.indexOf('sm_bug_rework_attempted') !== -1;
                 if (reworkAttempted) {
                     console.log('Test PR finalized and one rework already attempted — moving', ticketKey, 'to Blocked for triage');
-                    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
                     jira_post_comment({
                         key: ticketKey,
                         comment: 'h3. 🚫 Test PR Finalized But Acceptance Tests Still Blocking After Rework\n\n' +
@@ -186,7 +187,7 @@ function action(params) {
                 }
 
                 console.log('Test PR finalized but', blockingCount, 'linked Test Case(s) still block — moving', ticketKey, 'to In Rework (one attempt)');
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 jira_add_label({ key: ticketKey, label: 'sm_bug_rework_attempted' });
                 jira_post_comment({
                     key: ticketKey,
@@ -244,7 +245,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.DONE
+            statusName: jiraConfig.statuses.DONE
         });
 
         // Clean up anti-cycle label on successful completion.

--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -20,6 +20,7 @@ const { LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 const scmModule = require('./common/scm.js');
+var trackerHelper = require('./common/tracker.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
@@ -28,15 +29,15 @@ function action(params) {
 
     // Load project config to get issue types (default: "Test Case" / "Bug")
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const jiraConfig = projectConfig.jira;
-    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
-    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
+    const trackerConfig = projectConfig.tracker;
+    const testCaseType = trackerConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = trackerConfig.issueTypes.BUG || 'Bug';
 
     // Helper: remove SM label so the check re-runs on the next SM cycle
     function releaseLock() {
         if (ticketKey && removeLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: removeLabel });
+                trackerHelper.removeLabel(ticketKey, removeLabel);
                 console.log('Released SM label — will re-check next cycle');
             } catch (e) {
                 console.warn('Failed to remove SM label:', e);
@@ -46,7 +47,7 @@ function action(params) {
 
     function getTicket() {
         try {
-            return jira_get_ticket({ key: ticketKey }) || {};
+            return tracker_get_ticket({ key: ticketKey }) || {};
         } catch (e) {
             console.warn('Failed to read ticket', ticketKey, ':', e);
             return {};
@@ -76,7 +77,7 @@ function action(params) {
 
     function findAllLinkedTCs() {
         try {
-            return jira_search_by_jql({
+            return tracker_search({
                 jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "' + testCaseType + '"',
                 maxResults: 100
             }) || [];
@@ -88,7 +89,7 @@ function action(params) {
 
     function findLinkedBugs(tcKey) {
         try {
-            return jira_search_by_jql({
+            return tracker_search({
                 jql: 'issue in linkedIssues("' + tcKey + '") AND issuetype = "' + bugType + '"',
                 maxResults: 50
             }) || [];
@@ -102,7 +103,7 @@ function action(params) {
         var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
         // Passed / intentionally skipped / no longer applicable are always non-blocking.
-        if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
+        if (status === trackerConfig.statuses.PASSED || status === trackerConfig.statuses.SKIPPED || status === trackerConfig.statuses.IRRELEVANT) {
             return false;
         }
 
@@ -113,7 +114,7 @@ function action(params) {
         // regression TCs TS-501/TS-252 were Bug To Fix). We count *any* other
         // linked Bug (even Done) so stale TCs that were already addressed do not
         // hold the current Bug hostage.
-        if (status === jiraConfig.statuses.BUG_TO_FIX) {
+        if (status === trackerConfig.statuses.BUG_TO_FIX) {
             var linkedBugs = findLinkedBugs(tc.key);
             var hasOtherBug = linkedBugs.some(function(bug) {
                 var bugStatus = bug.fields && bug.fields.status && bug.fields.status.name;
@@ -174,8 +175,8 @@ function action(params) {
                 var reworkAttempted = labels.indexOf('sm_bug_rework_attempted') !== -1;
                 if (reworkAttempted) {
                     console.log('Test PR finalized and one rework already attempted — moving', ticketKey, 'to Blocked for triage');
-                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
-                    jira_post_comment({
+                    tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BLOCKED });
+                    tracker_post_comment({
                         key: ticketKey,
                         comment: 'h3. 🚫 Test PR Finalized But Acceptance Tests Still Blocking After Rework\n\n' +
                             'The test-automation PR was merged and finalized, and one rework was already attempted, but the following linked Test Case(s) are still not *Passed*:\n' +
@@ -187,9 +188,9 @@ function action(params) {
                 }
 
                 console.log('Test PR finalized but', blockingCount, 'linked Test Case(s) still block — moving', ticketKey, 'to In Rework (one attempt)');
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
-                jira_add_label({ key: ticketKey, label: 'sm_bug_rework_attempted' });
-                jira_post_comment({
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
+                trackerHelper.addLabel(ticketKey, 'sm_bug_rework_attempted');
+                tracker_post_comment({
                     key: ticketKey,
                     comment: 'h3. 🔄 Test PR Merged But Acceptance Tests Still Blocking\n\n' +
                         'The test-automation PR was merged and finalized, but the following linked Test Case(s) are still not *Passed*:\n' +
@@ -243,19 +244,19 @@ function action(params) {
         // Step 4: Move Bug to Done
         console.log('Moving', ticketKey, 'to Done');
 
-        jira_move_to_status({
+        tracker_move_to_status({
             key: ticketKey,
-            statusName: jiraConfig.statuses.DONE
+            statusName: trackerConfig.statuses.DONE
         });
 
         // Clean up anti-cycle label on successful completion.
         try {
-            jira_remove_label({ key: ticketKey, label: 'sm_bug_rework_attempted' });
+            trackerHelper.removeLabel(ticketKey, 'sm_bug_rework_attempted');
         } catch (e) {
             console.warn('Could not remove sm_bug_rework_attempted label:', e);
         }
 
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: 'h3. ✅ Bug Complete — All Linked Test Cases Resolved\n\n' +
                 'All *' + totalTCs + '* linked Test Case(s) are either *Passed*, *Skipped*, *Irrelevant*, ' +

--- a/js/checkBugToFixReady.js
+++ b/js/checkBugToFixReady.js
@@ -15,7 +15,7 @@
  * - Otherwise → releases the SM idempotency label so the check re-runs next cycle.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -24,6 +24,8 @@ function action(params) {
     const issueType = (ticketFields && ticketFields.issuetype && ticketFields.issuetype.name) || 'Test Case';
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     /**
      * DMTools returns issue search results as host objects. In some runtime
@@ -59,7 +61,7 @@ function action(params) {
     function findNotDoneBugs(entityKey) {
         var key = entityKey || ticketKey;
         return toPlain(jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug AND status != "Done"',
+            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug AND status != "' + jiraConfig.statuses.DONE + '"',
             maxResults: 50
         })) || [];
     }
@@ -114,7 +116,7 @@ function action(params) {
             return { success: true, action: 'waiting', issueType, total: totalBugs, notDone: notDoneCount, ticketKey };
         }
 
-        if (issueType === 'Story') {
+        if (issueType === jiraConfig.issueTypes.STORY) {
             // Also check bugs linked to linked Test Cases before allowing the Story to re-test.
             const pendingTcBugs = findPendingBugsInLinkedTestCases();
             if (pendingTcBugs.length > 0) {
@@ -132,7 +134,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: STATUSES.READY_FOR_TESTING
+                statusName: jiraConfig.statuses.READY_FOR_TESTING
             });
 
             // Remove the story_done_check lock so it can re-run after the Story returns to In Testing
@@ -159,7 +161,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: STATUSES.BACKLOG
+                statusName: jiraConfig.statuses.BACKLOG
             });
 
             // Remove test automation label so SM can re-trigger automation
@@ -188,7 +190,7 @@ function action(params) {
             console.warn('Failed to post token usage comments:', e);
         }
 
-        return { success: true, action: issueType === 'Story' ? 'moved_to_ready_for_testing' : 'moved_to_backlog', totalBugs: totalBugs, ticketKey };
+        return { success: true, action: issueType === jiraConfig.issueTypes.STORY ? 'moved_to_ready_for_testing' : 'moved_to_backlog', totalBugs: totalBugs, ticketKey };
 
     } catch (error) {
         console.error('❌ Error in checkBugToFixReady:', error);

--- a/js/checkStoryTestsPassed.js
+++ b/js/checkStoryTestsPassed.js
@@ -14,7 +14,6 @@
  *   bugs) → moves the Story back to "Ready For Testing" to trigger a re-run.
  */
 
-const { STATUSES, resolveStatuses } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -22,11 +21,10 @@ function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
-    const statuses = resolveStatuses(customParams);
-
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const testCaseType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE) || 'Test Case';
-    const bugType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.BUG) || 'Bug';
+    const jiraConfig = projectConfig.jira;
+    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -69,7 +67,7 @@ function action(params) {
         var bugs = findLinkedBugs(tcKey);
         for (var i = 0; i < bugs.length; i++) {
             var status = bugs[i].fields && bugs[i].fields.status && bugs[i].fields.status.name;
-            if (status !== STATUSES.DONE) {
+            if (status !== jiraConfig.jiraConfig.statuses.DONE) {
                 return bugs[i].key;
             }
         }
@@ -77,10 +75,10 @@ function action(params) {
     }
 
     function isInFlightStatus(status) {
-        return status === statuses.IN_REVIEW_PASSED ||
-            status === statuses.IN_REVIEW_FAILED ||
-            status === statuses.IN_DEVELOPMENT ||
-            status === statuses.READY_FOR_DEVELOPMENT;
+        return status === jiraConfig.statuses.IN_REVIEW_PASSED ||
+            status === jiraConfig.statuses.IN_REVIEW_FAILED ||
+            status === jiraConfig.statuses.IN_DEVELOPMENT ||
+            status === jiraConfig.statuses.READY_FOR_DEVELOPMENT;
     }
 
     try {
@@ -105,7 +103,7 @@ function action(params) {
         allTCs.forEach(function(tc) {
             var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
-            if (status === statuses.PASSED || status === statuses.SKIPPED || status === statuses.IRRELEVANT) {
+            if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
                 return;
             }
 
@@ -120,7 +118,7 @@ function action(params) {
                 return;
             }
 
-            if (status === statuses.FAILED) {
+            if (status === jiraConfig.statuses.FAILED) {
                 waitingForBugsTCs.push(tc.key);
             } else {
                 readyForRetestTCs.push(tc.key);
@@ -133,7 +131,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: statuses.DONE
+                statusName: jiraConfig.statuses.DONE
             });
 
             jira_post_comment({
@@ -171,7 +169,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: statuses.BUG_TO_FIX
+                statusName: jiraConfig.statuses.BUG_TO_FIX
             });
 
             jira_post_comment({
@@ -205,7 +203,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: statuses.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
         jira_post_comment({

--- a/js/checkStoryTestsPassed.js
+++ b/js/checkStoryTestsPassed.js
@@ -16,20 +16,21 @@
 
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const jiraConfig = projectConfig.jira;
-    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
-    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
+    const trackerConfig = projectConfig.tracker;
+    const testCaseType = trackerConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = trackerConfig.issueTypes.BUG || 'Bug';
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: removeLabel });
+                trackerHelper.removeLabel(ticketKey, removeLabel);
                 console.log('Released SM label — will re-check next cycle');
             } catch (e) {
                 console.warn('Failed to remove SM label:', e);
@@ -39,7 +40,7 @@ function action(params) {
 
     function findLinkedTCs() {
         try {
-            return jira_search_by_jql({
+            return tracker_search({
                 jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = "' + testCaseType + '"',
                 fields: ['key', 'status'],
                 maxResults: 100
@@ -52,7 +53,7 @@ function action(params) {
 
     function findLinkedBugs(tcKey) {
         try {
-            return jira_search_by_jql({
+            return tracker_search({
                 jql: 'issue in linkedIssues("' + tcKey + '") AND issuetype = "' + bugType + '"',
                 fields: ['key', 'status'],
                 maxResults: 50
@@ -67,7 +68,7 @@ function action(params) {
         var bugs = findLinkedBugs(tcKey);
         for (var i = 0; i < bugs.length; i++) {
             var status = bugs[i].fields && bugs[i].fields.status && bugs[i].fields.status.name;
-            if (status !== jiraConfig.jiraConfig.statuses.DONE) {
+            if (status !== trackerConfig.statuses.DONE) {
                 return bugs[i].key;
             }
         }
@@ -75,10 +76,10 @@ function action(params) {
     }
 
     function isInFlightStatus(status) {
-        return status === jiraConfig.statuses.IN_REVIEW_PASSED ||
-            status === jiraConfig.statuses.IN_REVIEW_FAILED ||
-            status === jiraConfig.statuses.IN_DEVELOPMENT ||
-            status === jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+        return status === trackerConfig.statuses.IN_REVIEW_PASSED ||
+            status === trackerConfig.statuses.IN_REVIEW_FAILED ||
+            status === trackerConfig.statuses.IN_DEVELOPMENT ||
+            status === trackerConfig.statuses.READY_FOR_DEVELOPMENT;
     }
 
     try {
@@ -103,7 +104,7 @@ function action(params) {
         allTCs.forEach(function(tc) {
             var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
-            if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
+            if (status === trackerConfig.statuses.PASSED || status === trackerConfig.statuses.SKIPPED || status === trackerConfig.statuses.IRRELEVANT) {
                 return;
             }
 
@@ -118,7 +119,7 @@ function action(params) {
                 return;
             }
 
-            if (status === jiraConfig.statuses.FAILED) {
+            if (status === trackerConfig.statuses.FAILED) {
                 waitingForBugsTCs.push(tc.key);
             } else {
                 readyForRetestTCs.push(tc.key);
@@ -129,12 +130,12 @@ function action(params) {
         if (inFlightTCs.length === 0 && pendingBugTCs.length === 0 && waitingForBugsTCs.length === 0 && readyForRetestTCs.length === 0) {
             console.log('All', totalTCs, 'Test Case(s) passed — moving', ticketKey, 'to Done');
 
-            jira_move_to_status({
+            tracker_move_to_status({
                 key: ticketKey,
-                statusName: jiraConfig.statuses.DONE
+                statusName: trackerConfig.statuses.DONE
             });
 
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. ✅ Story Complete — All Test Cases Passed\n\n' +
                     'All *' + totalTCs + '* linked Test Case(s) are in *Passed* status.\n\n' +
@@ -167,12 +168,12 @@ function action(params) {
 
             console.log('Found', pendingBugTCs.length, 'TC(s) with pending bugs — moving Story to Bug To Fix');
 
-            jira_move_to_status({
+            tracker_move_to_status({
                 key: ticketKey,
-                statusName: jiraConfig.statuses.BUG_TO_FIX
+                statusName: trackerConfig.statuses.BUG_TO_FIX
             });
 
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. 🐛 Story Moved to Bug To Fix\n\n' +
                     'The following linked Test Cases have open bugs:\n\n' + bugList + '\n\n' +
@@ -201,12 +202,12 @@ function action(params) {
         // Step 5: All remaining non-passed TCs are ready for re-test → back to Ready For Testing
         console.log('All non-passed TCs are ready for re-test — moving Story to Ready For Testing');
 
-        jira_move_to_status({
+        tracker_move_to_status({
             key: ticketKey,
-            statusName: jiraConfig.statuses.READY_FOR_TESTING
+            statusName: trackerConfig.statuses.READY_FOR_TESTING
         });
 
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: 'h3. 🔄 Story Ready for Re-test\n\n' +
                 'All linked bugs are resolved. The Story has been moved back to *Ready For Testing* to re-run the linked Test Cases.'

--- a/js/checkSubtasksDoneForBA.js
+++ b/js/checkSubtasksDoneForBA.js
@@ -15,6 +15,7 @@
 
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
@@ -22,13 +23,13 @@ function action(params) {
     const removeLabel = customParams && customParams.removeLabel;
 
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const questionsJql = projectConfig.jira.questions.fetchJql;
-    const baAnalysisStatus = projectConfig.jira.statuses.BA_ANALYSIS;
+    const questionsJql = projectConfig.tracker.questions.fetchJql;
+    const baAnalysisStatus = projectConfig.tracker.statuses.BA_ANALYSIS;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: removeLabel });
+                trackerHelper.removeLabel(ticketKey, removeLabel);
                 console.log('Released SM label — will re-check next cycle');
             } catch (e) {
                 console.warn('Failed to remove SM label:', e);
@@ -42,7 +43,7 @@ function action(params) {
 
         // Step 1: Fetch subtasks via JQL — jira_search_by_jql returns a plain array
         const allJql = questionsJql.replace('{ticketKey}', ticketKey);
-        const subtasks = jira_search_by_jql({
+        const subtasks = tracker_search({
             jql: allJql,
             maxResults: 100
         }) || [];
@@ -52,12 +53,12 @@ function action(params) {
         if (totalSubtasks === 0) {
             console.log('No subtasks found — no PO clarifications are required, moving', ticketKey, 'to', baAnalysisStatus);
 
-            jira_move_to_status({
+            tracker_move_to_status({
                 key: ticketKey,
                 statusName: baAnalysisStatus
             });
 
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. ✅ PO Review Complete — Moving to ' + baAnalysisStatus + '\n\n' +
                     'No clarification subtasks were created for this story, so there is nothing waiting for PO answers.\n\n' +
@@ -69,8 +70,8 @@ function action(params) {
         }
 
         // Step 2: Find subtasks NOT yet Done via JQL (more reliable than client-side field check)
-        const notDoneSubtasks = jira_search_by_jql({
-            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "' + projectConfig.jira.statuses.DONE + '"',
+        const notDoneSubtasks = tracker_search({
+            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "' + projectConfig.tracker.statuses.DONE + '"',
             maxResults: 1
         }) || [];
         const notDoneCount = notDoneSubtasks.length;
@@ -85,12 +86,12 @@ function action(params) {
         // All subtasks Done → move to BA Analysis
         console.log('All', totalSubtasks, 'subtask(s) done — moving', ticketKey, 'to', baAnalysisStatus);
 
-        jira_move_to_status({
+        tracker_move_to_status({
             key: ticketKey,
             statusName: baAnalysisStatus
         });
 
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: 'h3. ✅ PO Review Complete — Moving to ' + baAnalysisStatus + '\n\n' +
                 'All *' + totalSubtasks + '* subtask(s) are *Done*.\n\n' +

--- a/js/checkSubtasksDoneForBA.js
+++ b/js/checkSubtasksDoneForBA.js
@@ -24,7 +24,6 @@ function action(params) {
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
     const questionsJql = projectConfig.jira.questions.fetchJql;
     const baAnalysisStatus = projectConfig.jira.statuses.BA_ANALYSIS;
-    const subtaskIssueType = projectConfig.jira.issueTypes.SUBTASK;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -71,7 +70,7 @@ function action(params) {
 
         // Step 2: Find subtasks NOT yet Done via JQL (more reliable than client-side field check)
         const notDoneSubtasks = jira_search_by_jql({
-            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "Done"',
+            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "' + projectConfig.jira.statuses.DONE + '"',
             maxResults: 1
         }) || [];
         const notDoneCount = notDoneSubtasks.length;

--- a/js/checkTaskStoriesDone.js
+++ b/js/checkTaskStoriesDone.js
@@ -10,13 +10,15 @@
  *   this check on the next cycle.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -49,7 +51,7 @@ function action(params) {
 
         // Step 2: Find linked Stories/Bugs NOT yet Done
         const notDoneItems = jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype in (Story, Bug) AND status != "Done"',
+            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype in (Story, Bug) AND status != "' + jiraConfig.statuses.DONE + '"',
             maxResults: 1
         }) || [];
         const notDoneCount = notDoneItems.length;
@@ -66,7 +68,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
         jira_post_comment({

--- a/js/closeQuestionTicket.js
+++ b/js/closeQuestionTicket.js
@@ -4,12 +4,15 @@
  * after the Answer field has been written by the outputType:field handler.
  */
 
-const { LABELS, STATUSES } = require('./config.js');
+const { LABELS } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
     try {
         var ticketKey = params.ticket.key;
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : null;
@@ -31,7 +34,7 @@ function action(params) {
         }
 
         // Move to Done
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.DONE });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.DONE });
         console.log('Moved ' + ticketKey + ' to Done');
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider

--- a/js/common/jiraHelpers.js
+++ b/js/common/jiraHelpers.js
@@ -1,49 +1,41 @@
 /**
- * Common Jira Helper Functions
- * Shared utilities for Jira ticket operations
+ * Common Tracker Helper Functions
+ * Shared utilities for ticket operations (Jira, ADO, Rally).
  */
 
 const { STATUSES, LABELS } = require('../config.js');
+const trackerHelper = require('./tracker.js');
 
 /**
- * Assign ticket to initiator and move to "In Review" status with AI-generated label
- * This is the common post-processing logic used by multiple agents
- * 
- * @param {string} ticketKey - The Jira ticket key
+ * Assign ticket to initiator and move to "In Review" status with AI-generated label.
+ *
+ * @param {string} ticketKey   - The ticket key
  * @param {string} initiatorId - Account ID of the person to assign the ticket to
- * @param {string} wipLabel - Optional WIP label to remove after processing
+ * @param {string} wipLabel    - Optional WIP label to remove after processing
+ * @param {string} targetStatus
+ * @param {Object} [config]    - Optional project config (for tracker type detection)
  * @returns {Object} Result object with success status and message
  */
-function assignForReview(ticketKey, initiatorId, wipLabel, targetStatus) {
+function assignForReview(ticketKey, initiatorId, wipLabel, targetStatus, config) {
     const statusName = targetStatus || STATUSES.IN_REVIEW;
     try {
         console.log("Processing ticket:", ticketKey);
 
-        // Assign to initiator
-        jira_assign_ticket_to({
+        tracker_assign_ticket({
             key: ticketKey,
             accountId: initiatorId
         });
 
-        // Move to target status
-        jira_move_to_status({
+        tracker_move_to_status({
             key: ticketKey,
             statusName: statusName
         });
 
-        // Add AI-generated label
-        jira_add_label({
-            key: ticketKey,
-            label: LABELS.AI_GENERATED
-        });
+        trackerHelper.addLabel(ticketKey, LABELS.AI_GENERATED, config);
 
-        // Remove WIP label if provided
         if (wipLabel) {
             try {
-                jira_remove_label({
-                    key: ticketKey,
-                    label: wipLabel
-                });
+                trackerHelper.removeLabel(ticketKey, wipLabel, config);
                 console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
             } catch (labelError) {
                 console.warn('Failed to remove WIP label "' + wipLabel + '":', labelError);
@@ -67,9 +59,9 @@ function assignForReview(ticketKey, initiatorId, wipLabel, targetStatus) {
 }
 
 /**
- * Extract ticket key from Jira API response
- * 
- * @param {string|Object} result - Jira API response
+ * Extract ticket key from tracker API response.
+ *
+ * @param {string|Object} result - API response
  * @returns {string|null} Extracted ticket key or null if not found
  */
 function extractTicketKey(result) {
@@ -91,22 +83,20 @@ function extractTicketKey(result) {
 }
 
 /**
- * Set priority on a Jira ticket using the appropriate API
- * 
- * @param {string} ticketKey - The Jira ticket key
- * @param {string} priority - Priority name (e.g., 'Low', 'Medium', 'High')
+ * Set priority on a ticket.
+ *
+ * @param {string} ticketKey - The ticket key
+ * @param {string} priority  - Priority name (e.g., 'Low', 'Medium', 'High')
+ * @param {Object} [config]  - Optional project config (for tracker type detection)
  * @returns {boolean} True if successful, false otherwise
  */
-function setTicketPriority(ticketKey, priority) {
+function setTicketPriority(ticketKey, priority, config) {
     if (!ticketKey || !priority) {
         return false;
     }
-    
+
     try {
-        jira_set_priority({
-            key: ticketKey,
-            priority: priority
-        });
+        trackerHelper.setPriority(ticketKey, priority, config);
         console.log('Set priority ' + priority + ' on ticket ' + ticketKey);
         return true;
     } catch (priorityError) {
@@ -115,10 +105,8 @@ function setTicketPriority(ticketKey, priority) {
     }
 }
 
-// Export functions for use by other modules
 module.exports = {
     assignForReview,
     extractTicketKey,
     setTicketPriority
 };
-

--- a/js/common/tracker.js
+++ b/js/common/tracker.js
@@ -1,0 +1,182 @@
+/**
+ * Task Tracker abstraction for operations that have no server-side tracker_* alias.
+ *
+ * Operations with server-side aliases (tracker_move_to_status, tracker_post_comment,
+ * tracker_get_ticket, tracker_search, tracker_assign_ticket, tracker_get_comments,
+ * tracker_create_ticket, tracker_link_tickets, tracker_get_my_profile) should be
+ * called directly — the server routes them to the active tracker backend.
+ *
+ * This module covers: addLabel, removeLabel, setPriority, updateField, attachFile.
+ *
+ * Supported trackers: 'jira', 'jira_xray', 'ado'
+ * NOT YET supported: 'rally' — Rally has no tracker_* server aliases and no rally_*
+ *   MCP tools documented for label/priority/field operations. Calls log a warning and
+ *   no-op rather than crash.
+ *
+ * Tracker selection: reads DEFAULT_TRACKER env var (set by dmtools runtime),
+ * falls back to config.defaultTracker, then defaults to 'jira'.
+ */
+
+function _getTrackerType(config) {
+    var trackerType = null;
+    try {
+        trackerType = java.lang.System.getenv('DEFAULT_TRACKER');
+    } catch (e) {
+        // Not running in GraalJS — ignore
+    }
+    if (!trackerType && config && config.defaultTracker) {
+        trackerType = config.defaultTracker;
+    }
+    return (trackerType || 'jira').toLowerCase();
+}
+
+function _warnUnsupported(tracker, operation, key) {
+    console.warn('tracker: "' + operation + '" is not implemented for tracker "' + tracker +
+        '" (key=' + key + '). Skipping.');
+}
+
+// ── ADO helpers ───────────────────────────────────────────────────────────────
+
+function _adoGetTags(key) {
+    try {
+        var raw = ado_get_work_item({ id: parseInt(key, 10) });
+        var wi = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        var tagStr = wi && wi.fields && wi.fields['System.Tags'];
+        return tagStr ? tagStr.split(';').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+    } catch (e) {
+        console.warn('tracker: Failed to read ADO work item tags for ' + key + ':', e);
+        return [];
+    }
+}
+
+function _adoSetTags(key, tags) {
+    ado_update_work_item({
+        id: parseInt(key, 10),
+        data: JSON.stringify({ 'System.Tags': tags.join('; ') })
+    });
+}
+
+// ── Exported API ─────────────────────────────────────────────────────────────
+
+/**
+ * Add a label/tag to a ticket.
+ * @param {string} key      - Ticket key (Jira) or work item ID (ADO)
+ * @param {string} label    - Label or tag name
+ * @param {Object} [config] - Optional project config (for defaultTracker fallback)
+ */
+function addLabel(key, label, config) {
+    var tt = _getTrackerType(config);
+    if (tt === 'jira' || tt === 'jira_xray') {
+        jira_add_label({ key: key, label: label });
+    } else if (tt === 'ado') {
+        var tags = _adoGetTags(key);
+        if (tags.indexOf(label) === -1) {
+            tags.push(label);
+            _adoSetTags(key, tags);
+        }
+    } else {
+        _warnUnsupported(tt, 'addLabel', key);
+    }
+}
+
+/**
+ * Remove a label/tag from a ticket.
+ * @param {string} key      - Ticket key (Jira) or work item ID (ADO)
+ * @param {string} label    - Label or tag name
+ * @param {Object} [config] - Optional project config (for defaultTracker fallback)
+ */
+function removeLabel(key, label, config) {
+    var tt = _getTrackerType(config);
+    if (tt === 'jira' || tt === 'jira_xray') {
+        jira_remove_label({ key: key, label: label });
+    } else if (tt === 'ado') {
+        var tags = _adoGetTags(key);
+        var filtered = tags.filter(function(t) { return t !== label; });
+        if (filtered.length !== tags.length) {
+            _adoSetTags(key, filtered);
+        }
+    } else {
+        _warnUnsupported(tt, 'removeLabel', key);
+    }
+}
+
+/**
+ * Set priority on a ticket.
+ * @param {string} key      - Ticket key or work item ID
+ * @param {string} priority - Priority name (e.g. 'High', 'Medium', 'Low')
+ * @param {Object} [config] - Optional project config
+ */
+function setPriority(key, priority, config) {
+    var tt = _getTrackerType(config);
+    if (tt === 'jira' || tt === 'jira_xray') {
+        jira_set_priority({ key: key, priority: priority });
+    } else if (tt === 'ado') {
+        var priorityMap = { Highest: 1, High: 2, Medium: 3, Low: 4, Lowest: 4 };
+        var adoPriority = priorityMap[priority] !== undefined ? priorityMap[priority] : 3;
+        ado_update_work_item({
+            id: parseInt(key, 10),
+            data: JSON.stringify({ 'Microsoft.VSTS.Common.Priority': adoPriority })
+        });
+    } else {
+        _warnUnsupported(tt, 'setPriority', key);
+    }
+}
+
+/**
+ * Update a named field on a ticket.
+ * @param {string} key      - Ticket key or work item ID
+ * @param {string} field    - Field name (Jira field name; ADO uses System.* naming)
+ * @param {*}      value    - New value
+ * @param {Object} [config] - Optional project config
+ */
+function updateField(key, field, value, config) {
+    var tt = _getTrackerType(config);
+    if (tt === 'jira' || tt === 'jira_xray') {
+        jira_update_field({ key: key, field: field, value: value });
+    } else if (tt === 'ado') {
+        var adoFieldMap = {
+            summary: 'System.Title',
+            description: 'System.Description',
+            priority: 'Microsoft.VSTS.Common.Priority',
+            storyPoints: 'Microsoft.VSTS.Scheduling.StoryPoints'
+        };
+        var adoField = adoFieldMap[field] || field;
+        var data = {};
+        data[adoField] = value;
+        ado_update_work_item({ id: parseInt(key, 10), data: JSON.stringify(data) });
+    } else {
+        _warnUnsupported(tt, 'updateField', key);
+    }
+}
+
+/**
+ * Attach a file to a ticket.
+ * @param {string} key         - Ticket key or work item ID
+ * @param {string} name        - Attachment file name
+ * @param {string} filePath    - Local file path
+ * @param {string} contentType - MIME type
+ * @param {Object} [config]    - Optional project config
+ */
+function attachFile(key, name, filePath, contentType, config) {
+    var tt = _getTrackerType(config);
+    if (tt === 'jira' || tt === 'jira_xray') {
+        jira_attach_file_to_ticket({
+            ticketKey: key,
+            name: name,
+            filePath: filePath,
+            contentType: contentType || 'application/octet-stream'
+        });
+    } else if (tt === 'ado') {
+        ado_add_attachment({ id: parseInt(key, 10), filePath: filePath, fileName: name });
+    } else {
+        _warnUnsupported(tt, 'attachFile', key);
+    }
+}
+
+module.exports = {
+    addLabel: addLabel,
+    removeLabel: removeLabel,
+    setPriority: setPriority,
+    updateField: updateField,
+    attachFile: attachFile
+};

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -33,6 +33,27 @@ var DEFAULTS = {
         repo: ''
     },
 
+    // Canonical tracker config — use config.tracker in new code.
+    // config.jira is kept as a backward-compat alias (see loadProjectConfig bridge below).
+    tracker: {
+        project: '',
+        parentTicket: '',
+        statuses: DEFAULT_CONFIG.STATUSES,
+        issueTypes: DEFAULT_CONFIG.ISSUE_TYPES,
+        questions: {
+            // JQL/WIQL to fetch question subtasks. {ticketKey} is replaced at runtime.
+            fetchJql: 'parent = {ticketKey} AND issuetype = Subtask ORDER BY created ASC',
+            answerField: 'Answer'
+        },
+        parentContextFetch: {
+            enabled: false
+        },
+        // Field names — override per project in .dmtools/config.js under tracker.fields
+        fields: {
+            acceptanceCriteria: 'Acceptance Criteria'
+        }
+    },
+
     jira: {
         project: '',
         parentTicket: '',
@@ -183,6 +204,17 @@ function mergeProjectConfig(defaults, overrides) {
             result.jira.questions = overrides.jira.questions;
         }
     }
+    if (overrides.tracker) {
+        if (overrides.tracker.statuses) {
+            result.tracker.statuses = overrides.tracker.statuses;
+        }
+        if (overrides.tracker.issueTypes) {
+            result.tracker.issueTypes = overrides.tracker.issueTypes;
+        }
+        if (overrides.tracker.questions) {
+            result.tracker.questions = overrides.tracker.questions;
+        }
+    }
     if (overrides.labels) {
         result.labels = overrides.labels;
     }
@@ -329,6 +361,16 @@ function loadProjectConfig(params) {
 
     // Store resolved config path so callers can propagate it downstream
     if (resolvedPath) config._configPath = resolvedPath;
+
+    // Backward-compat bridge:
+    //   Project configs that only define  jira: {}  get config.tracker pointing at it.
+    //   Project configs that only define  tracker: {}  get config.jira pointing at it.
+    //   This keeps existing .dmtools/config.js files working while new code reads config.tracker.
+    if (!loaded || (!loaded.tracker && loaded.jira)) {
+        config.tracker = config.jira;
+    } else if (!loaded || (!loaded.jira && loaded.tracker)) {
+        config.jira = config.tracker;
+    }
 
     // Apply targetRepository override from customParams
     if (customParams.targetRepository) {

--- a/js/createBugFixBatchEpic.js
+++ b/js/createBugFixBatchEpic.js
@@ -22,18 +22,21 @@
  * individual bug_development rule, so the batch agent owns them.
  */
 
-const { STATUSES, ISSUE_TYPES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const { extractTicketKey } = require('./common/jiraHelpers.js');
+const configLoader = require('./configLoader.js');
 
 var BUG_FIX_BATCH_LABEL = LABELS.BUG_FIX_BATCH || 'bug_fix_batch';
-var BATCH_STATUS = STATUSES.READY_FOR_DEVELOPMENT || 'Ready For Development';
-var DONE_STATUS = STATUSES.DONE || 'Done';
 
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var customParams = (params.jobParams && params.jobParams.customParams) || {};
     var removeLabel = customParams.removeLabel;
     var batchSize = customParams.batchSize || 5;
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
+    var BATCH_STATUS = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+    var DONE_STATUS = jiraConfig.statuses.DONE;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -84,7 +87,7 @@ function action(params) {
         // Only group bugs that have not been individually picked up yet.
         // In Development / In Progress bugs are left for the single-bug pipeline.
         var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = Bug ' +
-            'AND status in ("' + (STATUSES.BACKLOG || 'Backlog') + '", "' + (STATUSES.TODO || 'To Do') + '", "' + (STATUSES.READY_FOR_DEVELOPMENT || 'Ready For Development') + '") ' +
+            'AND status in ("' + jiraConfig.statuses.BACKLOG + '", "' + jiraConfig.statuses.TODO + '", "' + jiraConfig.statuses.READY_FOR_DEVELOPMENT + '") ' +
             'AND (labels is EMPTY OR labels NOT IN ("' + BUG_FIX_BATCH_LABEL + '")) ' +
             'ORDER BY created ASC';
         return searchIssues(jql, ['key', 'status', 'summary', 'labels']);
@@ -101,7 +104,7 @@ function action(params) {
 
     function bugStillRelevant(bugKey) {
         var jql = 'issue in linkedIssues("' + bugKey + '") AND issuetype = "Test Case" ' +
-            'AND status in ("' + (STATUSES.FAILED || 'Failed') + '", "' + (STATUSES.BUG_TO_FIX || 'Bug To Fix') + '")';
+            'AND status in ("' + jiraConfig.statuses.FAILED + '", "' + jiraConfig.statuses.BUG_TO_FIX + '")';
         var tcs = searchIssues(jql, ['key', 'status'], 1);
         return tcs.length > 0;
     }
@@ -118,7 +121,7 @@ function action(params) {
         var fieldsJson = {
             summary: summary,
             description: description,
-            issuetype: { name: ISSUE_TYPES.EPIC || 'Epic' },
+            issuetype: { name: jiraConfig.issueTypes.EPIC || 'Epic' },
             labels: [BUG_FIX_BATCH_LABEL]
         };
 

--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -19,7 +19,7 @@
  */
 
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS, resolveStatuses } = require('./config.js');
+const { LABELS, resolveStatuses } = require('./config.js');
 const developTicket = require('./developTicketAndCreatePR.js');
 const outputFiles = require('./common/outputFiles.js');
 
@@ -73,6 +73,7 @@ function action(params) {
         const actualParams = params.ticket ? params : (params.jobParams || params);
         const ticketKey = actualParams.ticket.key;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var scm = configLoader.createScm(config);
         const _customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         const statuses = resolveStatuses(_customParams);
@@ -150,7 +151,7 @@ function action(params) {
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
                 console.log('✅ Moved', ticketKey, 'to Blocked');
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
@@ -185,7 +186,7 @@ function action(params) {
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.DONE });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.DONE });
                 console.log('✅ Moved', ticketKey, 'to Done');
             } catch (e) {
                 console.warn('Failed to move to Done:', e);

--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -22,6 +22,7 @@ var configLoader = require('./configLoader.js');
 const { LABELS, resolveStatuses } = require('./config.js');
 const developTicket = require('./developTicketAndCreatePR.js');
 const outputFiles = require('./common/outputFiles.js');
+var trackerHelper = require('./common/tracker.js');
 
 function cleanCliOutput(output) {
     return (output || '').split('\n').filter(function(l) {
@@ -55,14 +56,14 @@ function removeLabels(ticketKey, params) {
     const wipLabel = params.metadata && params.metadata.contextId
         ? params.metadata.contextId + '_wip' : null;
     if (wipLabel) {
-        try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
+        try { trackerHelper.removeLabel(ticketKey, wipLabel); } catch (e) {}
     }
 
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
     if (removeLabel) {
         try {
-            jira_remove_label({ key: ticketKey, label: removeLabel });
+            trackerHelper.removeLabel(ticketKey, removeLabel);
             console.log('✅ Removed SM label:', removeLabel);
         } catch (e) {}
     }
@@ -73,7 +74,7 @@ function action(params) {
         const actualParams = params.ticket ? params : (params.jobParams || params);
         const ticketKey = actualParams.ticket.key;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = config.jira;
+        var trackerConfig = config.tracker;
         var scm = configLoader.createScm(config);
         const _customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         const statuses = resolveStatuses(_customParams);
@@ -93,7 +94,7 @@ function action(params) {
                     var existingUrl = existingPr.html_url || existingPr.url || ('#' + existingPr.number);
                     console.log('⚠️  PR already open for', ticketKey, ':', existingUrl, '— skipping re-development');
                     try {
-                        jira_post_comment({
+                        tracker_post_comment({
                             key: ticketKey,
                             comment: 'h3. ℹ️ PR Already Open\n\n' +
                                 'A pull/merge request already exists for this ticket: ' + existingUrl + '\n\n' +
@@ -101,7 +102,7 @@ function action(params) {
                         });
                     } catch (e) {}
                     try {
-                        jira_move_to_status({ key: ticketKey, statusName: statuses.IN_REVIEW });
+                        tracker_move_to_status({ key: ticketKey, statusName: statuses.IN_REVIEW });
                         console.log('✅ Moved', ticketKey, 'to In Review');
                     } catch (e) { console.warn('Failed to move to In Review:', e); }
                     removeLabels(ticketKey, params);
@@ -119,7 +120,7 @@ function action(params) {
             if (!hasCodeGraphUsage()) {
                 console.warn('outputs/blocked.json rejected — no CodeGraph usage was recorded');
                 try {
-                    jira_post_comment({
+                    tracker_post_comment({
                         key: ticketKey,
                         comment: 'h3. ⚠️ Blocked Claim Needs CodeGraph Verification\n\n' +
                             'The agent wrote `outputs/blocked.json`, but no CodeGraph usage was recorded. ' +
@@ -128,7 +129,7 @@ function action(params) {
                     });
                 } catch (e) {}
                 try {
-                    jira_move_to_status({ key: ticketKey, statusName: statuses.READY_FOR_DEVELOPMENT });
+                    tracker_move_to_status({ key: ticketKey, statusName: statuses.READY_FOR_DEVELOPMENT });
                     console.log('✅ Moved', ticketKey, 'to Ready For Development for CodeGraph retry');
                 } catch (e) {
                     console.warn('Failed to move ticket to Ready For Development:', e);
@@ -148,10 +149,10 @@ function action(params) {
                 comment += '*Needs from human*: ' + blocked.needs + '\n';
             }
 
-            try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BLOCKED });
                 console.log('✅ Moved', ticketKey, 'to Blocked');
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
@@ -183,16 +184,16 @@ function action(params) {
                 comment += 'No new PR required — fix is already in the codebase. Moved to *Done*.';
             }
 
-            try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.DONE });
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.DONE });
                 console.log('✅ Moved', ticketKey, 'to Done');
             } catch (e) {
                 console.warn('Failed to move to Done:', e);
             }
 
-            try { jira_add_label({ key: ticketKey, label: LABELS.AI_DEVELOPED }); } catch (e) {}
+            try { trackerHelper.addLabel(ticketKey, LABELS.AI_DEVELOPED); } catch (e) {}
 
             removeLabels(ticketKey, params);
             return { success: true, path: 'already_fixed', ticketKey };
@@ -274,7 +275,7 @@ function action(params) {
 
             // Post informational comment
             try {
-                jira_post_comment({
+                tracker_post_comment({
                     key: ticketKeyForCheck,
                     comment: 'h3. ⏸️ Development Interrupted\n\nThe AI agent was interrupted (likely hit a rate limit) before completing the implementation. The ticket has been reset to *Ready For Development* and will be automatically retried.\n\n' +
                         (hasGitChanges ? 'Partial analysis work was saved to the branch.' : 'No partial work was produced.')
@@ -283,7 +284,7 @@ function action(params) {
 
             // Move ticket back to Ready For Development for retry
             try {
-                jira_move_to_status({ key: ticketKeyForCheck, statusName: statuses.READY_FOR_DEVELOPMENT });
+                tracker_move_to_status({ key: ticketKeyForCheck, statusName: statuses.READY_FOR_DEVELOPMENT });
                 console.log('✅ Moved', ticketKeyForCheck, 'to Ready For Development for retry');
             } catch (e) {
                 console.warn('Failed to move ticket to Ready For Development:', e);
@@ -306,7 +307,7 @@ function action(params) {
         try {
             const key = (params.ticket || (params.jobParams && params.jobParams.ticket) || {}).key;
             if (key) {
-                jira_post_comment({
+                tracker_post_comment({
                     key: key,
                     comment: 'h3. ❌ Bug Development Error\n\n{code}' + error.toString() + '{code}'
                 });

--- a/js/finishTestCasesGeneration.js
+++ b/js/finishTestCasesGeneration.js
@@ -7,7 +7,7 @@
  *    story_test_automation.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -15,12 +15,14 @@ function action(params) {
     if (!ticketKey) {
         return { success: false, error: 'No ticket key found in params' };
     }
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     console.log('=== Finishing test case generation for', ticketKey, '===');
 
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.READY_FOR_TESTING });
-        console.log('✅ Moved', ticketKey, 'to', STATUSES.READY_FOR_TESTING);
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.READY_FOR_TESTING });
+        console.log('✅ Moved', ticketKey, 'to', jiraConfig.statuses.READY_FOR_TESTING);
     } catch (e) {
         console.warn('Could not move Story to Ready For Testing:', e);
     }

--- a/js/mergeStoryTestAutomationPR.js
+++ b/js/mergeStoryTestAutomationPR.js
@@ -4,7 +4,7 @@
  * from In Review - Passed/Failed to Passed/Failed.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
@@ -78,19 +78,19 @@ function fetchLinkedTestCases(storyKey, testCaseType) {
     }
 }
 
-function resolveFinalStatus(currentStatus) {
-    if (currentStatus === STATUSES.IN_REVIEW_PASSED) return STATUSES.PASSED;
-    if (currentStatus === STATUSES.IN_REVIEW_FAILED) return STATUSES.FAILED;
+function resolveFinalStatus(currentStatus, jiraConfig) {
+    if (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) return jiraConfig.statuses.PASSED;
+    if (currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED) return jiraConfig.statuses.FAILED;
     return null;
 }
 
-function moveLinkedTestCases(storyKey, testCaseType) {
+function moveLinkedTestCases(storyKey, testCaseType, jiraConfig) {
     var testCases = fetchLinkedTestCases(storyKey, testCaseType);
     var moved = 0;
     var skipped = 0;
     testCases.forEach(function(tc) {
         var currentStatus = tc.fields && tc.fields.status ? tc.fields.status.name : '';
-        var finalStatus = resolveFinalStatus(currentStatus);
+        var finalStatus = resolveFinalStatus(currentStatus, jiraConfig);
         if (!finalStatus) {
             console.log('Skipping linked TC', tc.key, '— current status', currentStatus);
             skipped++;
@@ -108,7 +108,7 @@ function moveLinkedTestCases(storyKey, testCaseType) {
     return { moved: moved, skipped: skipped, total: testCases.length };
 }
 
-function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams) {
+function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams, jiraConfig) {
     const prNumber = pr.number;
     const prUrl = pr.html_url;
     console.log('PR #' + prNumber + ' already merged for story ' + storyKey + ' — finalizing');
@@ -116,7 +116,7 @@ function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, custom
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
-    var tcResult = moveLinkedTestCases(storyKey, testCaseType);
+    var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
 
     // Bug stays In Testing; bug_done_check will move it to Done only when all
     // directly linked Test Cases are Passed. Moving it here allowed bugs to be
@@ -177,12 +177,10 @@ function attemptMerge(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
-    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    var testCaseType = projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE
-        ? projectConfig.jira.issueTypes.TEST_CASE
-        : 'Test Case';
+    var testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
@@ -199,7 +197,7 @@ function attemptMerge(params) {
     }
 
     if (found.merged) {
-        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams);
+        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams, jiraConfig);
         return {
             success: true,
             alreadyMerged: true,
@@ -276,7 +274,7 @@ function attemptMerge(params) {
 
         try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
 
-        var tcResult = moveLinkedTestCases(storyKey, testCaseType);
+        var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
 
         try {
             jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
@@ -354,6 +352,7 @@ function action(params) {
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
 
     const mergeResult = attemptMerge(params);
@@ -384,7 +383,7 @@ function action(params) {
     }
     try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
     try { jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED }); } catch (e) {}
-    var reworkSkipLabel = issueType === 'Bug' ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
+    var reworkSkipLabel = issueType === jiraConfig.issueTypes.BUG ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
     try { jira_remove_label({ key: storyKey, label: reworkSkipLabel }); } catch (e) {}
 
     releaseLock(storyKey, customParams);
@@ -400,7 +399,7 @@ function action(params) {
         key: storyKey,
         comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *' + panelTitle + '* — Could not merge PR #' + (prNumber || 'unknown') + ': ' + reasonText + '.\n\n' + (prUrl ? '[View PR|' + prUrl + ']' : '') + '{panel}'
     });
-    jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+    jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_REWORK });
     return true;
 }
 

--- a/js/mergeStoryTestAutomationPR.js
+++ b/js/mergeStoryTestAutomationPR.js
@@ -8,6 +8,7 @@ const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function findPRForStory(scm, storyKey) {
     try {
@@ -34,7 +35,7 @@ function findPRForStory(scm, storyKey) {
 function releaseLock(storyKey, customParams) {
     const removeLabel = customParams && customParams.removeLabel;
     if (removeLabel && storyKey) {
-        try { jira_remove_label({ key: storyKey, label: removeLabel }); } catch (e) {}
+        try { trackerHelper.removeLabel(storyKey, removeLabel); } catch (e) {}
     }
 }
 
@@ -71,33 +72,33 @@ function checkCiStatus(scm, headSha) {
 function fetchLinkedTestCases(storyKey, testCaseType) {
     var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = "' + testCaseType + '"';
     try {
-        return jira_search_by_jql({ jql: jql, maxResults: 100, fields: ['key', 'status'] }) || [];
+        return tracker_search({ jql: jql, maxResults: 100, fields: ['key', 'status'] }) || [];
     } catch (e) {
         console.warn('Failed to fetch linked Test Cases for merge:', e);
         return [];
     }
 }
 
-function resolveFinalStatus(currentStatus, jiraConfig) {
-    if (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) return jiraConfig.statuses.PASSED;
-    if (currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED) return jiraConfig.statuses.FAILED;
+function resolveFinalStatus(currentStatus, trackerConfig) {
+    if (currentStatus === trackerConfig.statuses.IN_REVIEW_PASSED) return trackerConfig.statuses.PASSED;
+    if (currentStatus === trackerConfig.statuses.IN_REVIEW_FAILED) return trackerConfig.statuses.FAILED;
     return null;
 }
 
-function moveLinkedTestCases(storyKey, testCaseType, jiraConfig) {
+function moveLinkedTestCases(storyKey, testCaseType, trackerConfig) {
     var testCases = fetchLinkedTestCases(storyKey, testCaseType);
     var moved = 0;
     var skipped = 0;
     testCases.forEach(function(tc) {
         var currentStatus = tc.fields && tc.fields.status ? tc.fields.status.name : '';
-        var finalStatus = resolveFinalStatus(currentStatus, jiraConfig);
+        var finalStatus = resolveFinalStatus(currentStatus, trackerConfig);
         if (!finalStatus) {
             console.log('Skipping linked TC', tc.key, '— current status', currentStatus);
             skipped++;
             return;
         }
         try {
-            jira_move_to_status({ key: tc.key, statusName: finalStatus });
+            tracker_move_to_status({ key: tc.key, statusName: finalStatus });
             console.log('✅ Moved', tc.key, 'to', finalStatus);
             moved++;
         } catch (e) {
@@ -108,7 +109,7 @@ function moveLinkedTestCases(storyKey, testCaseType, jiraConfig) {
     return { moved: moved, skipped: skipped, total: testCases.length };
 }
 
-function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams, jiraConfig) {
+function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams, trackerConfig) {
     const prNumber = pr.number;
     const prUrl = pr.html_url;
     console.log('PR #' + prNumber + ' already merged for story ' + storyKey + ' — finalizing');
@@ -116,31 +117,31 @@ function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, custom
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
-    var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
+    var tcResult = moveLinkedTestCases(storyKey, testCaseType, trackerConfig);
 
     // Bug stays In Testing; bug_done_check will move it to Done only when all
     // directly linked Test Cases are Passed. Moving it here allowed bugs to be
     // closed while their acceptance tests were still failing.
 
     try {
-        jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
+        trackerHelper.removeLabel(storyKey, LABELS.PR_APPROVED);
     } catch (e) {
         console.warn('Could not remove pr_approved label:', e);
     }
     try {
-        jira_remove_label({ key: storyKey, label: LABELS.TEST_PR_MERGED });
+        trackerHelper.removeLabel(storyKey, LABELS.TEST_PR_MERGED);
     } catch (e) {
         console.warn('Could not remove test_pr_merged label:', e);
     }
     try {
-        jira_add_label({ key: storyKey, label: LABELS.TEST_PR_FINALIZED });
+        trackerHelper.addLabel(storyKey, LABELS.TEST_PR_FINALIZED);
         console.log('Added test_pr_finalized label to', storyKey);
     } catch (e) {
         console.warn('Could not add test_pr_finalized label:', e);
     }
 
     var ticketLabel = issueType || 'Story';
-    jira_post_comment({
+    tracker_post_comment({
         key: storyKey,
         comment: 'h3. ✅ ' + ticketLabel + ' Test PR Already Merged\n\n' +
             'PR [#' + prNumber + '|' + prUrl + '] for branch {code}test/' + storyKey + '{code} was already merged.\n\n' +
@@ -177,10 +178,10 @@ function attemptMerge(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
     var scm = scmModule.createScm(config);
     var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
-    var testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
+    var testCaseType = trackerConfig.issueTypes.TEST_CASE || 'Test Case';
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
@@ -197,7 +198,7 @@ function attemptMerge(params) {
     }
 
     if (found.merged) {
-        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams, jiraConfig);
+        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams, trackerConfig);
         return {
             success: true,
             alreadyMerged: true,
@@ -274,28 +275,28 @@ function attemptMerge(params) {
 
         try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
 
-        var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
+        var tcResult = moveLinkedTestCases(storyKey, testCaseType, trackerConfig);
 
         try {
-            jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
+            trackerHelper.removeLabel(storyKey, LABELS.PR_APPROVED);
             console.log('Removed pr_approved label from Jira ticket');
         } catch (e) {
             console.warn('Could not remove pr_approved from Jira ticket:', e);
         }
         try {
-            jira_remove_label({ key: storyKey, label: LABELS.TEST_PR_MERGED });
+            trackerHelper.removeLabel(storyKey, LABELS.TEST_PR_MERGED);
         } catch (e) {
             console.warn('Could not remove test_pr_merged label:', e);
         }
         try {
-            jira_add_label({ key: storyKey, label: LABELS.TEST_PR_FINALIZED });
+            trackerHelper.addLabel(storyKey, LABELS.TEST_PR_FINALIZED);
             console.log('Added test_pr_finalized label to', storyKey);
         } catch (e) {
             console.warn('Could not add test_pr_finalized label:', e);
         }
 
         var ticketLabel = issueType || 'Story';
-        jira_post_comment({
+        tracker_post_comment({
             key: storyKey,
             comment: 'h3. ✅ ' + ticketLabel + ' Test PR Merged\n\n' +
                 'PR [#' + prNumber + '|' + prUrl + '] for branch {code}test/' + storyKey + '{code} was merged.\n\n' +
@@ -352,7 +353,7 @@ function action(params) {
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
     var scm = scmModule.createScm(config);
 
     const mergeResult = attemptMerge(params);
@@ -381,10 +382,10 @@ function action(params) {
     if (prNumber) {
         try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
     }
-    try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
-    try { jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED }); } catch (e) {}
-    var reworkSkipLabel = issueType === jiraConfig.issueTypes.BUG ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
-    try { jira_remove_label({ key: storyKey, label: reworkSkipLabel }); } catch (e) {}
+    try { trackerHelper.removeLabel(storyKey, LABELS.PR_APPROVED); } catch (e) {}
+    try { trackerHelper.addLabel(storyKey, LABELS.TEST_PR_REWORK_NEEDED); } catch (e) {}
+    var reworkSkipLabel = issueType === trackerConfig.issueTypes.BUG ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
+    try { trackerHelper.removeLabel(storyKey, reworkSkipLabel); } catch (e) {}
 
     releaseLock(storyKey, customParams);
 
@@ -395,11 +396,11 @@ function action(params) {
     if (mergeResult.reason === 'ci_failed' && mergeResult.failedNames) {
         reasonText = 'required checks failed: ' + checksList;
     }
-    jira_post_comment({
+    tracker_post_comment({
         key: storyKey,
         comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *' + panelTitle + '* — Could not merge PR #' + (prNumber || 'unknown') + ': ' + reasonText + '.\n\n' + (prUrl ? '[View PR|' + prUrl + ']' : '') + '{panel}'
     });
-    jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_REWORK });
+    tracker_move_to_status({ key: storyKey, statusName: trackerConfig.statuses.IN_REWORK });
     return true;
 }
 

--- a/js/moveToDone.js
+++ b/js/moveToDone.js
@@ -4,7 +4,7 @@
  * If tests fail later, AI creates a new bug instead of re-opening this one.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -13,12 +13,14 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.DONE + ' (bug with test cases generated)');
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.DONE + ' (bug with test cases generated)');
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.DONE
+            statusName: jiraConfig.statuses.DONE
         });
 
         try {
@@ -32,7 +34,7 @@ function action(params) {
             comment: 'Test cases generated. Bug marked as Done. If regression is detected, a new bug will be created automatically.'
         });
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.DONE);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.DONE);
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider
         // wrote outputs/*_usage.json during the agent run.
@@ -44,7 +46,7 @@ function action(params) {
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.DONE
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.DONE
         };
 
     } catch (error) {

--- a/js/moveToInTesting.js
+++ b/js/moveToInTesting.js
@@ -3,7 +3,7 @@
  * Moves the ticket to "In Testing" status after test cases are generated.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -12,12 +12,14 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.IN_TESTING);
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.IN_TESTING);
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.IN_TESTING
+            statusName: jiraConfig.statuses.IN_TESTING
         });
 
         try {
@@ -26,7 +28,7 @@ function action(params) {
             console.log('Label sm_test_cases_triggered not found or already removed');
         }
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.IN_TESTING);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.IN_TESTING);
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider
         // wrote outputs/*_usage.json during the agent run.
@@ -38,7 +40,7 @@ function action(params) {
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.IN_TESTING
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.IN_TESTING
         };
 
     } catch (error) {

--- a/js/moveToReadyForTesting.js
+++ b/js/moveToReadyForTesting.js
@@ -3,7 +3,7 @@
  * Moves the ticket to "Ready For Testing" status after test cases are generated.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 
 function action(params) {
     try {
@@ -11,19 +11,21 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.READY_FOR_TESTING);
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.READY_FOR_TESTING);
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.READY_FOR_TESTING);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.READY_FOR_TESTING);
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.READY_FOR_TESTING
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.READY_FOR_TESTING
         };
 
     } catch (error) {

--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -12,7 +12,8 @@
  * Link direction: Bug "blocks" TC (TC is blocked by the Bug until it's fixed).
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function readFile(path) {
@@ -61,9 +62,9 @@ function linkBugToTC(ticketKey, bugKey) {
     console.log('✅ Linked:', bugKey, 'blocks', ticketKey);
 }
 
-function moveFailedTcToRework(ticketKey) {
-    jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
-    console.log('🔧 Moved', ticketKey, 'to', STATUSES.IN_REWORK || 'In Rework');
+function moveFailedTcToRework(ticketKey, jiraConfig) {
+    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+    console.log('🔧 Moved', ticketKey, 'to', jiraConfig.statuses.IN_REWORK);
     try {
         jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
         console.log('✅ Removed sm_test_automation_triggered');
@@ -73,6 +74,8 @@ function moveFailedTcToRework(ticketKey) {
 function action(params) {
     try {
         var ticketKey = params.ticket.key;
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         console.log('=== Processing bug creation decision for', ticketKey, '===');
 
         var customParams = params.jobParams && params.jobParams.customParams;
@@ -158,8 +161,8 @@ function action(params) {
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.PASSED });
-                console.log('✅ Tests pass — moved', ticketKey, 'to', STATUSES.PASSED);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.PASSED });
+                console.log('✅ Tests pass — moved', ticketKey, 'to', jiraConfig.statuses.PASSED);
             } catch (e) {
                 console.warn('Failed to move to Passed:', e);
             }
@@ -176,7 +179,7 @@ function action(params) {
                 '\n\n_TC moved to *In Rework* so the test automation can be fixed instead of staying in *Failed*._';
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
-            moveFailedTcToRework(ticketKey);
+            moveFailedTcToRework(ticketKey, jiraConfig);
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
             if (smTriggerLabel) {
                 try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
@@ -195,8 +198,8 @@ function action(params) {
         // Move TC to Bug To Fix after successful link or create
         if (bugLinked) {
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BUG_TO_FIX });
-                console.log('✅ Moved', ticketKey, 'to', STATUSES.BUG_TO_FIX);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
+                console.log('✅ Moved', ticketKey, 'to', jiraConfig.statuses.BUG_TO_FIX);
             } catch (e) {
                 console.warn('Failed to move to Bug To Fix:', e);
             }
@@ -204,8 +207,8 @@ function action(params) {
             // Move the bug to Ready For Development so it gets picked up
             if (bugKey) {
                 try {
-                    jira_move_to_status({ key: bugKey, statusName: STATUSES.READY_FOR_DEVELOPMENT });
-                    console.log('✅ Moved bug', bugKey, 'to', STATUSES.READY_FOR_DEVELOPMENT);
+                    jira_move_to_status({ key: bugKey, statusName: jiraConfig.statuses.READY_FOR_DEVELOPMENT });
+                    console.log('✅ Moved bug', bugKey, 'to', jiraConfig.statuses.READY_FOR_DEVELOPMENT);
                 } catch (e) {
                     console.warn('Failed to move bug to Ready For Development:', e);
                 }

--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -24,7 +24,7 @@
  * For skipped:  move TC to Backlog so test automation can be re-automated/reworked
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var feedbackLoop = require('./common/feedbackLoop.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 var configLoader = require('./configLoader.js');
@@ -154,9 +154,9 @@ function findAnyLinkedNonDoneBug(tcKeys) {
     return null;
 }
 
-function moveToBugToFix(tcKey) {
+function moveToBugToFix(tcKey, jiraConfig) {
     try {
-        jira_move_to_status({ key: tcKey, statusName: STATUSES.BUG_TO_FIX || 'Bug To Fix' });
+        jira_move_to_status({ key: tcKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
         console.log('  📋 Moved to Bug To Fix:', tcKey);
     } catch (e) {
         console.warn('  ⚠️ Could not move to Bug To Fix:', tcKey, e);
@@ -248,9 +248,9 @@ function markResolved(resolvedSet, tcKey) {
     if (tcKey) resolvedSet[tcKey] = true;
 }
 
-function moveSkippedTcToBacklog(tcKey) {
-    jira_move_to_status({ key: tcKey, statusName: STATUSES.BACKLOG || 'Backlog' });
-    console.log('  🔧 Moved to ' + (STATUSES.BACKLOG || 'Backlog') + ':', tcKey);
+function moveSkippedTcToBacklog(tcKey, jiraConfig) {
+    jira_move_to_status({ key: tcKey, statusName: jiraConfig.statuses.BACKLOG });
+    console.log('  🔧 Moved to ' + jiraConfig.statuses.BACKLOG + ':', tcKey);
     try {
         jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
     } catch (e) {}
@@ -263,6 +263,7 @@ function action(params) {
         var triggerLabel = customParams.removeLabel || 'sm_bug_creation_triggered';
         var smTriggerLabel = customParams.smTriggerLabel || 'sm_bulk_bugs_creation_triggered';
         var projectConfig = configLoader.loadProjectConfig(actualParams);
+        var jiraConfig = projectConfig.jira;
         var failedReasonFieldName = getFailedReasonFieldName(projectConfig, customParams);
 
         console.log('=== Processing bulk bug creation decisions ===');
@@ -367,7 +368,7 @@ function action(params) {
                     }
                     try {
                         linkBugToTC(tcKey, existingBugKey);
-                        moveToBugToFix(tcKey);
+                        moveToBugToFix(tcKey, jiraConfig);
                         removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                         postComment(tcKey,
                             'h3. 🔗 Existing Bug Linked (Batch Live Re-check)\n\n' +
@@ -419,7 +420,7 @@ function action(params) {
                 }
                 try {
                     linkBugToTC(tcKey, bugKey);
-                    moveToBugToFix(tcKey);
+                    moveToBugToFix(tcKey, jiraConfig);
                     removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                     postComment(tcKey,
                         'h3. 🐛 New Bug Created (Batch)\n\n' +
@@ -481,7 +482,7 @@ function action(params) {
                 return;
             }
             console.log('  Skipping', tcKey, '—', skipDef.reason || 'no reason given');
-            moveSkippedTcToBacklog(tcKey);
+            moveSkippedTcToBacklog(tcKey, jiraConfig);
             try {
                 removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 console.log('  🏷️ Removed trigger labels from', tcKey, '— eligible for re-automation');

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -32,6 +32,7 @@ var configLoader = require('./configLoader.js');
 const { LABELS } = require('./config.js');
 var prHelper = require('./common/pullRequest.js');
 var outputFiles = require('./common/outputFiles.js');
+var trackerHelper = require('./common/tracker.js');
 
 /** Marker file path to prevent infinite resume loops. */
 var RESUME_MARKER = 'outputs/.missing-output-resume-attempted';
@@ -495,7 +496,7 @@ function removeWipLabel(params, ticketKey) {
     var wipLabel = params.metadata && params.metadata.contextId
         ? params.metadata.contextId + '_wip'
         : 'mobile_test_automation_wip';
-    try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
+    try { trackerHelper.removeLabel(ticketKey, wipLabel); } catch (e) {}
 }
 
 function removeSMTriggerLabel(params, ticketKey) {
@@ -504,7 +505,7 @@ function removeSMTriggerLabel(params, ticketKey) {
     var smTriggerLabel = customParams.removeLabel;
     if (smTriggerLabel) {
         try {
-            jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+            trackerHelper.removeLabel(ticketKey, smTriggerLabel);
             console.log('✅ Removed SM trigger label:', smTriggerLabel);
         } catch (e) {}
     }
@@ -516,7 +517,7 @@ function action(params) {
         var ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         var jiraComment = params.response || '';
         var config = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = config.jira;
+        var trackerConfig = config.tracker;
         var automationScm = createScmCompat(config, config.repository && config.repository.owner, config.repository && config.repository.repo);
         var workingDir = config.workingDir;
 
@@ -582,7 +583,7 @@ function action(params) {
                 var errMsg = 'h3. ⚠️ Test Automation Error\n\nFlows may have been written but output JSON is missing. Check workflow logs.' +
                     (resumed ? '\n\n_Resume was attempted but also did not produce output files._' : '');
                 if (automationPrUrl) errMsg += '\n\n*Automation PR*: ' + automationPrUrl;
-                jira_post_comment({ key: ticketKey, comment: errMsg });
+                tracker_post_comment({ key: ticketKey, comment: errMsg });
             } catch (e) { console.warn('Failed to post error Jira comment:', e); }
             return { success: false, error: 'No test result JSON found', automationPrUrl: automationPrUrl };
         }
@@ -637,7 +638,7 @@ function action(params) {
             if (automationPrUrl && comment.indexOf(automationPrUrl) === -1) {
                 comment += '\n\n*Automation PR*: ' + automationPrUrl;
             }
-            jira_post_comment({ key: ticketKey, comment: comment });
+            tracker_post_comment({ key: ticketKey, comment: comment });
             console.log('✅ Posted Jira comment');
         } catch (e) {
             console.warn('Failed to post Jira comment:', e);
@@ -656,8 +657,8 @@ function action(params) {
                 });
             }
             blockedComment += '\nOnce setup is complete, move this ticket back to *Backlog* to trigger re-run.';
-            try { jira_post_comment({ key: ticketKey, comment: blockedComment }); } catch (e) {}
-            try { jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: blockedComment }); } catch (e) {}
+            try { tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BLOCKED }); } catch (e) {}
 
             removeWipLabel(params, ticketKey);
             removeSMTriggerLabel(params, ticketKey);
@@ -666,8 +667,8 @@ function action(params) {
 
         // Step 8: Move ticket status
         try {
-            var targetStatus = passed ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
-            jira_move_to_status({ key: ticketKey, statusName: targetStatus });
+            var targetStatus = passed ? trackerConfig.statuses.PASSED : trackerConfig.statuses.FAILED;
+            tracker_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);
         } catch (e) {
             console.warn('Failed to move ticket status:', e);
@@ -675,7 +676,7 @@ function action(params) {
 
         // Step 9: Add AI label
         try {
-            jira_add_label({ key: ticketKey, label: LABELS.AI_TEST_AUTOMATION });
+            trackerHelper.addLabel(ticketKey, LABELS.AI_TEST_AUTOMATION);
         } catch (e) {
             console.warn('Failed to add AI label:', e);
         }
@@ -695,7 +696,7 @@ function action(params) {
     } catch (error) {
         console.error('❌ Error in postMobileTestAutomationResults:', error);
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: params.ticket.key,
                 comment: 'h3. ❌ Test Automation Error\n\n{code}' + error.toString() + '{code}'
             });

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -29,7 +29,7 @@
  */
 
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var prHelper = require('./common/pullRequest.js');
 var outputFiles = require('./common/outputFiles.js');
 
@@ -516,6 +516,7 @@ function action(params) {
         var ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         var jiraComment = params.response || '';
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var automationScm = createScmCompat(config, config.repository && config.repository.owner, config.repository && config.repository.repo);
         var workingDir = config.workingDir;
 
@@ -656,7 +657,7 @@ function action(params) {
             }
             blockedComment += '\nOnce setup is complete, move this ticket back to *Backlog* to trigger re-run.';
             try { jira_post_comment({ key: ticketKey, comment: blockedComment }); } catch (e) {}
-            try { jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED }); } catch (e) {}
+            try { jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED }); } catch (e) {}
 
             removeWipLabel(params, ticketKey);
             removeSMTriggerLabel(params, ticketKey);
@@ -665,7 +666,7 @@ function action(params) {
 
         // Step 8: Move ticket status
         try {
-            var targetStatus = passed ? STATUSES.PASSED : STATUSES.FAILED;
+            var targetStatus = passed ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
             jira_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);
         } catch (e) {

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -13,7 +13,7 @@
 var configLoader = require('./configLoader.js');
 var prHelper = require('./common/pullRequest.js');
 var autoStart = require('./common/autoStart.js');
-const { GIT_CONFIG, STATUSES, LABELS, JIRA_FIELDS, resolveStatuses } = require('./config.js');
+const { GIT_CONFIG, LABELS, JIRA_FIELDS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -433,7 +433,7 @@ function updateFailedReasonField(tcKey, attachmentName, failureSummary, fieldNam
 
 function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     try {
-        var targetStatus = status === 'passed' ? STATUSES.IN_REVIEW_PASSED : STATUSES.IN_REVIEW_FAILED;
+        var targetStatus = status === 'passed' ? config.jira.statuses.IN_REVIEW_PASSED : config.jira.statuses.IN_REVIEW_FAILED;
         jira_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Moved', tcKey, 'to', targetStatus);
 
@@ -454,9 +454,9 @@ function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     }
 }
 
-function finalizeTestCaseStatus(tcKey, status) {
+function finalizeTestCaseStatus(tcKey, status, jiraConfig) {
     try {
-        var targetStatus = status === 'passed' ? STATUSES.PASSED : STATUSES.FAILED;
+        var targetStatus = status === 'passed' ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
         jira_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Finalized', tcKey, 'to', targetStatus, '(no code changes)');
     } catch (e) {
@@ -552,8 +552,8 @@ function action(params) {
         const storyKey = params.ticket.key;
         const storySummary = params.ticket.fields ? params.ticket.fields.summary : storyKey;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var customParams = (params.jobParams || params).customParams || {};
-        var statuses = resolveStatuses(customParams);
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
         var testFilesPath = customParams.testFilesGlob || 'testing/';
@@ -562,8 +562,7 @@ function action(params) {
         console.log('=== Processing story test automation results for', storyKey, '===');
 
         // Step 1: Read structured result and ensure all linked Test Cases were checked
-        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-        var testCaseType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE) || 'Test Case';
+        var testCaseType = (jiraConfig.issueTypes && jiraConfig.issueTypes.TEST_CASE) || 'Test Case';
         var linkedTestCases = readLinkedTestCases(storyKey, testCaseType);
 
         var result = readResultJson(workingDir, storyKey);
@@ -607,14 +606,14 @@ function action(params) {
 
         // For a Bug, a product failure means the fix did not work. Send the Bug
         // straight back to development and finalize the failing Test Cases as Failed.
-        if (issueType === 'Bug' && hasProductFailure) {
+        if (issueType === jiraConfig.issueTypes.BUG && hasProductFailure) {
             console.log('Bug', storyKey, 'has', failedResults.length, 'product failure(s) — returning to development');
             failedResults.forEach(function(item) {
                 updateTestCaseStatus(item.testCaseKey, 'failed', workingDir, storyKey, config);
-                finalizeTestCaseStatus(item.testCaseKey, 'failed');
+                finalizeTestCaseStatus(item.testCaseKey, 'failed', jiraConfig);
             });
 
-            var bugReturnStatus = statuses.READY_FOR_DEVELOPMENT || STATUSES.READY_FOR_DEVELOPMENT;
+            var bugReturnStatus = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
             try {
                 jira_move_to_status({ key: storyKey, statusName: bugReturnStatus });
                 console.log('✅ Moved Bug', storyKey, 'back to', bugReturnStatus);
@@ -706,8 +705,8 @@ function action(params) {
                 'Once setup is complete, move this Story back to *Ready For Testing* to trigger re-run.';
             try {
                 jira_post_comment({ key: storyKey, comment: blockedComment });
-                jira_move_to_status({ key: storyKey, statusName: STATUSES.BLOCKED });
-                console.log('✅ Blocked — moved', storyKey, 'to', STATUSES.BLOCKED);
+                jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', storyKey, 'to', jiraConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to handle blocked story:', e);
             }
@@ -723,14 +722,14 @@ function action(params) {
                     // When there are no test code changes we skip the PR/review/merge flow,
                     // so we must finalize TC statuses immediately so story_done_check can act.
                     if (noCodeChanges) {
-                        finalizeTestCaseStatus(item.testCaseKey, item.status);
+                        finalizeTestCaseStatus(item.testCaseKey, item.status, jiraConfig);
                     }
                 } else if (item.status === 'skipped') {
                     // Skipped tests are final — no PR/review needed.
-                    moveSkippedTcToStatus(item.testCaseKey, statuses.SKIPPED || 'Skipped');
+                    moveSkippedTcToStatus(item.testCaseKey, jiraConfig.statuses.SKIPPED);
                 } else if (item.status === 'irrelevant') {
                     // Legacy/no-longer-applicable tests are final; delete their test code.
-                    moveIrrelevantTcToStatus(item.testCaseKey, statuses.IRRELEVANT || 'Irrelevant', testFilesPath, workingDir);
+                    moveIrrelevantTcToStatus(item.testCaseKey, jiraConfig.statuses.IRRELEVANT, testFilesPath, workingDir);
                 } else {
                     console.log('Skipping status update for', item.testCaseKey, '— status:', item.status);
                 }
@@ -739,8 +738,8 @@ function action(params) {
 
         // Step 8: Move Story to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -16,6 +16,7 @@ var autoStart = require('./common/autoStart.js');
 const { GIT_CONFIG, LABELS, JIRA_FIELDS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 var RESUME_MARKER = 'outputs/.story-test-resume-attempted';
 
@@ -74,7 +75,7 @@ function readLinkedTestCases(storyKey, testCaseType) {
 
     try {
         var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = "' + testCaseType + '"';
-        var results = jira_search_by_jql({ jql: jql, maxResults: 100, fields: ['key'] });
+        var results = tracker_search({ jql: jql, maxResults: 100, fields: ['key'] });
         return Array.isArray(results) ? results : [];
     } catch (e) {
         console.warn('Failed to fetch linked Test Cases from Jira:', e);
@@ -395,7 +396,7 @@ function createPullRequest(title, branchName, baseBranch, workingDir, scm) {
 }
 
 function getFailedReasonField(config) {
-    return (config.jira && config.jira.fields && config.jira.fields.failedReason)
+    return (config.tracker && config.tracker.fields && config.tracker.fields.failedReason)
         || JIRA_FIELDS.FAILED_REASON
         || 'Failed Reason';
 }
@@ -404,12 +405,7 @@ function attachFailedDescription(tcKey, filePath) {
     try {
         if (!filePath) return null;
         var name = filePath.split('/').pop();
-        jira_attach_file_to_ticket({
-            ticketKey: tcKey,
-            name: name,
-            filePath: filePath,
-            contentType: 'text/markdown'
-        });
+        trackerHelper.attachFile(tcKey, name, filePath, 'text/markdown');
         console.log('✅ Attached failed description to', tcKey, ':', name);
         return name;
     } catch (e) {
@@ -424,7 +420,7 @@ function updateFailedReasonField(tcKey, attachmentName, failureSummary, fieldNam
         if (attachmentName) {
             value += '*Attachment*: [^' + attachmentName + ']\n';
         }
-        jira_update_field({ key: tcKey, field: fieldName, value: value });
+        trackerHelper.updateField(tcKey, fieldName, value);
         console.log('✅ Updated Failed Reason field for', tcKey);
     } catch (e) {
         console.warn('Failed to update Failed Reason field for', tcKey, ':', e);
@@ -433,8 +429,8 @@ function updateFailedReasonField(tcKey, attachmentName, failureSummary, fieldNam
 
 function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     try {
-        var targetStatus = status === 'passed' ? config.jira.statuses.IN_REVIEW_PASSED : config.jira.statuses.IN_REVIEW_FAILED;
-        jira_move_to_status({ key: tcKey, statusName: targetStatus });
+        var targetStatus = status === 'passed' ? config.tracker.statuses.IN_REVIEW_PASSED : config.tracker.statuses.IN_REVIEW_FAILED;
+        tracker_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Moved', tcKey, 'to', targetStatus);
 
         if (status === 'failed') {
@@ -454,10 +450,10 @@ function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     }
 }
 
-function finalizeTestCaseStatus(tcKey, status, jiraConfig) {
+function finalizeTestCaseStatus(tcKey, status, trackerConfig) {
     try {
-        var targetStatus = status === 'passed' ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
-        jira_move_to_status({ key: tcKey, statusName: targetStatus });
+        var targetStatus = status === 'passed' ? trackerConfig.statuses.PASSED : trackerConfig.statuses.FAILED;
+        tracker_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Finalized', tcKey, 'to', targetStatus, '(no code changes)');
     } catch (e) {
         console.warn('Failed to finalize Test Case', tcKey, ':', e);
@@ -466,7 +462,7 @@ function finalizeTestCaseStatus(tcKey, status, jiraConfig) {
 
 function moveSkippedTcToStatus(tcKey, skippedStatus) {
     try {
-        jira_move_to_status({ key: tcKey, statusName: skippedStatus });
+        tracker_move_to_status({ key: tcKey, statusName: skippedStatus });
         console.log('✅ Moved', tcKey, 'to', skippedStatus, '(skipped)');
     } catch (e) {
         console.warn('Failed to move skipped Test Case', tcKey, ':', e);
@@ -490,7 +486,7 @@ function deleteTestCaseCode(tcKey, testFilesPath, workingDir) {
 
 function moveIrrelevantTcToStatus(tcKey, irrelevantStatus, testFilesPath, workingDir) {
     try {
-        jira_move_to_status({ key: tcKey, statusName: irrelevantStatus });
+        tracker_move_to_status({ key: tcKey, statusName: irrelevantStatus });
         console.log('✅ Moved', tcKey, 'to', irrelevantStatus, '(irrelevant)');
     } catch (e) {
         console.warn('Failed to move irrelevant Test Case', tcKey, ':', e);
@@ -526,13 +522,13 @@ function removeAutomationLabels(storyKey, params) {
         const wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : 'story_test_automation_wip';
-        jira_remove_label({ key: storyKey, label: wipLabel });
+        trackerHelper.removeLabel(storyKey, wipLabel);
     } catch (e) {}
 
     try {
         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
         if (smTriggerLabel) {
-            jira_remove_label({ key: storyKey, label: smTriggerLabel });
+            trackerHelper.removeLabel(storyKey, smTriggerLabel);
             console.log('✅ Removed SM trigger label:', smTriggerLabel);
         }
     } catch (e) {}
@@ -541,7 +537,7 @@ function removeAutomationLabels(storyKey, params) {
     // new bulk PR can go through review/merge again.
     [LABELS.PR_APPROVED, LABELS.TEST_PR_MERGED, LABELS.TEST_PR_FINALIZED, LABELS.TEST_PR_REWORK_NEEDED].forEach(function(staleLabel) {
         try {
-            jira_remove_label({ key: storyKey, label: staleLabel });
+            trackerHelper.removeLabel(storyKey, staleLabel);
             console.log('✅ Removed stale label:', staleLabel);
         } catch (e) {}
     });
@@ -552,7 +548,7 @@ function action(params) {
         const storyKey = params.ticket.key;
         const storySummary = params.ticket.fields ? params.ticket.fields.summary : storyKey;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = config.jira;
+        var trackerConfig = config.tracker;
         var customParams = (params.jobParams || params).customParams || {};
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
@@ -562,7 +558,7 @@ function action(params) {
         console.log('=== Processing story test automation results for', storyKey, '===');
 
         // Step 1: Read structured result and ensure all linked Test Cases were checked
-        var testCaseType = (jiraConfig.issueTypes && jiraConfig.issueTypes.TEST_CASE) || 'Test Case';
+        var testCaseType = (trackerConfig.issueTypes && trackerConfig.issueTypes.TEST_CASE) || 'Test Case';
         var linkedTestCases = readLinkedTestCases(storyKey, testCaseType);
 
         var result = readResultJson(workingDir, storyKey);
@@ -576,7 +572,7 @@ function action(params) {
 
         if (!result) {
             var commentMsg = 'h3. ⚠️ Story Test Automation Error\n\nCLI exited without producing result JSON. The Story will stay in Ready For Testing so SM can retry.';
-            jira_post_comment({ key: storyKey, comment: commentMsg });
+            tracker_post_comment({ key: storyKey, comment: commentMsg });
             removeAutomationLabels(storyKey, params);
             return { success: false, error: 'No story test result JSON found' };
         }
@@ -588,7 +584,7 @@ function action(params) {
                 'The automation could not verify all linked Test Cases. Missing results for:\n\n' +
                 stillMissingKeys.map(function(k) { return '* ' + k; }).join('\n') + '\n\n' +
                 'The Story will stay in Ready For Testing so SM can retry.';
-            jira_post_comment({ key: storyKey, comment: missingComment });
+            tracker_post_comment({ key: storyKey, comment: missingComment });
             removeAutomationLabels(storyKey, params);
             return { success: false, error: 'Missing Test Case results: ' + stillMissingKeys.join(', ') };
         }
@@ -606,16 +602,16 @@ function action(params) {
 
         // For a Bug, a product failure means the fix did not work. Send the Bug
         // straight back to development and finalize the failing Test Cases as Failed.
-        if (issueType === jiraConfig.issueTypes.BUG && hasProductFailure) {
+        if (issueType === trackerConfig.issueTypes.BUG && hasProductFailure) {
             console.log('Bug', storyKey, 'has', failedResults.length, 'product failure(s) — returning to development');
             failedResults.forEach(function(item) {
                 updateTestCaseStatus(item.testCaseKey, 'failed', workingDir, storyKey, config);
-                finalizeTestCaseStatus(item.testCaseKey, 'failed', jiraConfig);
+                finalizeTestCaseStatus(item.testCaseKey, 'failed', trackerConfig);
             });
 
-            var bugReturnStatus = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+            var bugReturnStatus = trackerConfig.statuses.READY_FOR_DEVELOPMENT;
             try {
-                jira_move_to_status({ key: storyKey, statusName: bugReturnStatus });
+                tracker_move_to_status({ key: storyKey, statusName: bugReturnStatus });
                 console.log('✅ Moved Bug', storyKey, 'back to', bugReturnStatus);
             } catch (moveErr) {
                 console.warn('Failed to move Bug', storyKey, 'to', bugReturnStatus, ':', moveErr);
@@ -623,7 +619,7 @@ function action(params) {
 
             try {
                 var failureList = failedResults.map(function(r) { return '* ' + r.testCaseKey + (r.failureSummary ? ' — ' + r.failureSummary : ''); }).join('\n');
-                jira_post_comment({
+                tracker_post_comment({
                     key: storyKey,
                     comment: 'h3. ⚠️ Bug Fix Did Not Pass Automated Tests\n\nThe following Test Cases failed with a product regression:\n' + failureList + '\n\nThe Bug is being returned to *Ready For Development* for a corrected fix.'
                 });
@@ -666,7 +662,7 @@ function action(params) {
                 prUrl = prResult.prUrl;
                 if (!prResult.success || !prUrl) {
                     console.error('PR creation failed');
-                    jira_post_comment({ key: storyKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.' });
+                    tracker_post_comment({ key: storyKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.' });
                     removeAutomationLabels(storyKey, params);
                     return { success: false, error: 'PR creation failed' };
                 }
@@ -675,7 +671,7 @@ function action(params) {
                 console.log('ℹ️ No test code changes — skipping PR review, moving Story directly');
             } else {
                 console.warn('Git operations failed:', gitResult.error);
-                jira_post_comment({ key: storyKey, comment: 'h3. ⚠️ Git Operations Failed\n\n' + gitResult.error });
+                tracker_post_comment({ key: storyKey, comment: 'h3. ⚠️ Git Operations Failed\n\n' + gitResult.error });
                 removeAutomationLabels(storyKey, params);
                 return { success: false, error: 'Git operations failed: ' + gitResult.error };
             }
@@ -691,7 +687,7 @@ function action(params) {
                 comment += '\n\nℹ️ _Test code unchanged from previous run._';
             }
             if (comment) {
-                jira_post_comment({ key: storyKey, comment: comment });
+                tracker_post_comment({ key: storyKey, comment: comment });
                 console.log('✅ Posted story test result comment to Jira');
             }
         } catch (e) {
@@ -704,9 +700,9 @@ function action(params) {
                 (result.blockedReason || 'Missing credentials or test data.') + '\n\n' +
                 'Once setup is complete, move this Story back to *Ready For Testing* to trigger re-run.';
             try {
-                jira_post_comment({ key: storyKey, comment: blockedComment });
-                jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.BLOCKED });
-                console.log('✅ Blocked — moved', storyKey, 'to', jiraConfig.statuses.BLOCKED);
+                tracker_post_comment({ key: storyKey, comment: blockedComment });
+                tracker_move_to_status({ key: storyKey, statusName: trackerConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', storyKey, 'to', trackerConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to handle blocked story:', e);
             }
@@ -722,14 +718,14 @@ function action(params) {
                     // When there are no test code changes we skip the PR/review/merge flow,
                     // so we must finalize TC statuses immediately so story_done_check can act.
                     if (noCodeChanges) {
-                        finalizeTestCaseStatus(item.testCaseKey, item.status, jiraConfig);
+                        finalizeTestCaseStatus(item.testCaseKey, item.status, trackerConfig);
                     }
                 } else if (item.status === 'skipped') {
                     // Skipped tests are final — no PR/review needed.
-                    moveSkippedTcToStatus(item.testCaseKey, jiraConfig.statuses.SKIPPED);
+                    moveSkippedTcToStatus(item.testCaseKey, trackerConfig.statuses.SKIPPED);
                 } else if (item.status === 'irrelevant') {
                     // Legacy/no-longer-applicable tests are final; delete their test code.
-                    moveIrrelevantTcToStatus(item.testCaseKey, jiraConfig.statuses.IRRELEVANT, testFilesPath, workingDir);
+                    moveIrrelevantTcToStatus(item.testCaseKey, trackerConfig.statuses.IRRELEVANT, testFilesPath, workingDir);
                 } else {
                     console.log('Skipping status update for', item.testCaseKey, '— status:', item.status);
                 }
@@ -738,8 +734,8 @@ function action(params) {
 
         // Step 8: Move Story to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
+            tracker_move_to_status({ key: storyKey, statusName: trackerConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', trackerConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }
@@ -754,7 +750,7 @@ function action(params) {
         // Step 10: Labels cleanup
         removeAutomationLabels(storyKey, params);
         try {
-            jira_add_label({ key: storyKey, label: LABELS.AI_TEST_AUTOMATION });
+            trackerHelper.addLabel(storyKey, LABELS.AI_TEST_AUTOMATION);
         } catch (e) {
             console.warn('Failed to add ai_test_automation label:', e);
         }
@@ -776,7 +772,7 @@ function action(params) {
     } catch (error) {
         console.error('❌ Error in postStoryTestAutomationResults:', error);
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: params.ticket.key,
                 comment: 'h3. ❌ Story Test Automation Error\n\n{code}' + error.toString() + '{code}'
             });

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -16,6 +16,7 @@ var autoStart = require('./common/autoStart.js');
 const { GIT_CONFIG, LABELS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function cleanCommandOutput(output) {
     return prHelper.cleanCommandOutput(output);
@@ -294,13 +295,13 @@ function removeAutomationLabels(ticketKey, params) {
         const wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : 'test_case_automation_wip';
-        jira_remove_label({ key: ticketKey, label: wipLabel });
+        trackerHelper.removeLabel(ticketKey, wipLabel);
     } catch (e) {}
 
     try {
         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
         if (smTriggerLabel) {
-            jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+            trackerHelper.removeLabel(ticketKey, smTriggerLabel);
             console.log('✅ Removed SM trigger label:', smTriggerLabel);
         }
     } catch (e) {}
@@ -340,7 +341,7 @@ function action(params) {
         const ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         const projectKey = ticketKey.split('-')[0];
         var config = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = config.jira;
+        var trackerConfig = config.tracker;
         var customParams = (params.jobParams || params).customParams || {};
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
@@ -380,17 +381,17 @@ function action(params) {
             }
             commentMsg += 'Ticket moved back to *Backlog* so SM can retry.';
 
-            jira_post_comment({ key: ticketKey, comment: commentMsg });
+            tracker_post_comment({ key: ticketKey, comment: commentMsg });
             try {
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
-                console.log('✅ Missing result — moved', ticketKey, 'to', jiraConfig.statuses.BACKLOG);
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BACKLOG });
+                console.log('✅ Missing result — moved', ticketKey, 'to', trackerConfig.statuses.BACKLOG);
             } catch (e) {
                 console.warn('Failed to move missing-result ticket to Backlog:', e);
             }
             try {
                 const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
                 if (smTriggerLabel) {
-                    jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                    trackerHelper.removeLabel(ticketKey, smTriggerLabel);
                     console.log('✅ Removed SM trigger label after missing result:', smTriggerLabel);
                 }
             } catch (e) {
@@ -400,7 +401,7 @@ function action(params) {
                 const wipLabelMissingResult = params.metadata && params.metadata.contextId
                     ? params.metadata.contextId + '_wip'
                     : 'test_case_automation_wip';
-                jira_remove_label({ key: ticketKey, label: wipLabelMissingResult });
+                trackerHelper.removeLabel(ticketKey, wipLabelMissingResult);
             } catch (e) {
                 console.warn('Failed to remove WIP label after missing result:', e);
             }
@@ -443,13 +444,13 @@ function action(params) {
                     // PR creation failed — branch has code but no PR; post comment and reset to Backlog for retry
                     console.error('PR creation failed — resetting ticket to Backlog for retry');
                     try {
-                        jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.\n\nTicket moved back to *Backlog* — will be re-processed automatically. The next run will detect the existing branch and create the PR.\n\nError: ' + (prResult.error || 'unknown') });
-                        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
+                        tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.\n\nTicket moved back to *Backlog* — will be re-processed automatically. The next run will detect the existing branch and create the PR.\n\nError: ' + (prResult.error || 'unknown') });
+                        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BACKLOG });
                     } catch (e) { console.warn('Could not reset to Backlog:', e); }
                     try {
                         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
                         if (smTriggerLabel) {
-                            jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                            trackerHelper.removeLabel(ticketKey, smTriggerLabel);
                             console.log('✅ Removed SM trigger label on PR failure:', smTriggerLabel);
                         }
                     } catch (e) { console.warn('Could not remove SM trigger label:', e); }
@@ -466,10 +467,10 @@ function action(params) {
                             'A {code}merge_conflicts.md{code} guidance file was present for this run, which means the existing test branch could not be safely auto-aligned with {code}origin/' + config.git.baseBranch + '{code}. ' +
                             'Do not send this PR into automated review until the branch is deliberately synced with main and only ticket-specific test automation changes remain.\n\n' +
                             'Ticket moved to *Blocked* for human conflict resolution.';
-                        try { jira_post_comment({ key: ticketKey, comment: conflictComment }); } catch (e) {}
+                        try { tracker_post_comment({ key: ticketKey, comment: conflictComment }); } catch (e) {}
                         try {
-                            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
-                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
+                            tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BLOCKED });
+                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', trackerConfig.statuses.BLOCKED);
                         } catch (e) {
                             console.warn('Failed to move conflicting PR ticket to Blocked:', e);
                         }
@@ -490,11 +491,11 @@ function action(params) {
                 // Git operations failed — reset to Backlog for retry
                 console.warn('Git operations failed:', gitResult.error);
                 try {
-                    jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Git Operations Failed\n\nFailed to commit/push test code: ' + gitResult.error + '\n\nTicket moved back to *Backlog* — will be re-processed automatically.' });
-                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
+                    tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Git Operations Failed\n\nFailed to commit/push test code: ' + gitResult.error + '\n\nTicket moved back to *Backlog* — will be re-processed automatically.' });
+                    tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BACKLOG });
                 } catch (e) { console.warn('Could not reset to Backlog:', e); }
                 try {
-                    jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
+                    trackerHelper.removeLabel(ticketKey, 'sm_test_automation_triggered');
                 } catch (e) {}
                 return { success: false, error: 'Git operations failed: ' + gitResult.error };
             }
@@ -510,7 +511,7 @@ function action(params) {
                 comment += '\n\nℹ️ _Test code unchanged from previous run — PR review step skipped._';
             }
             if (comment) {
-                jira_post_comment({ key: ticketKey, comment: comment });
+                tracker_post_comment({ key: ticketKey, comment: comment });
                 console.log('✅ Posted test result comment to Jira');
             }
         } catch (e) {
@@ -543,15 +544,15 @@ function action(params) {
             blockedComment += '\n\nOnce setup is complete, move this ticket back to *Backlog* to trigger re-run.';
 
             try {
-                jira_post_comment({ key: ticketKey, comment: blockedComment });
+                tracker_post_comment({ key: ticketKey, comment: blockedComment });
                 console.log('✅ Posted blocked comment to Jira');
             } catch (e) {
                 console.warn('Failed to post blocked comment:', e);
             }
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
-                console.log('✅ Blocked — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', ticketKey, 'to', trackerConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
             }
@@ -560,13 +561,13 @@ function action(params) {
             const wipLabelBlocked = params.metadata && params.metadata.contextId
                 ? params.metadata.contextId + '_wip'
                 : 'test_case_automation_wip';
-            try { jira_remove_label({ key: ticketKey, label: wipLabelBlocked }); } catch (e) {}
+            try { trackerHelper.removeLabel(ticketKey, wipLabelBlocked); } catch (e) {}
 
             // Remove SM trigger label so the ticket is re-processed after human fixes the issue
             const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
             if (smTriggerLabel) {
                 try {
-                    jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                    trackerHelper.removeLabel(ticketKey, smTriggerLabel);
                     console.log('✅ Removed SM trigger label:', smTriggerLabel);
                 } catch (e) {}
             }
@@ -577,8 +578,8 @@ function action(params) {
 
         if (passed) {
             try {
-                var passedStatus = noCodeChanges ? jiraConfig.statuses.PASSED : jiraConfig.statuses.IN_REVIEW_PASSED;
-                jira_move_to_status({ key: ticketKey, statusName: passedStatus });
+                var passedStatus = noCodeChanges ? trackerConfig.statuses.PASSED : trackerConfig.statuses.IN_REVIEW_PASSED;
+                tracker_move_to_status({ key: ticketKey, statusName: passedStatus });
                 console.log('✅ Passed — moved', ticketKey, 'to', passedStatus);
             } catch (e) {
                 console.warn('Failed to move to Passed:', e);
@@ -586,8 +587,8 @@ function action(params) {
         } else {
             // Bug creation is handled by the bug_creation agent when TC reaches Failed status
             try {
-                var failedStatus = noCodeChanges ? jiraConfig.statuses.FAILED : jiraConfig.statuses.IN_REVIEW_FAILED;
-                jira_move_to_status({ key: ticketKey, statusName: failedStatus });
+                var failedStatus = noCodeChanges ? trackerConfig.statuses.FAILED : trackerConfig.statuses.IN_REVIEW_FAILED;
+                tracker_move_to_status({ key: ticketKey, statusName: failedStatus });
                 console.log('✅ Failed — moved', ticketKey, 'to', failedStatus);
             } catch (e) {
                 console.warn('Failed to move to Failed:', e);
@@ -602,7 +603,7 @@ function action(params) {
 
         // Step 7: Add label
         try {
-            jira_add_label({ key: ticketKey, label: LABELS.AI_TEST_AUTOMATION });
+            trackerHelper.addLabel(ticketKey, LABELS.AI_TEST_AUTOMATION);
         } catch (e) {
             console.warn('Failed to add label:', e);
         }
@@ -612,7 +613,7 @@ function action(params) {
             ? params.metadata.contextId + '_wip'
             : 'test_case_automation_wip';
         try {
-            jira_remove_label({ key: ticketKey, label: wipLabel });
+            trackerHelper.removeLabel(ticketKey, wipLabel);
         } catch (e) {
             console.warn('Failed to remove WIP label:', e);
         }
@@ -622,7 +623,7 @@ function action(params) {
         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
         if (smTriggerLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                trackerHelper.removeLabel(ticketKey, smTriggerLabel);
                 console.log('✅ Removed SM trigger label:', smTriggerLabel);
             } catch (e) {}
         }
@@ -647,7 +648,7 @@ function action(params) {
     } catch (error) {
         console.error('❌ Error in postTestAutomationResults:', error);
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: params.ticket.key,
                 comment: 'h3. ❌ Test Automation Error\n\n{code}' + error.toString() + '{code}'
             });
@@ -655,7 +656,7 @@ function action(params) {
         try {
             const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
             if (smTriggerLabel) {
-                jira_remove_label({ key: params.ticket.key, label: smTriggerLabel });
+                trackerHelper.removeLabel(params.ticket.key, smTriggerLabel);
                 console.log('✅ Removed SM trigger label on error:', smTriggerLabel);
             }
         } catch (e) {}

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -13,7 +13,7 @@
 var configLoader = require('./configLoader.js');
 var prHelper = require('./common/pullRequest.js');
 var autoStart = require('./common/autoStart.js');
-const { GIT_CONFIG, STATUSES, LABELS } = require('./config.js');
+const { GIT_CONFIG, LABELS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -340,6 +340,7 @@ function action(params) {
         const ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         const projectKey = ticketKey.split('-')[0];
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var customParams = (params.jobParams || params).customParams || {};
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
@@ -381,8 +382,8 @@ function action(params) {
 
             jira_post_comment({ key: ticketKey, comment: commentMsg });
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
-                console.log('✅ Missing result — moved', ticketKey, 'to', STATUSES.BACKLOG);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
+                console.log('✅ Missing result — moved', ticketKey, 'to', jiraConfig.statuses.BACKLOG);
             } catch (e) {
                 console.warn('Failed to move missing-result ticket to Backlog:', e);
             }
@@ -443,7 +444,7 @@ function action(params) {
                     console.error('PR creation failed — resetting ticket to Backlog for retry');
                     try {
                         jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.\n\nTicket moved back to *Backlog* — will be re-processed automatically. The next run will detect the existing branch and create the PR.\n\nError: ' + (prResult.error || 'unknown') });
-                        jira_move_to_status({ key: ticketKey, statusName: 'Backlog' });
+                        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
                     } catch (e) { console.warn('Could not reset to Backlog:', e); }
                     try {
                         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
@@ -467,8 +468,8 @@ function action(params) {
                             'Ticket moved to *Blocked* for human conflict resolution.';
                         try { jira_post_comment({ key: ticketKey, comment: conflictComment }); } catch (e) {}
                         try {
-                            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
-                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', STATUSES.BLOCKED);
+                            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
+                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
                         } catch (e) {
                             console.warn('Failed to move conflicting PR ticket to Blocked:', e);
                         }
@@ -490,7 +491,7 @@ function action(params) {
                 console.warn('Git operations failed:', gitResult.error);
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Git Operations Failed\n\nFailed to commit/push test code: ' + gitResult.error + '\n\nTicket moved back to *Backlog* — will be re-processed automatically.' });
-                    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
                 } catch (e) { console.warn('Could not reset to Backlog:', e); }
                 try {
                     jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
@@ -549,8 +550,8 @@ function action(params) {
             }
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
-                console.log('✅ Blocked — moved', ticketKey, 'to', STATUSES.BLOCKED);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
             }
@@ -576,7 +577,7 @@ function action(params) {
 
         if (passed) {
             try {
-                var passedStatus = noCodeChanges ? STATUSES.PASSED : STATUSES.IN_REVIEW_PASSED;
+                var passedStatus = noCodeChanges ? jiraConfig.statuses.PASSED : jiraConfig.statuses.IN_REVIEW_PASSED;
                 jira_move_to_status({ key: ticketKey, statusName: passedStatus });
                 console.log('✅ Passed — moved', ticketKey, 'to', passedStatus);
             } catch (e) {
@@ -585,7 +586,7 @@ function action(params) {
         } else {
             // Bug creation is handled by the bug_creation agent when TC reaches Failed status
             try {
-                var failedStatus = noCodeChanges ? STATUSES.FAILED : STATUSES.IN_REVIEW_FAILED;
+                var failedStatus = noCodeChanges ? jiraConfig.statuses.FAILED : jiraConfig.statuses.IN_REVIEW_FAILED;
                 jira_move_to_status({ key: ticketKey, statusName: failedStatus });
                 console.log('✅ Failed — moved', ticketKey, 'to', failedStatus);
             } catch (e) {

--- a/js/postTestReviewComments.js
+++ b/js/postTestReviewComments.js
@@ -11,7 +11,7 @@
  *   - Moves to In Rework
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const gh = require('./common/githubHelpers.js');
 const autoStart = require('./common/autoStart.js');
 const configLoader = require('./configLoader.js');
@@ -282,6 +282,7 @@ function action(params) {
         const ticketKey = params.ticket.key;
         const jiraComment = params.response || '';
         const config = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = config.jira;
         const customParams = resolveCustomParams(params, config);
         const workingDir = config.workingDir || null;
 
@@ -406,7 +407,7 @@ function action(params) {
             autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
         } else {
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 console.log('✅ Changes requested — moved', ticketKey, 'to In Rework');
                 if (!triggerReworkIfConfigured(ticketKey, config, customParams)) {
                     markForSmTestRework(ticketKey);
@@ -436,11 +437,11 @@ function action(params) {
 
         var finalStatus;
         if (isApproved && !mergeSucceeded) {
-            finalStatus = STATUSES.IN_REWORK;
+            finalStatus = jiraConfig.statuses.IN_REWORK;
         } else if (isApproved) {
-            finalStatus = (currentStatus === STATUSES.IN_REVIEW_PASSED) ? STATUSES.PASSED : STATUSES.FAILED;
+            finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
         } else {
-            finalStatus = STATUSES.IN_REWORK;
+            finalStatus = jiraConfig.statuses.IN_REWORK;
         }
         console.log('✅ Test review workflow complete:', isApproved ? (mergeSucceeded ? 'APPROVED' : 'MERGE CONFLICT') : 'CHANGES REQUESTED');
 

--- a/js/postTestReviewComments.js
+++ b/js/postTestReviewComments.js
@@ -17,6 +17,7 @@ const autoStart = require('./common/autoStart.js');
 const configLoader = require('./configLoader.js');
 const outputFiles = require('./common/outputFiles.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function readFile(path) {
     return outputFiles.readOutputFile(path, {});
@@ -38,7 +39,7 @@ function readReviewJson(ticketKey, workingDir) {
 
 function getCurrentTicketStatus(ticketKey) {
     try {
-        const ticket = jira_get_ticket({ key: ticketKey });
+        const ticket = tracker_get_ticket({ key: ticketKey });
         return ticket && ticket.fields && ticket.fields.status
             ? ticket.fields.status.name
             : null;
@@ -249,7 +250,7 @@ function triggerReworkIfConfigured(ticketKey, config, customParams) {
 
 function markForSmTestRework(ticketKey) {
     try {
-        jira_add_label({ key: ticketKey, label: 'sm_test_rework_triggered' });
+        trackerHelper.addLabel(ticketKey, 'sm_test_rework_triggered');
         console.log('✅ Added SM rework label: sm_test_rework_triggered');
         return true;
     } catch (e) {
@@ -282,7 +283,7 @@ function action(params) {
         const ticketKey = params.ticket.key;
         const jiraComment = params.response || '';
         const config = configLoader.loadProjectConfig(params.jobParams || params);
-        const jiraConfig = config.jira;
+        const trackerConfig = config.tracker;
         const customParams = resolveCustomParams(params, config);
         const workingDir = config.workingDir || null;
 
@@ -291,13 +292,13 @@ function action(params) {
         // Step 1: Read review data
         const reviewData = readReviewJson(ticketKey, workingDir);
         if (!reviewData) {
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. ⚠️ Review Error\n\nCould not read pr_review.json. Removed SM trigger label so SM can retry.'
             });
             try {
                 const smTriggerLabel = customParams.removeLabel || 'sm_test_review_triggered';
-                jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                trackerHelper.removeLabel(ticketKey, smTriggerLabel);
                 console.log('✅ Removed SM trigger label after missing review:', smTriggerLabel);
             } catch (e) {
                 console.warn('Failed to remove SM trigger label after missing review:', e);
@@ -306,7 +307,7 @@ function action(params) {
                 const wipLabelMissingReview = params.metadata && params.metadata.contextId
                     ? params.metadata.contextId + '_wip'
                     : 'pr_test_automation_review_wip';
-                jira_remove_label({ key: ticketKey, label: wipLabelMissingReview });
+                trackerHelper.removeLabel(ticketKey, wipLabelMissingReview);
             } catch (e) {
                 console.warn('Failed to remove WIP label after missing review:', e);
             }
@@ -378,7 +379,7 @@ function action(params) {
                     console.warn('Failed to add pr_approved to GitHub PR:', e);
                 }
                 try {
-                    jira_add_label({ key: ticketKey, label: LABELS.PR_APPROVED });
+                    trackerHelper.addLabel(ticketKey, LABELS.PR_APPROVED);
                     console.log('✅ Added pr_approved label to Jira ticket');
                 } catch (e) {
                     console.warn('Failed to add pr_approved to Jira ticket:', e);
@@ -393,7 +394,7 @@ function action(params) {
         // Step 5: Post Jira comment
         try {
             if (jiraComment) {
-                jira_post_comment({ key: ticketKey, comment: jiraComment });
+                tracker_post_comment({ key: ticketKey, comment: jiraComment });
                 console.log('✅ Posted review comment to Jira');
             }
         } catch (e) {
@@ -407,7 +408,7 @@ function action(params) {
             autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
         } else {
             try {
-                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+                tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
                 console.log('✅ Changes requested — moved', ticketKey, 'to In Rework');
                 if (!triggerReworkIfConfigured(ticketKey, config, customParams)) {
                     markForSmTestRework(ticketKey);
@@ -420,28 +421,28 @@ function action(params) {
 
         // Step 7: Add label + remove WIP
         try {
-            jira_add_label({ key: ticketKey, label: LABELS.AI_PR_REVIEWED });
+            trackerHelper.addLabel(ticketKey, LABELS.AI_PR_REVIEWED);
         } catch (e) {}
 
         const wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : 'pr_test_automation_review_wip';
         try {
-            jira_remove_label({ key: ticketKey, label: wipLabel });
+            trackerHelper.removeLabel(ticketKey, wipLabel);
         } catch (e) {}
 
         try {
-            jira_remove_label({ key: ticketKey, label: 'sm_test_review_triggered' });
+            trackerHelper.removeLabel(ticketKey, 'sm_test_review_triggered');
             console.log('✅ Removed SM label: sm_test_review_triggered');
         } catch (e) {}
 
         var finalStatus;
         if (isApproved && !mergeSucceeded) {
-            finalStatus = jiraConfig.statuses.IN_REWORK;
+            finalStatus = trackerConfig.statuses.IN_REWORK;
         } else if (isApproved) {
-            finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
+            finalStatus = (currentStatus === trackerConfig.statuses.IN_REVIEW_PASSED) ? trackerConfig.statuses.PASSED : trackerConfig.statuses.FAILED;
         } else {
-            finalStatus = jiraConfig.statuses.IN_REWORK;
+            finalStatus = trackerConfig.statuses.IN_REWORK;
         }
         console.log('✅ Test review workflow complete:', isApproved ? (mergeSucceeded ? 'APPROVED' : 'MERGE CONFLICT') : 'CHANGES REQUESTED');
 
@@ -466,11 +467,11 @@ function action(params) {
         try {
             const ticketKey = params.ticket ? params.ticket.key : (params.inputFolderPath ? params.inputFolderPath.split('/').pop() : null);
             if (ticketKey) {
-                jira_remove_label({ key: ticketKey, label: 'sm_test_review_triggered' });
+                trackerHelper.removeLabel(ticketKey, 'sm_test_review_triggered');
             }
         } catch (e) {}
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: params.ticket.key,
                 comment: 'h3. ❌ Test Review Error\n\n{code}' + error.toString() + '{code}'
             });

--- a/js/postTestReworkResults.js
+++ b/js/postTestReworkResults.js
@@ -16,6 +16,7 @@ var feedbackLoop = require('./common/feedbackLoop.js');
 var prHelper = require('./common/pullRequest.js');
 const { GIT_CONFIG, LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function cleanCommandOutput(output) {
     if (!output) return '';
@@ -275,7 +276,7 @@ function createPRIfMissing(scm, branchName, ticketKey, config) {
 
         console.log('No open PR/MR found — creating one...');
         var ticket;
-        try { ticket = jira_get_ticket({ key: ticketKey }); } catch (e) { ticket = null; }
+        try { ticket = tracker_get_ticket({ key: ticketKey }); } catch (e) { ticket = null; }
         const summary = ticket && ticket.fields ? (ticket.fields.summary || ticketKey) : ticketKey;
         const prTitle = ticketKey + ' ' + summary;
 
@@ -387,7 +388,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const ticketKey = actualParams.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params);
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
     var scm = configLoader.createScm(config);
     const customParams = resolveCustomParams(params, actualParams, config);
     const removeLabel = customParams && customParams.removeLabel;
@@ -396,10 +397,10 @@ function action(params) {
         : 'pr_test_automation_rework_wip';
 
     function releaseLock() {
-        try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
+        try { trackerHelper.removeLabel(ticketKey, wipLabel); } catch (e) {}
         if (removeLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: removeLabel });
+                trackerHelper.removeLabel(ticketKey, removeLabel);
                 console.log('✅ Removed SM label:', removeLabel);
             } catch (e) {}
         }
@@ -417,7 +418,7 @@ function action(params) {
                 : 'outputs/test_automation_result.json is missing required "status" field (got: ' + JSON.stringify(result) + '). The agent must write { "status": "passed" | "failed", ... }.';
             console.error(errMsg);
             try {
-                jira_post_comment({
+                tracker_post_comment({
                     key: ticketKey,
                     comment: 'h3. ⚠️ Rework Error\n\n' + errMsg + '\n\nCheck CI logs for the agent output.'
                 });
@@ -481,7 +482,7 @@ function action(params) {
             if (resume.attempted) {
                 return action(params);
             }
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. ❌ Rework Push Failed\n\n{code}' + e.toString() + '{code}'
             });
@@ -516,9 +517,9 @@ function action(params) {
 
         // Step 4: Move ticket to In Review - Passed or In Review - Failed
         // Bug creation/linking is handled by the bug_creation agent when TC reaches Failed status
-        const targetStatus = passed ? jiraConfig.statuses.IN_REVIEW_PASSED : jiraConfig.statuses.IN_REVIEW_FAILED;
+        const targetStatus = passed ? trackerConfig.statuses.IN_REVIEW_PASSED : trackerConfig.statuses.IN_REVIEW_FAILED;
         try {
-            jira_move_to_status({ key: ticketKey, statusName: targetStatus });
+            tracker_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);
         } catch (e) {
             console.warn('Failed to move ticket status:', e);
@@ -532,7 +533,7 @@ function action(params) {
             comment += '*Branch*: {code}' + branchName + '{code}\n';
             if (pr) comment += '*Pull Request*: ' + pr.html_url + '\n';
             comment += '\n' + fixSummary;
-            jira_post_comment({ key: ticketKey, comment: comment });
+            tracker_post_comment({ key: ticketKey, comment: comment });
         } catch (e) {
             console.warn('Failed to post Jira comment:', e);
         }
@@ -595,7 +596,7 @@ function action(params) {
                 if (resume.attempted) {
                     return action(params);
                 }
-                jira_post_comment({
+                tracker_post_comment({
                     key: key,
                     comment: 'h3. ❌ Test Rework Error\n\n{code}' + error.toString() + '{code}'
                 });

--- a/js/postTestReworkResults.js
+++ b/js/postTestReworkResults.js
@@ -14,7 +14,7 @@ var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
 var feedbackLoop = require('./common/feedbackLoop.js');
 var prHelper = require('./common/pullRequest.js');
-const { GIT_CONFIG, STATUSES, LABELS } = require('./config.js');
+const { GIT_CONFIG, LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function cleanCommandOutput(output) {
@@ -387,6 +387,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const ticketKey = actualParams.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = configLoader.createScm(config);
     const customParams = resolveCustomParams(params, actualParams, config);
     const removeLabel = customParams && customParams.removeLabel;
@@ -515,7 +516,7 @@ function action(params) {
 
         // Step 4: Move ticket to In Review - Passed or In Review - Failed
         // Bug creation/linking is handled by the bug_creation agent when TC reaches Failed status
-        const targetStatus = passed ? STATUSES.IN_REVIEW_PASSED : STATUSES.IN_REVIEW_FAILED;
+        const targetStatus = passed ? jiraConfig.statuses.IN_REVIEW_PASSED : jiraConfig.statuses.IN_REVIEW_FAILED;
         try {
             jira_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);

--- a/js/preCliTestReworkSetup.js
+++ b/js/preCliTestReworkSetup.js
@@ -80,7 +80,7 @@ function action(params) {
                 const err = 'No test PR and no remote branch found for ' + testBranchName + '. Moving to Backlog for re-automation.';
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err });
-                    jira_move_to_status({ key: ticketKey, statusName: 'Backlog' });
+                    jira_move_to_status({ key: ticketKey, statusName: config.jira.statuses.BACKLOG });
                 } catch (e) {}
                 return { success: false, error: err };
             }

--- a/js/preCliTestReworkSetup.js
+++ b/js/preCliTestReworkSetup.js
@@ -9,6 +9,7 @@ const gh = require('./common/githubHelpers.js');
 const gitOps = require('./common/gitOps.js');
 const fetchQuestionsToInput = require('./fetchQuestionsToInput.js');
 const fetchLinkedBugsToInput = require('./fetchLinkedBugsToInput.js');
+var trackerHelper = require('./common/tracker.js');
 
 function findTestPRForTicket(scm, ticketKey) {
     try {
@@ -57,7 +58,7 @@ function action(params) {
         var repoInfo = scm.getRemoteRepoInfo();
         if (!repoInfo) {
             const err = 'Could not determine GitHub repository from git remote';
-            try { jira_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err }); } catch (e) {}
             return { success: false, error: err };
         }
 
@@ -79,8 +80,8 @@ function action(params) {
             if (!branchExists) {
                 const err = 'No test PR and no remote branch found for ' + testBranchName + '. Moving to Backlog for re-automation.';
                 try {
-                    jira_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err });
-                    jira_move_to_status({ key: ticketKey, statusName: config.jira.statuses.BACKLOG });
+                    tracker_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err });
+                    tracker_move_to_status({ key: ticketKey, statusName: config.tracker.statuses.BACKLOG });
                 } catch (e) {}
                 return { success: false, error: err };
             }
@@ -103,7 +104,7 @@ function action(params) {
 
             console.log('Creating PR for rework from existing branch...');
             try {
-                const ticket = jira_get_ticket({ key: ticketKey });
+                const ticket = tracker_get_ticket({ key: ticketKey });
                 const summary = ticket && ticket.fields ? (ticket.fields.summary || ticketKey) : ticketKey;
                 const prTitle = configLoader.formatTemplate(config.formats.prTitle.rework, {ticketKey: ticketKey, ticketSummary: summary});
 
@@ -126,12 +127,12 @@ function action(params) {
                 // PR creation failed — CLI is already on correct branch, postTestReworkResults will create PR
                 console.warn('PR auto-creation failed (CLI will run on correct branch, PR will be created post-rework):', createErr.toString());
                 try {
-                    jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Auto-Creation Warning\n\nBranch {code}' + testBranchName + '{code} is checked out and rework will proceed.\nA PR will be created automatically after rework completes.\n\nError: ' + createErr.toString() });
+                    tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Auto-Creation Warning\n\nBranch {code}' + testBranchName + '{code} is checked out and rework will proceed.\nA PR will be created automatically after rework completes.\n\nError: ' + createErr.toString() });
                 } catch (e) {}
 
                 // Write minimal context so CLI knows what to do
                 try {
-                    const ticket2 = jira_get_ticket({ key: ticketKey });
+                    const ticket2 = tracker_get_ticket({ key: ticketKey });
                     const summary2 = ticket2 && ticket2.fields ? (ticket2.fields.summary || '') : '';
                     gitOps.writePRContext(inputFolder, { number: 0, title: ticketKey + ' ' + summary2, html_url: '' }, '', 'No PR exists yet — re-run tests from scratch on this branch.', []);
                 } catch (e) { console.warn('Could not write fallback context:', e); }
@@ -202,7 +203,7 @@ function action(params) {
             jiraComment += 'AI Teammate is fixing test code issues raised in the review.\n\n' +
                 '_Results will be posted shortly..._';
 
-            jira_post_comment({ key: ticketKey, comment: jiraComment });
+            tracker_post_comment({ key: ticketKey, comment: jiraComment });
         } catch (e) {
             console.warn('Failed to post Jira comment:', e);
         }
@@ -224,7 +225,7 @@ function action(params) {
             const ticketKey = (params.inputFolderPath ||
                 (params.jobParams && params.jobParams.inputFolderPath) || '').split('/').pop();
             if (ticketKey) {
-                jira_post_comment({
+                tracker_post_comment({
                     key: ticketKey,
                     comment: 'h3. ❌ Test Rework Setup Error\n\n{code}' + error.toString() + '{code}'
                 });

--- a/js/prepareTestPRForReview.js
+++ b/js/prepareTestPRForReview.js
@@ -12,6 +12,7 @@ const gh = require('./common/githubHelpers.js');
 const gitOps = require('./common/gitOps.js');
 var prHelper = require('./common/pullRequest.js');
 const { LABELS } = require('./config.js');
+var trackerHelper = require('./common/tracker.js');
 
 function getTicketKey(params) {
     if (params.ticket && params.ticket.key) {
@@ -112,37 +113,37 @@ function isWip(pr, ticket) {
     return false;
 }
 
-function resolveFinalStatus(currentStatus, issueType, jiraConfig) {
+function resolveFinalStatus(currentStatus, issueType, trackerConfig) {
     // Test Cases finish in Passed/Failed; Stories and Bugs stay in In Testing
     // so the done-check agents (checkStoryTestsPassed / checkBugTestsPassed)
     // can evaluate all linked Test Cases and move to Done / Bug To Fix / Ready For Testing.
-    if (issueType === jiraConfig.issueTypes.TEST_CASE) {
-        return currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED
-            ? jiraConfig.statuses.FAILED
-            : jiraConfig.statuses.PASSED;
+    if (issueType === trackerConfig.issueTypes.TEST_CASE) {
+        return currentStatus === trackerConfig.statuses.IN_REVIEW_FAILED
+            ? trackerConfig.statuses.FAILED
+            : trackerConfig.statuses.PASSED;
     }
-    return jiraConfig.statuses.IN_TESTING;
+    return trackerConfig.statuses.IN_TESTING;
 }
 
 function markTestPrMerged(ticketKey) {
     try {
-        jira_add_label({ key: ticketKey, label: LABELS.TEST_PR_MERGED });
+        trackerHelper.addLabel(ticketKey, LABELS.TEST_PR_MERGED);
         console.log('Added label', LABELS.TEST_PR_MERGED, 'to', ticketKey);
     } catch (e) {
         console.warn('Could not add test_pr_merged label:', e);
     }
 }
 
-function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig) {
+function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, trackerConfig) {
     try {
         markTestPrMerged(ticketKey);
-        const ticket = jira_get_ticket({ key: ticketKey });
+        const ticket = tracker_get_ticket({ key: ticketKey });
         const currentStatus = ticket && ticket.fields && ticket.fields.status
             ? ticket.fields.status.name
             : '';
-        const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
-        jira_move_to_status({ key: ticketKey, statusName: finalStatus });
-        jira_post_comment({
+        const finalStatus = resolveFinalStatus(currentStatus, issueType, trackerConfig);
+        tracker_move_to_status({ key: ticketKey, statusName: finalStatus });
+        tracker_post_comment({
             key: ticketKey,
             comment: 'h3. ✅ Test Code Already Merged\n\n' +
                 'Branch {code}' + branchName + '{code} has no commits ahead of main, so the test code is already in main.\n\n' +
@@ -166,7 +167,7 @@ function action(params) {
         const inputFolder = getInputFolder(params, ticketKey);
         const issueType = getIssueType(params);
         var config = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = config.jira;
+        var trackerConfig = config.tracker;
         var scm = configLoader.createScm(config);
 
         console.log('=== Preparing test PR for review:', ticketKey, '===');
@@ -178,7 +179,7 @@ function action(params) {
         var repoInfo = scm.getRemoteRepoInfo();
         if (!repoInfo) {
             const err = 'Could not determine repository from git remote';
-            try { jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Review cancelled._' }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Review cancelled._' }); } catch (e) {}
             return false;
         }
 
@@ -200,8 +201,8 @@ function action(params) {
                 // No branch at all — needs re-automation from scratch
                 const err = 'No test PR and no remote branch found for test/' + ticketKey + '. Ticket needs re-automation.';
                 try {
-                    jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Moving to In Rework so it can be re-automated._' });
-                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+                    tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Moving to In Rework so it can be re-automated._' });
+                    tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
                 } catch (e) {}
                 return false;
             }
@@ -209,7 +210,7 @@ function action(params) {
             // Branch exists — create a new PR/MR so review can proceed
             console.log('Branch exists but no PR — creating PR for review...');
             try {
-                const ticket = jira_get_ticket({ key: ticketKey });
+                const ticket = tracker_get_ticket({ key: ticketKey });
                 const summary = ticket && ticket.fields ? (ticket.fields.summary || ticketKey) : ticketKey;
                 const prTitle = configLoader.formatTemplate(config.formats.prTitle.testAutomation, {ticketKey: ticketKey, ticketSummary: summary});
 
@@ -233,11 +234,11 @@ function action(params) {
             } catch (createErr) {
                 if (isNoCommitsError(createErr)) {
                     console.log('Branch test/' + ticketKey + ' has no commits ahead of main — test code is already merged.');
-                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig);
+                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, trackerConfig);
                     return false;
                 }
                 const err = 'Branch test/' + ticketKey + ' exists but could not create PR: ' + createErr.toString();
-                try { jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Review cancelled._' }); } catch (e) {}
+                try { tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Review cancelled._' }); } catch (e) {}
                 return false;
             }
         }
@@ -247,12 +248,12 @@ function action(params) {
             const pr = found.pr;
             markTestPrMerged(ticketKey);
             try {
-                const ticket = jira_get_ticket({ key: ticketKey });
+                const ticket = tracker_get_ticket({ key: ticketKey });
                 const currentStatus = ticket && ticket.fields && ticket.fields.status
                     ? ticket.fields.status.name : '';
-                const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
-                jira_move_to_status({ key: ticketKey, statusName: finalStatus });
-                jira_post_comment({
+                const finalStatus = resolveFinalStatus(currentStatus, issueType, trackerConfig);
+                tracker_move_to_status({ key: ticketKey, statusName: finalStatus });
+                tracker_post_comment({
                     key: ticketKey,
                     comment: 'h3. ✅ Test PR Already Merged\n\n' +
                         'PR [#' + pr.number + '|' + pr.html_url + '] for branch {code}test/' + ticketKey + '{code} was already merged.\n\n' +
@@ -271,7 +272,7 @@ function action(params) {
         if (isWip(pr, params.ticket)) {
             console.log('PR #' + pr.number + ' is WIP/draft — skipping review for', ticketKey);
             try {
-                jira_post_comment({
+                tracker_post_comment({
                     key: ticketKey,
                     comment: 'h3. ⏸️ Test PR Review Skipped\n\nPR [#' + pr.number + '|' + (pr.html_url || '') + '] is WIP/draft. Review will run once it is ready.'
                 });
@@ -282,7 +283,7 @@ function action(params) {
         // Step 3: PR details
         const prDetails = gh.getPRDetails(scm, pr.number);
         if (!prDetails) {
-            try { jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\nCould not fetch details for PR #' + pr.number + '.\n\n_Review cancelled._' }); } catch (e) {}
+            try { tracker_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\nCould not fetch details for PR #' + pr.number + '.\n\n_Review cancelled._' }); } catch (e) {}
             return false;
         }
 
@@ -292,7 +293,7 @@ function action(params) {
         var changedFiles = prDetails.changed_files;
         if (typeof changedFiles === 'number' && changedFiles === 0) {
             console.log('PR #' + pr.number + ' has 0 changed files — test code is already in main');
-            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType, jiraConfig);
+            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType, trackerConfig);
             return false;
         }
 
@@ -317,7 +318,7 @@ function action(params) {
 
         // Step 7: Jira comment
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. 🧪 Automated Test PR Review Started\n\n' +
                     '*Pull Request*: [PR #' + prDetails.number + '|' + prDetails.html_url + ']\n' +
@@ -344,7 +345,7 @@ function action(params) {
         console.error('❌ Error in prepareTestPRForReview:', error);
         try {
             const ticketKey = getTicketKey(params);
-            jira_post_comment({
+            tracker_post_comment({
                 key: ticketKey,
                 comment: 'h3. ❌ Test PR Review Setup Error\n\n{code}' + error.toString() + '{code}'
             });

--- a/js/prepareTestPRForReview.js
+++ b/js/prepareTestPRForReview.js
@@ -11,7 +11,7 @@ var configLoader = require('./configLoader.js');
 const gh = require('./common/githubHelpers.js');
 const gitOps = require('./common/gitOps.js');
 var prHelper = require('./common/pullRequest.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 
 function getTicketKey(params) {
     if (params.ticket && params.ticket.key) {
@@ -112,14 +112,16 @@ function isWip(pr, ticket) {
     return false;
 }
 
-function resolveFinalStatus(currentStatus, issueType) {
+function resolveFinalStatus(currentStatus, issueType, jiraConfig) {
     // Test Cases finish in Passed/Failed; Stories and Bugs stay in In Testing
     // so the done-check agents (checkStoryTestsPassed / checkBugTestsPassed)
     // can evaluate all linked Test Cases and move to Done / Bug To Fix / Ready For Testing.
-    if (issueType === 'Test Case') {
-        return currentStatus === 'In Review - Failed' ? 'Failed' : 'Passed';
+    if (issueType === jiraConfig.issueTypes.TEST_CASE) {
+        return currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED
+            ? jiraConfig.statuses.FAILED
+            : jiraConfig.statuses.PASSED;
     }
-    return STATUSES.IN_TESTING;
+    return jiraConfig.statuses.IN_TESTING;
 }
 
 function markTestPrMerged(ticketKey) {
@@ -131,14 +133,14 @@ function markTestPrMerged(ticketKey) {
     }
 }
 
-function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType) {
+function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig) {
     try {
         markTestPrMerged(ticketKey);
         const ticket = jira_get_ticket({ key: ticketKey });
         const currentStatus = ticket && ticket.fields && ticket.fields.status
             ? ticket.fields.status.name
             : '';
-        const finalStatus = resolveFinalStatus(currentStatus, issueType);
+        const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
         jira_move_to_status({ key: ticketKey, statusName: finalStatus });
         jira_post_comment({
             key: ticketKey,
@@ -164,6 +166,7 @@ function action(params) {
         const inputFolder = getInputFolder(params, ticketKey);
         const issueType = getIssueType(params);
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var scm = configLoader.createScm(config);
 
         console.log('=== Preparing test PR for review:', ticketKey, '===');
@@ -198,7 +201,7 @@ function action(params) {
                 const err = 'No test PR and no remote branch found for test/' + ticketKey + '. Ticket needs re-automation.';
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Moving to In Rework so it can be re-automated._' });
-                    jira_move_to_status({ key: ticketKey, statusName: 'In Rework' });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 } catch (e) {}
                 return false;
             }
@@ -230,7 +233,7 @@ function action(params) {
             } catch (createErr) {
                 if (isNoCommitsError(createErr)) {
                     console.log('Branch test/' + ticketKey + ' has no commits ahead of main — test code is already merged.');
-                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType);
+                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig);
                     return false;
                 }
                 const err = 'Branch test/' + ticketKey + ' exists but could not create PR: ' + createErr.toString();
@@ -247,7 +250,7 @@ function action(params) {
                 const ticket = jira_get_ticket({ key: ticketKey });
                 const currentStatus = ticket && ticket.fields && ticket.fields.status
                     ? ticket.fields.status.name : '';
-                const finalStatus = resolveFinalStatus(currentStatus, issueType);
+                const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
                 jira_move_to_status({ key: ticketKey, statusName: finalStatus });
                 jira_post_comment({
                     key: ticketKey,
@@ -289,7 +292,7 @@ function action(params) {
         var changedFiles = prDetails.changed_files;
         if (typeof changedFiles === 'number' && changedFiles === 0) {
             console.log('PR #' + pr.number + ' has 0 changed files — test code is already in main');
-            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType);
+            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType, jiraConfig);
             return false;
         }
 

--- a/js/recoverDirtyReviewTestCase.js
+++ b/js/recoverDirtyReviewTestCase.js
@@ -14,6 +14,7 @@
 
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
+var trackerHelper = require('./common/tracker.js');
 
 var PR_CACHE_FILE = 'outputs/.recover_dirty_prs_cache.json';
 var PR_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -101,7 +102,7 @@ function findOpenPRForTicket(scm, config, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -145,7 +146,7 @@ function action(params) {
 
     console.log('PR #' + pr.number + ' is dirty — moving ticket to In Rework for conflict resolution');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
         console.log('Moved', ticketKey, 'to In Rework');
     } catch (e) {
         console.error('Failed to move to In Rework:', e);
@@ -153,12 +154,12 @@ function action(params) {
     }
 
     // Remove stale labels so the rework agent can pick it up
-    try { jira_remove_label({ key: ticketKey, label: 'sm_test_rework_triggered' }); } catch (e) {}
-    try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-    try { jira_remove_label({ key: ticketKey, label: 'sm_test_review_triggered' }); } catch (e) {}
+    try { trackerHelper.removeLabel(ticketKey, 'sm_test_rework_triggered'); } catch (e) {}
+    try { trackerHelper.removeLabel(ticketKey, 'sm_test_automation_triggered'); } catch (e) {}
+    try { trackerHelper.removeLabel(ticketKey, 'sm_test_review_triggered'); } catch (e) {}
 
     try {
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: '🔄 *Recovery*: Test Case PR #' + pr.number + ' became dirty while in code review. Moved to In Rework so the test-automation rework agent can resolve the merge conflicts.'
         });

--- a/js/recoverDirtyReviewTestCase.js
+++ b/js/recoverDirtyReviewTestCase.js
@@ -14,7 +14,6 @@
 
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
-var { STATUSES } = require('./config.js');
 
 var PR_CACHE_FILE = 'outputs/.recover_dirty_prs_cache.json';
 var PR_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -102,6 +101,7 @@ function findOpenPRForTicket(scm, config, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
+    var jiraConfig = config.jira;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -145,7 +145,7 @@ function action(params) {
 
     console.log('PR #' + pr.number + ' is dirty — moving ticket to In Rework for conflict resolution');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('Moved', ticketKey, 'to In Rework');
     } catch (e) {
         console.error('Failed to move to In Rework:', e);

--- a/js/recoverFailedTCBugStatus.js
+++ b/js/recoverFailedTCBugStatus.js
@@ -7,7 +7,7 @@
  * new bug creation.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function removeLabel(ticketKey, label) {
@@ -23,11 +23,13 @@ function action(params) {
     if (!ticketKey) {
         throw new Error('params.ticket.key is missing');
     }
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
 
     console.log('=== Failed TC bug status recovery for', ticketKey, '===');
 
     var linkedBugs = jira_search_by_jql({
-        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in (Done)',
+        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in ("' + jiraConfig.statuses.DONE + '")',
         maxResults: 50
     }) || [];
 
@@ -41,8 +43,8 @@ function action(params) {
         return { success: true, action: 'released_for_bulk_bug_creation', ticketKey: ticketKey };
     }
 
-    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BUG_TO_FIX });
-    console.log('Moved', ticketKey, 'to', STATUSES.BUG_TO_FIX);
+    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
+    console.log('Moved', ticketKey, 'to', jiraConfig.statuses.BUG_TO_FIX);
 
     removeLabel(ticketKey, 'sm_bug_creation_triggered');
     removeLabel(ticketKey, 'sm_bulk_bugs_creation_triggered');
@@ -52,7 +54,7 @@ function action(params) {
         key: ticketKey,
         comment: 'h3. 🐛 Linked Non-Done Bug Found — Moved to Bug To Fix\n\n' +
             'This failed test case already has linked non-Done Bug issue(s), so it was moved to *' +
-            STATUSES.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
+            jiraConfig.statuses.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
     });
 
     // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider

--- a/js/recoverMergedPRTicket.js
+++ b/js/recoverMergedPRTicket.js
@@ -3,7 +3,7 @@
  * a review/rework status.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
@@ -68,6 +68,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var pr = findMergedPRForTicket(scm, ticketKey);
 
@@ -81,8 +82,8 @@ function action(params) {
     console.log('Recovered merged PR #' + prNumber + ' for ' + ticketKey);
 
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.MERGED });
-        console.log('Moved', ticketKey, 'to', STATUSES.MERGED);
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
+        console.log('Moved', ticketKey, 'to', jiraConfig.statuses.MERGED);
     } catch (e) {
         console.warn('Could not move ticket to Merged:', e.message || e);
     }
@@ -97,7 +98,7 @@ function action(params) {
             key: ticketKey,
             comment: 'h3. ✅ Merged PR Recovered\n\n' +
                 'Found already merged PR #' + prNumber + (prUrl ? ' — [View PR|' + prUrl + ']' : '') +
-                '. Ticket moved to *' + STATUSES.MERGED + '* so the normal post-merge pipeline can continue.'
+                '. Ticket moved to *' + jiraConfig.statuses.MERGED + '* so the normal post-merge pipeline can continue.'
         });
     } catch (e) {}
 

--- a/js/recoverMergedPRTicket.js
+++ b/js/recoverMergedPRTicket.js
@@ -7,6 +7,7 @@ const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function prMatchesTicket(pr, ticketKey) {
     if (!pr || !ticketKey) return false;
@@ -55,7 +56,7 @@ function findMergedPRForTicket(scm, ticketKey) {
 function removeLabel(ticketKey, label) {
     if (!ticketKey || !label) return;
     try {
-        jira_remove_label({ key: ticketKey, label: label });
+        trackerHelper.removeLabel(ticketKey, label);
         console.log('Removed label from Jira:', label);
     } catch (e) {}
 }
@@ -68,7 +69,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
     var scm = scmModule.createScm(config);
     var pr = findMergedPRForTicket(scm, ticketKey);
 
@@ -82,8 +83,8 @@ function action(params) {
     console.log('Recovered merged PR #' + prNumber + ' for ' + ticketKey);
 
     try {
-        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
-        console.log('Moved', ticketKey, 'to', jiraConfig.statuses.MERGED);
+        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.MERGED });
+        console.log('Moved', ticketKey, 'to', trackerConfig.statuses.MERGED);
     } catch (e) {
         console.warn('Could not move ticket to Merged:', e.message || e);
     }
@@ -94,11 +95,11 @@ function action(params) {
     removeLabel(ticketKey, 'sm_story_rework_triggered');
 
     try {
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: 'h3. ✅ Merged PR Recovered\n\n' +
                 'Found already merged PR #' + prNumber + (prUrl ? ' — [View PR|' + prUrl + ']' : '') +
-                '. Ticket moved to *' + jiraConfig.statuses.MERGED + '* so the normal post-merge pipeline can continue.'
+                '. Ticket moved to *' + trackerConfig.statuses.MERGED + '* so the normal post-merge pipeline can continue.'
         });
     } catch (e) {}
 

--- a/js/recoverStuckTestCase.js
+++ b/js/recoverStuckTestCase.js
@@ -19,7 +19,7 @@
 
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function findPRForTicket(scm, ticketKey) {
@@ -40,6 +40,7 @@ function findPRForTicket(scm, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
+    var jiraConfig = config.jira;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -54,7 +55,7 @@ function action(params) {
     if (!pr) {
         console.log('No open PR found for', ticketKey, '— moving back to Backlog');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
             console.log('✅ Moved', ticketKey, 'to Backlog');
         } catch (e) {
             console.error('Failed to move to Backlog:', e);
@@ -86,7 +87,7 @@ function action(params) {
     if (mergeableState === 'dirty' || mergeableState === 'conflicting' || mergeable === false) {
         console.log('PR has conflicts — moving ticket to In Rework');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
             console.log('✅ Moved', ticketKey, 'to In Rework');
         } catch (e) {
             console.error('Failed to move to In Rework:', e);
@@ -104,7 +105,7 @@ function action(params) {
     // PR is clean/mergeable — move to In Review - Passed for review
     console.log('PR looks clean — moving ticket to In Review - Passed');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REVIEW_PASSED });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REVIEW_PASSED });
         console.log('✅ Moved', ticketKey, 'to In Review - Passed');
     } catch (e) {
         console.error('Failed to move to In Review - Passed:', e);

--- a/js/recoverStuckTestCase.js
+++ b/js/recoverStuckTestCase.js
@@ -21,6 +21,7 @@ var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function findPRForTicket(scm, ticketKey) {
     try {
@@ -40,7 +41,7 @@ function findPRForTicket(scm, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -55,14 +56,14 @@ function action(params) {
     if (!pr) {
         console.log('No open PR found for', ticketKey, '— moving back to Backlog');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
+            tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.BACKLOG });
             console.log('✅ Moved', ticketKey, 'to Backlog');
         } catch (e) {
             console.error('Failed to move to Backlog:', e);
         }
         // Remove automation label so SM can re-trigger
-        try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-        jira_post_comment({
+        try { trackerHelper.removeLabel(ticketKey, 'sm_test_automation_triggered'); } catch (e) {}
+        tracker_post_comment({
             key: ticketKey,
             comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with no open PR. Moved back to Backlog for re-automation.'
         });
@@ -87,15 +88,15 @@ function action(params) {
     if (mergeableState === 'dirty' || mergeableState === 'conflicting' || mergeable === false) {
         console.log('PR has conflicts — moving ticket to In Rework');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+            tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
             console.log('✅ Moved', ticketKey, 'to In Rework');
         } catch (e) {
             console.error('Failed to move to In Rework:', e);
         }
         // Remove stale labels so rework agent can pick it up
-        try { jira_remove_label({ key: ticketKey, label: 'sm_test_rework_triggered' }); } catch (e) {}
-        try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-        jira_post_comment({
+        try { trackerHelper.removeLabel(ticketKey, 'sm_test_rework_triggered'); } catch (e) {}
+        try { trackerHelper.removeLabel(ticketKey, 'sm_test_automation_triggered'); } catch (e) {}
+        tracker_post_comment({
             key: ticketKey,
             comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with a conflicting PR #' + pr.number + '. Moved to In Rework for conflict resolution.'
         });
@@ -105,13 +106,13 @@ function action(params) {
     // PR is clean/mergeable — move to In Review - Passed for review
     console.log('PR looks clean — moving ticket to In Review - Passed');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REVIEW_PASSED });
+        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REVIEW_PASSED });
         console.log('✅ Moved', ticketKey, 'to In Review - Passed');
     } catch (e) {
         console.error('Failed to move to In Review - Passed:', e);
     }
-    try { jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' }); } catch (e) {}
-    jira_post_comment({
+    try { trackerHelper.removeLabel(ticketKey, 'sm_test_automation_triggered'); } catch (e) {}
+    tracker_post_comment({
         key: ticketKey,
         comment: '🔄 *Recovery*: Test Case was stuck in "In Development" with clean PR #' + pr.number + '. Moved to In Review - Passed for code review.'
     });

--- a/js/retryMergePR.js
+++ b/js/retryMergePR.js
@@ -15,6 +15,7 @@ var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function getGitHubRepoInfo() {
     try {
@@ -54,7 +55,7 @@ function removeApprovedLabels(scm, prNumber, ticketKey) {
         console.warn('Could not remove pr_approved from PR:', e);
     }
     try {
-        jira_remove_label({ key: ticketKey, label: LABELS.PR_APPROVED });
+        trackerHelper.removeLabel(ticketKey, LABELS.PR_APPROVED);
         console.log('Removed pr_approved label from Jira ticket');
     } catch (e) {
         console.warn('Could not remove pr_approved from Jira ticket:', e);
@@ -64,7 +65,7 @@ function removeApprovedLabels(scm, prNumber, ticketKey) {
 function releaseLock(ticketKey, customParams) {
     const removeLabel = customParams && customParams.removeLabel;
     if (removeLabel && ticketKey) {
-        try { jira_remove_label({ key: ticketKey, label: removeLabel }); } catch (e) {}
+        try { trackerHelper.removeLabel(ticketKey, removeLabel); } catch (e) {}
     }
 }
 
@@ -122,7 +123,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
-    var jiraConfig = config.jira;
+    var trackerConfig = config.tracker;
     var scm = scmModule.createScm(config);
     var customParams = resolveCustomParams(params, config);
 
@@ -194,11 +195,11 @@ function action(params) {
         console.log('PR has merge conflict — moving ticket to In Rework');
         removeApprovedLabels(scm, prNumber, ticketKey);
         releaseLock(ticketKey, customParams);
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE CONFLICT* — PR #' + prNumber + ' has a merge conflict with main. Please resolve conflicts and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (merge conflict)');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
         return true;
@@ -225,19 +226,19 @@ function action(params) {
         // the review-trigger rule (JQL: NOT IN pr_approved) naturally skips the ticket.
         const isTestCase = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.testCaseMerge;
         if (isTestCase) {
-            var ticketDetail = jira_get_ticket({ key: ticketKey });
+            var ticketDetail = tracker_get_ticket({ key: ticketKey });
             var currentStatus = ticketDetail && ticketDetail.fields && ticketDetail.fields.status && ticketDetail.fields.status.name;
-            var finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
-            jira_move_to_status({ key: ticketKey, statusName: finalStatus });
+            var finalStatus = (currentStatus === trackerConfig.statuses.IN_REVIEW_PASSED) ? trackerConfig.statuses.PASSED : trackerConfig.statuses.FAILED;
+            tracker_move_to_status({ key: ticketKey, statusName: finalStatus });
             console.log('✅ Ticket moved to ' + finalStatus);
         } else {
-            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
+            tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.MERGED });
             console.log('✅ Ticket moved to Merged');
         }
 
         // Now safe to remove pr_approved from Jira — status is already updated
         try {
-            jira_remove_label({ key: ticketKey, label: LABELS.PR_APPROVED });
+            trackerHelper.removeLabel(ticketKey, LABELS.PR_APPROVED);
             console.log('Removed pr_approved label from Jira ticket');
         } catch (e) {
             console.warn('Could not remove pr_approved from Jira ticket:', e);
@@ -258,11 +259,11 @@ function action(params) {
         const reason = isConflict ? 'merge conflict' : 'CI checks failing or PR not mergeable';
         removeApprovedLabels(scm, prNumber, ticketKey);
         releaseLock(ticketKey, customParams);
-        jira_post_comment({
+        tracker_post_comment({
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE FAILED* — Could not merge PR #' + prNumber + ': ' + reason + '. Please check and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+        tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (' + reason + ')');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
 

--- a/js/retryMergePR.js
+++ b/js/retryMergePR.js
@@ -10,7 +10,7 @@
  *  - Conflict / CI failing    → remove pr_approved label, move ticket to In Rework, post comment
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
@@ -122,6 +122,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var customParams = resolveCustomParams(params, config);
 
@@ -197,7 +198,7 @@ function action(params) {
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE CONFLICT* — PR #' + prNumber + ' has a merge conflict with main. Please resolve conflicts and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (merge conflict)');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
         return true;
@@ -226,11 +227,11 @@ function action(params) {
         if (isTestCase) {
             var ticketDetail = jira_get_ticket({ key: ticketKey });
             var currentStatus = ticketDetail && ticketDetail.fields && ticketDetail.fields.status && ticketDetail.fields.status.name;
-            var finalStatus = (currentStatus === STATUSES.IN_REVIEW_PASSED) ? STATUSES.PASSED : STATUSES.FAILED;
+            var finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
             jira_move_to_status({ key: ticketKey, statusName: finalStatus });
             console.log('✅ Ticket moved to ' + finalStatus);
         } else {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.MERGED });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
             console.log('✅ Ticket moved to Merged');
         }
 
@@ -261,7 +262,7 @@ function action(params) {
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE FAILED* — Could not merge PR #' + prNumber + ': ' + reason + '. Please check and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (' + reason + ')');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
 

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -6,7 +6,7 @@
 var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
 var prHelper = require('./common/pullRequest.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function smLabelForContext(contextId) {
@@ -204,6 +204,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const storyKey = actualParams.ticket.key;
     const config = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = config.jira;
     const scm = configLoader.createScm(config);
     const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
     const contextId = actualParams.metadata && actualParams.metadata.contextId;
@@ -274,8 +275,8 @@ function action(params) {
 
         // Step 3: Move Story back to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -8,6 +8,7 @@ var autoStart = require('./common/autoStart.js');
 var prHelper = require('./common/pullRequest.js');
 const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function smLabelForContext(contextId) {
     if (!contextId) return null;
@@ -204,7 +205,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const storyKey = actualParams.ticket.key;
     const config = configLoader.loadProjectConfig(params.jobParams || params);
-    const jiraConfig = config.jira;
+    const trackerConfig = config.tracker;
     const scm = configLoader.createScm(config);
     const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
     const contextId = actualParams.metadata && actualParams.metadata.contextId;
@@ -213,15 +214,15 @@ function action(params) {
 
     function releaseWipLock() {
         if (wipLabel) {
-            try { jira_remove_label({ key: storyKey, label: wipLabel }); } catch (e) {}
+            try { trackerHelper.removeLabel(storyKey, wipLabel); } catch (e) {}
         } else {
             // If contextId is missing, clean up both known WIP labels defensively.
-            try { jira_remove_label({ key: storyKey, label: 'story_test_automation_rework_wip' }); } catch (e) {}
-            try { jira_remove_label({ key: storyKey, label: 'bug_test_automation_rework_wip' }); } catch (e) {}
+            try { trackerHelper.removeLabel(storyKey, 'story_test_automation_rework_wip'); } catch (e) {}
+            try { trackerHelper.removeLabel(storyKey, 'bug_test_automation_rework_wip'); } catch (e) {}
         }
         if (removeLabel) {
             try {
-                jira_remove_label({ key: storyKey, label: removeLabel });
+                trackerHelper.removeLabel(storyKey, removeLabel);
                 console.log('✅ Removed SM label:', removeLabel);
             } catch (e) {}
         }
@@ -230,7 +231,7 @@ function action(params) {
     function releaseLock() {
         releaseWipLock();
         try {
-            jira_remove_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED });
+            trackerHelper.removeLabel(storyKey, LABELS.TEST_PR_REWORK_NEEDED);
             console.log('✅ Removed test_pr_rework_needed label');
         } catch (e) {}
 
@@ -254,7 +255,7 @@ function action(params) {
             branchName = commitAndPush(storyKey, config);
         } catch (e) {
             console.error('Git operations failed:', e);
-            jira_post_comment({
+            tracker_post_comment({
                 key: storyKey,
                 comment: 'h3. ❌ Story Test Rework Push Failed\n\n{code}' + e.toString() + '{code}'
             });
@@ -275,8 +276,8 @@ function action(params) {
 
         // Step 3: Move Story back to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
+            tracker_move_to_status({ key: storyKey, statusName: trackerConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', trackerConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }
@@ -287,7 +288,7 @@ function action(params) {
             comment += '*Branch*: {code}' + branchName + '{code}\n';
             if (pr) comment += '*Pull Request*: ' + pr.html_url + '\n';
             comment += '\n' + fixSummary;
-            jira_post_comment({ key: storyKey, comment: comment });
+            tracker_post_comment({ key: storyKey, comment: comment });
         } catch (e) {
             console.warn('Failed to post Jira comment:', e);
         }
@@ -328,7 +329,7 @@ function action(params) {
     } catch (error) {
         console.error('❌ Error in storyTestAutomationRework:', error);
         try {
-            jira_post_comment({
+            tracker_post_comment({
                 key: storyKey,
                 comment: 'h3. ❌ Story Test Rework Error\n\n{code}' + error.toString() + '{code}'
             });

--- a/js/unblockResolvedDependencies.js
+++ b/js/unblockResolvedDependencies.js
@@ -8,25 +8,17 @@
  * - Otherwise leaves the ticket in Blocked.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
-const TERMINAL_STATUSES = [
-    STATUSES.DONE,
-    STATUSES.MERGED,
-    STATUSES.PASSED,
-    'Closed',
-    'Irrelevant'
-];
-
-function isResolved(blocker) {
+function isResolved(blocker, terminalStatuses) {
     // Deleted ticket — no inwardIssue object at all
     if (!blocker) return true;
 
     var statusName = blocker.fields && blocker.fields.status && blocker.fields.status.name;
     if (!statusName) return false;
 
-    return TERMINAL_STATUSES.indexOf(statusName) !== -1;
+    return terminalStatuses.indexOf(statusName) !== -1;
 }
 
 function action(params) {
@@ -35,6 +27,15 @@ function action(params) {
         console.error('No ticket key provided');
         return { success: false, action: 'missing_ticket' };
     }
+
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
+    var terminalStatuses = [
+        jiraConfig.statuses.DONE,
+        jiraConfig.statuses.MERGED,
+        jiraConfig.statuses.PASSED,
+        jiraConfig.statuses.IRRELEVANT
+    ].filter(Boolean);
 
     console.log('=== Unblock resolved dependencies check for', ticketKey, '===');
 
@@ -64,7 +65,7 @@ function action(params) {
     if (blockers.length === 0) {
         console.log('No active blockers found — moving', ticketKey, 'to Backlog');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
             jira_post_comment({
                 key: ticketKey,
                 comment: 'h3. ✅ Auto-unblocked — No Active Blockers\n\n' +
@@ -85,7 +86,7 @@ function action(params) {
         var b = blockers[j];
         var bKey = b.key || '?';
         var bStatus = b.fields && b.fields.status && b.fields.status.name || 'Unknown';
-        if (isResolved(b)) {
+        if (isResolved(b, terminalStatuses)) {
             console.log('  Blocker', bKey, 'is resolved (', bStatus, ')');
         } else {
             console.log('  Blocker', bKey, 'is NOT resolved (', bStatus, ')');
@@ -101,7 +102,7 @@ function action(params) {
     // All blockers resolved → move to Backlog
     console.log('All', blockers.length, 'blocker(s) resolved — moving', ticketKey, 'to Backlog');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
     } catch (e) {
         console.warn('Failed to move ticket to Backlog:', e.message || e);
         return { success: false, action: 'move_failed', error: e.toString() };

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -14,7 +14,7 @@
  *                   Useful for tickets (e.g. bugs) where the field already has content that must be preserved.
  */
 
-const { LABELS, DIAGRAM_FORMAT, JIRA_FIELDS, STATUSES } = require('./config.js');
+const { LABELS, DIAGRAM_FORMAT, JIRA_FIELDS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
@@ -32,6 +32,7 @@ function action(params) {
         // Resolve field names from customParams if provided
         var customParams = (params.customParams) || (params.jobParams && params.jobParams.customParams) || {};
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var solutionField = customParams.solutionField || JIRA_FIELDS.SOLUTION;
         var diagramField  = (customParams.diagramField !== undefined) ? customParams.diagramField : JIRA_FIELDS.DIAGRAMS;
         var outputType    = customParams.outputType || 'replace'; // 'replace' | 'append'
@@ -122,7 +123,7 @@ function action(params) {
 
         // 7. Move to Ready For Development
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.READY_FOR_DEVELOPMENT });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.READY_FOR_DEVELOPMENT });
             console.log('Moved ' + ticketKey + ' to Ready For Development');
         } catch (e) {
             console.warn('Failed to move to Ready For Development:', e);

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -20,6 +20,7 @@ const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
 const outputFiles = require('./common/outputFiles.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+var trackerHelper = require('./common/tracker.js');
 
 function action(params) {
     try {
@@ -32,7 +33,7 @@ function action(params) {
         // Resolve field names from customParams if provided
         var customParams = (params.customParams) || (params.jobParams && params.jobParams.customParams) || {};
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-        var jiraConfig = projectConfig.jira;
+        var trackerConfig = projectConfig.tracker;
         var solutionField = customParams.solutionField || JIRA_FIELDS.SOLUTION;
         var diagramField  = (customParams.diagramField !== undefined) ? customParams.diagramField : JIRA_FIELDS.DIAGRAMS;
         var outputType    = customParams.outputType || 'replace'; // 'replace' | 'append'
@@ -78,7 +79,7 @@ function action(params) {
             if (outputType === 'append') {
                 var existing = '';
                 try {
-                    var freshTicket = jira_get_ticket({ key: ticketKey, fields: [solutionField] });
+                    var freshTicket = tracker_get_ticket({ key: ticketKey, fields: [solutionField] });
                     var freshFields = (freshTicket && freshTicket.fields) ? freshTicket.fields : freshTicket;
                     var rawValue = freshFields ? freshFields[solutionField] : null;
                     if (rawValue && typeof rawValue === 'object') {
@@ -96,7 +97,7 @@ function action(params) {
                     : solution;
                 console.log('Appending to "' + solutionField + '" (' + (existing ? existing.length : 0) + ' existing chars)');
             }
-            jira_update_field({ key: ticketKey, field: solutionField, value: valueToWrite });
+            trackerHelper.updateField(ticketKey, solutionField, valueToWrite);
             console.log('Updated "' + solutionField + '" field for ' + ticketKey + ' (mode: ' + outputType + ')');
         } catch (e) {
             console.error('Failed to update solution field "' + solutionField + '":', e);
@@ -106,7 +107,7 @@ function action(params) {
         // 5. Write to diagram field if configured and diagram exists
         if (diagram && diagramField) {
             try {
-                jira_update_field({ key: ticketKey, field: diagramField, value: diagram });
+                trackerHelper.updateField(ticketKey, diagramField, diagram);
                 console.log('Updated "' + diagramField + '" field for ' + ticketKey);
             } catch (e) {
                 console.warn('Failed to update diagram field "' + diagramField + '":', e);
@@ -115,7 +116,7 @@ function action(params) {
 
         // 6. Assign to initiator
         try {
-            jira_assign_ticket_to({ key: ticketKey, accountId: initiatorId });
+            tracker_assign_ticket({ key: ticketKey, accountId: initiatorId });
             console.log('Assigned ' + ticketKey + ' to initiator');
         } catch (e) {
             console.warn('Failed to assign ticket:', e);
@@ -123,7 +124,7 @@ function action(params) {
 
         // 7. Move to Ready For Development
         try {
-            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.READY_FOR_DEVELOPMENT });
+            tracker_move_to_status({ key: ticketKey, statusName: trackerConfig.statuses.READY_FOR_DEVELOPMENT });
             console.log('Moved ' + ticketKey + ' to Ready For Development');
         } catch (e) {
             console.warn('Failed to move to Ready For Development:', e);
@@ -131,7 +132,7 @@ function action(params) {
 
         // 8. Add ai_generated label
         try {
-            jira_add_label({ key: ticketKey, label: LABELS.AI_GENERATED });
+            trackerHelper.addLabel(ticketKey, LABELS.AI_GENERATED);
         } catch (e) {
             console.warn('Failed to add ai_generated label:', e);
         }
@@ -139,7 +140,7 @@ function action(params) {
         // 9. Remove WIP label if present
         if (wipLabel) {
             try {
-                jira_remove_label({ key: ticketKey, label: wipLabel });
+                trackerHelper.removeLabel(ticketKey, wipLabel);
                 console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
             } catch (e) {
                 console.warn('Failed to remove WIP label:', e);


### PR DESCRIPTION
## Summary

- Add `js/common/tracker.js`: thin abstraction for ops with no server-side `tracker_*` alias (`addLabel`, `removeLabel`, `setPriority`, `updateField`, `attachFile`). Dispatches to `jira_*`/`ado_*` based on `DEFAULT_TRACKER`; warns+no-ops for unsupported trackers (Rally) rather than calling wrong tools.
- Update `configLoader.js`: add canonical `config.tracker` section to `DEFAULTS` mirroring `config.jira`; bridge in `loadProjectConfig` keeps existing `.dmtools/config.js` files with `jira:{}` working via aliasing.
- Replace `jira_*` globals with `tracker_*` server aliases across 19 action files (`tracker_move_to_status`, `tracker_post_comment`, `tracker_get_ticket`, etc.).
- Rename `jiraConfig` → `trackerConfig` in local vars and function parameters.
- Fix `checkStoryTestsPassed.js`: double-nesting typo `jiraConfig.jiraConfig.statuses` was always truthy.

> **Depends on #277** — merge that first, then this PR's diff narrows to only the tracker-agnostic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)