### PR TITLE
refactor(agents): replace hardcoded STATUSES/ISSUE_TYPES with project-specific jiraConfig

### DIFF
--- a/js/assignForSolutionArchitecture.js
+++ b/js/assignForSolutionArchitecture.js
@@ -5,7 +5,7 @@
  */
 
 const { extractTicketKey } = require('./common/jiraHelpers.js');
-const { LABELS, STATUSES } = require('./config.js');
+const { LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
@@ -24,6 +24,7 @@ function action(params) {
             ? params.metadata.contextId + '_wip'
             : null;
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
 
         // Assign to initiator (skip if accountId is not available)
@@ -38,11 +39,16 @@ function action(params) {
             }
         }
 
-        // Move to Solution Architecture
-        jira_move_to_status({
-            key: ticketKey,
-            statusName: STATUSES.SOLUTION_ARCHITECTURE
-        });
+        // Move to Solution Architecture — trigger labels are only removed on success
+        try {
+            jira_move_to_status({
+                key: ticketKey,
+                statusName: jiraConfig.statuses.SOLUTION_ARCHITECTURE
+            });
+        } catch (statusError) {
+            console.error('Failed to move ' + ticketKey + ' to Solution Architecture — trigger labels NOT removed:', statusError);
+            throw statusError;
+        }
         console.log('Moved ' + ticketKey + ' to Solution Architecture');
 
         // Add ai_generated label

--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -16,7 +16,7 @@
  *   this check on the next cycle.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 const scmModule = require('./common/scm.js');
@@ -28,8 +28,9 @@ function action(params) {
 
     // Load project config to get issue types (default: "Test Case" / "Bug")
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const testCaseType = projectConfig.jira.issueTypes.TEST_CASE || 'Test Case';
-    const bugType = projectConfig.jira.issueTypes.BUG || 'Bug';
+    const jiraConfig = projectConfig.jira;
+    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
 
     // Helper: remove SM label so the check re-runs on the next SM cycle
     function releaseLock() {
@@ -101,7 +102,7 @@ function action(params) {
         var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
         // Passed / intentionally skipped / no longer applicable are always non-blocking.
-        if (status === STATUSES.PASSED || status === STATUSES.SKIPPED || status === STATUSES.IRRELEVANT) {
+        if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
             return false;
         }
 
@@ -112,7 +113,7 @@ function action(params) {
         // regression TCs TS-501/TS-252 were Bug To Fix). We count *any* other
         // linked Bug (even Done) so stale TCs that were already addressed do not
         // hold the current Bug hostage.
-        if (status === STATUSES.BUG_TO_FIX) {
+        if (status === jiraConfig.statuses.BUG_TO_FIX) {
             var linkedBugs = findLinkedBugs(tc.key);
             var hasOtherBug = linkedBugs.some(function(bug) {
                 var bugStatus = bug.fields && bug.fields.status && bug.fields.status.name;
@@ -173,7 +174,7 @@ function action(params) {
                 var reworkAttempted = labels.indexOf('sm_bug_rework_attempted') !== -1;
                 if (reworkAttempted) {
                     console.log('Test PR finalized and one rework already attempted — moving', ticketKey, 'to Blocked for triage');
-                    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
                     jira_post_comment({
                         key: ticketKey,
                         comment: 'h3. 🚫 Test PR Finalized But Acceptance Tests Still Blocking After Rework\n\n' +
@@ -186,7 +187,7 @@ function action(params) {
                 }
 
                 console.log('Test PR finalized but', blockingCount, 'linked Test Case(s) still block — moving', ticketKey, 'to In Rework (one attempt)');
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 jira_add_label({ key: ticketKey, label: 'sm_bug_rework_attempted' });
                 jira_post_comment({
                     key: ticketKey,
@@ -244,7 +245,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.DONE
+            statusName: jiraConfig.statuses.DONE
         });
 
         // Clean up anti-cycle label on successful completion.

--- a/js/checkBugTestsPassed.js
+++ b/js/checkBugTestsPassed.js
@@ -117,7 +117,7 @@ function action(params) {
             var linkedBugs = findLinkedBugs(tc.key);
             var hasOtherBug = linkedBugs.some(function(bug) {
                 var bugStatus = bug.fields && bug.fields.status && bug.fields.status.name;
-                return bug.key !== ticketKey && bugStatus !== STATUSES.DONE;
+                return bug.key !== ticketKey && bugStatus !== jiraConfig.statuses.DONE;
             });
             if (hasOtherBug) {
                 console.log('TC', tc.key, 'is Bug To Fix but already tracked by another active Bug — treating as non-blocking');

--- a/js/checkBugToFixReady.js
+++ b/js/checkBugToFixReady.js
@@ -15,7 +15,7 @@
  * - Otherwise → releases the SM idempotency label so the check re-runs next cycle.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -24,6 +24,8 @@ function action(params) {
     const issueType = (ticketFields && ticketFields.issuetype && ticketFields.issuetype.name) || 'Test Case';
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     /**
      * DMTools returns issue search results as host objects. In some runtime
@@ -59,7 +61,7 @@ function action(params) {
     function findNotDoneBugs(entityKey) {
         var key = entityKey || ticketKey;
         return toPlain(jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug AND status != "Done"',
+            jql: 'issue in linkedIssues("' + key + '") AND issuetype = Bug AND status != "' + jiraConfig.statuses.DONE + '"',
             maxResults: 50
         })) || [];
     }
@@ -114,7 +116,7 @@ function action(params) {
             return { success: true, action: 'waiting', issueType, total: totalBugs, notDone: notDoneCount, ticketKey };
         }
 
-        if (issueType === 'Story') {
+        if (issueType === jiraConfig.issueTypes.STORY) {
             // Also check bugs linked to linked Test Cases before allowing the Story to re-test.
             const pendingTcBugs = findPendingBugsInLinkedTestCases();
             if (pendingTcBugs.length > 0) {
@@ -132,7 +134,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: STATUSES.READY_FOR_TESTING
+                statusName: jiraConfig.statuses.READY_FOR_TESTING
             });
 
             // Remove the story_done_check lock so it can re-run after the Story returns to In Testing
@@ -159,7 +161,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: STATUSES.BACKLOG
+                statusName: jiraConfig.statuses.BACKLOG
             });
 
             // Remove test automation label so SM can re-trigger automation
@@ -188,7 +190,7 @@ function action(params) {
             console.warn('Failed to post token usage comments:', e);
         }
 
-        return { success: true, action: issueType === 'Story' ? 'moved_to_ready_for_testing' : 'moved_to_backlog', totalBugs: totalBugs, ticketKey };
+        return { success: true, action: issueType === jiraConfig.issueTypes.STORY ? 'moved_to_ready_for_testing' : 'moved_to_backlog', totalBugs: totalBugs, ticketKey };
 
     } catch (error) {
         console.error('❌ Error in checkBugToFixReady:', error);

--- a/js/checkStoryTestsPassed.js
+++ b/js/checkStoryTestsPassed.js
@@ -14,7 +14,6 @@
  *   bugs) → moves the Story back to "Ready For Testing" to trigger a re-run.
  */
 
-const { STATUSES, resolveStatuses } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -22,11 +21,10 @@ function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
-    const statuses = resolveStatuses(customParams);
-
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    const testCaseType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE) || 'Test Case';
-    const bugType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.BUG) || 'Bug';
+    const jiraConfig = projectConfig.jira;
+    const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
+    const bugType = jiraConfig.issueTypes.BUG || 'Bug';
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -69,7 +67,7 @@ function action(params) {
         var bugs = findLinkedBugs(tcKey);
         for (var i = 0; i < bugs.length; i++) {
             var status = bugs[i].fields && bugs[i].fields.status && bugs[i].fields.status.name;
-            if (status !== STATUSES.DONE) {
+            if (status !== jiraConfig.jiraConfig.statuses.DONE) {
                 return bugs[i].key;
             }
         }
@@ -77,10 +75,10 @@ function action(params) {
     }
 
     function isInFlightStatus(status) {
-        return status === statuses.IN_REVIEW_PASSED ||
-            status === statuses.IN_REVIEW_FAILED ||
-            status === statuses.IN_DEVELOPMENT ||
-            status === statuses.READY_FOR_DEVELOPMENT;
+        return status === jiraConfig.statuses.IN_REVIEW_PASSED ||
+            status === jiraConfig.statuses.IN_REVIEW_FAILED ||
+            status === jiraConfig.statuses.IN_DEVELOPMENT ||
+            status === jiraConfig.statuses.READY_FOR_DEVELOPMENT;
     }
 
     try {
@@ -105,7 +103,7 @@ function action(params) {
         allTCs.forEach(function(tc) {
             var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
-            if (status === statuses.PASSED || status === statuses.SKIPPED || status === statuses.IRRELEVANT) {
+            if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
                 return;
             }
 
@@ -120,7 +118,7 @@ function action(params) {
                 return;
             }
 
-            if (status === statuses.FAILED) {
+            if (status === jiraConfig.statuses.FAILED) {
                 waitingForBugsTCs.push(tc.key);
             } else {
                 readyForRetestTCs.push(tc.key);
@@ -133,7 +131,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: statuses.DONE
+                statusName: jiraConfig.statuses.DONE
             });
 
             jira_post_comment({
@@ -171,7 +169,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: statuses.BUG_TO_FIX
+                statusName: jiraConfig.statuses.BUG_TO_FIX
             });
 
             jira_post_comment({
@@ -205,7 +203,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: statuses.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
         jira_post_comment({

--- a/js/checkStoryTestsPassed.js
+++ b/js/checkStoryTestsPassed.js
@@ -23,6 +23,8 @@ function action(params) {
     const removeLabel = customParams && customParams.removeLabel;
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
     const jiraConfig = projectConfig.jira;
+    // Legacy override channel: customParams.customStatuses still wins over .dmtools/config.js statuses
+    const statuses = Object.assign({}, jiraConfig.statuses, (customParams && customParams.customStatuses) || {});
     const testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
     const bugType = jiraConfig.issueTypes.BUG || 'Bug';
 
@@ -67,7 +69,7 @@ function action(params) {
         var bugs = findLinkedBugs(tcKey);
         for (var i = 0; i < bugs.length; i++) {
             var status = bugs[i].fields && bugs[i].fields.status && bugs[i].fields.status.name;
-            if (status !== jiraConfig.statuses.DONE) {
+            if (status !== statuses.DONE) {
                 return bugs[i].key;
             }
         }
@@ -75,10 +77,10 @@ function action(params) {
     }
 
     function isInFlightStatus(status) {
-        return status === jiraConfig.statuses.IN_REVIEW_PASSED ||
-            status === jiraConfig.statuses.IN_REVIEW_FAILED ||
-            status === jiraConfig.statuses.IN_DEVELOPMENT ||
-            status === jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+        return status === statuses.IN_REVIEW_PASSED ||
+            status === statuses.IN_REVIEW_FAILED ||
+            status === statuses.IN_DEVELOPMENT ||
+            status === statuses.READY_FOR_DEVELOPMENT;
     }
 
     try {
@@ -103,7 +105,7 @@ function action(params) {
         allTCs.forEach(function(tc) {
             var status = tc.fields && tc.fields.status && tc.fields.status.name;
 
-            if (status === jiraConfig.statuses.PASSED || status === jiraConfig.statuses.SKIPPED || status === jiraConfig.statuses.IRRELEVANT) {
+            if (status === statuses.PASSED || status === statuses.SKIPPED || status === statuses.IRRELEVANT) {
                 return;
             }
 
@@ -118,7 +120,7 @@ function action(params) {
                 return;
             }
 
-            if (status === jiraConfig.statuses.FAILED) {
+            if (status === statuses.FAILED) {
                 waitingForBugsTCs.push(tc.key);
             } else {
                 readyForRetestTCs.push(tc.key);
@@ -131,7 +133,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: jiraConfig.statuses.DONE
+                statusName: statuses.DONE
             });
 
             jira_post_comment({
@@ -169,7 +171,7 @@ function action(params) {
 
             jira_move_to_status({
                 key: ticketKey,
-                statusName: jiraConfig.statuses.BUG_TO_FIX
+                statusName: statuses.BUG_TO_FIX
             });
 
             jira_post_comment({
@@ -203,7 +205,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: jiraConfig.statuses.READY_FOR_TESTING
+            statusName: statuses.READY_FOR_TESTING
         });
 
         jira_post_comment({

--- a/js/checkStoryTestsPassed.js
+++ b/js/checkStoryTestsPassed.js
@@ -67,7 +67,7 @@ function action(params) {
         var bugs = findLinkedBugs(tcKey);
         for (var i = 0; i < bugs.length; i++) {
             var status = bugs[i].fields && bugs[i].fields.status && bugs[i].fields.status.name;
-            if (status !== jiraConfig.jiraConfig.statuses.DONE) {
+            if (status !== jiraConfig.statuses.DONE) {
                 return bugs[i].key;
             }
         }

--- a/js/checkSubtasksDoneForBA.js
+++ b/js/checkSubtasksDoneForBA.js
@@ -24,7 +24,6 @@ function action(params) {
     const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
     const questionsJql = projectConfig.jira.questions.fetchJql;
     const baAnalysisStatus = projectConfig.jira.statuses.BA_ANALYSIS;
-    const subtaskIssueType = projectConfig.jira.issueTypes.SUBTASK;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -71,7 +70,7 @@ function action(params) {
 
         // Step 2: Find subtasks NOT yet Done via JQL (more reliable than client-side field check)
         const notDoneSubtasks = jira_search_by_jql({
-            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "Done"',
+            jql: allJql.replace('ORDER BY created ASC', '') + ' AND status != "' + projectConfig.jira.statuses.DONE + '"',
             maxResults: 1
         }) || [];
         const notDoneCount = notDoneSubtasks.length;

--- a/js/checkTaskStoriesDone.js
+++ b/js/checkTaskStoriesDone.js
@@ -10,13 +10,15 @@
  *   this check on the next cycle.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
     const ticketKey = params.ticket && params.ticket.key;
     const customParams = params.jobParams && params.jobParams.customParams;
     const removeLabel = customParams && customParams.removeLabel;
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -49,7 +51,7 @@ function action(params) {
 
         // Step 2: Find linked Stories/Bugs NOT yet Done
         const notDoneItems = jira_search_by_jql({
-            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype in (Story, Bug) AND status != "Done"',
+            jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype in (Story, Bug) AND status != "' + jiraConfig.statuses.DONE + '"',
             maxResults: 1
         }) || [];
         const notDoneCount = notDoneItems.length;
@@ -66,7 +68,7 @@ function action(params) {
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
         jira_post_comment({

--- a/js/closeQuestionTicket.js
+++ b/js/closeQuestionTicket.js
@@ -4,12 +4,15 @@
  * after the Answer field has been written by the outputType:field handler.
  */
 
-const { LABELS, STATUSES } = require('./config.js');
+const { LABELS } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
     try {
         var ticketKey = params.ticket.key;
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var wipLabel = params.metadata && params.metadata.contextId
             ? params.metadata.contextId + '_wip'
             : null;
@@ -31,7 +34,7 @@ function action(params) {
         }
 
         // Move to Done
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.DONE });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.DONE });
         console.log('Moved ' + ticketKey + ' to Done');
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -11,7 +11,9 @@
  *   4. Built-in defaults       (backward compatible)
  *
  * Merge strategy:
- *   - jira.statuses, jira.issueTypes, jira.questions, labels: FULL REPLACEMENT when provided
+ *   - jira.statuses, jira.issueTypes: DEEP MERGE over built-in defaults — a project may
+ *     override only the keys it renames; unspecified keys keep the defaults from config.js
+ *   - jira.questions, labels: FULL REPLACEMENT when provided
  *   - smRules, smMergeRules: FULL REPLACEMENT when provided
  *   - repository, git, formats, confluence, jira.fields: DEEP MERGE
  *   - additionalInstructions, instructionOverrides, cliPrompts, cliPromptOverrides, agentParamPatches, jobParamPatches:
@@ -163,7 +165,9 @@ function deepMerge(target, source) {
 
 /**
  * Merge project config with defaults using section-level strategy:
- * - statuses, issueTypes, labels, smRules, smMergeRules: full replacement
+ * - jira.statuses, jira.issueTypes: deep merge over defaults, so partial
+ *   overrides keep unspecified default keys (backward compatible)
+ * - jira.questions, labels, smRules, smMergeRules: full replacement
  * - everything else: deep merge
  */
 function mergeProjectConfig(defaults, overrides) {
@@ -173,12 +177,10 @@ function mergeProjectConfig(defaults, overrides) {
 
     // Full replacement sections: if override provides these, use them entirely
     if (overrides.jira) {
-        if (overrides.jira.statuses) {
-            result.jira.statuses = overrides.jira.statuses;
-        }
-        if (overrides.jira.issueTypes) {
-            result.jira.issueTypes = overrides.jira.issueTypes;
-        }
+        // statuses/issueTypes merge over defaults via deepMerge above — restore them
+        // if an explicit null in overrides wiped the section
+        if (!result.jira.statuses) result.jira.statuses = defaults.jira.statuses;
+        if (!result.jira.issueTypes) result.jira.issueTypes = defaults.jira.issueTypes;
         if (overrides.jira.questions) {
             result.jira.questions = overrides.jira.questions;
         }

--- a/js/createBugFixBatchEpic.js
+++ b/js/createBugFixBatchEpic.js
@@ -22,18 +22,21 @@
  * individual bug_development rule, so the batch agent owns them.
  */
 
-const { STATUSES, ISSUE_TYPES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const { extractTicketKey } = require('./common/jiraHelpers.js');
+const configLoader = require('./configLoader.js');
 
 var BUG_FIX_BATCH_LABEL = LABELS.BUG_FIX_BATCH || 'bug_fix_batch';
-var BATCH_STATUS = STATUSES.READY_FOR_DEVELOPMENT || 'Ready For Development';
-var DONE_STATUS = STATUSES.DONE || 'Done';
 
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var customParams = (params.jobParams && params.jobParams.customParams) || {};
     var removeLabel = customParams.removeLabel;
     var batchSize = customParams.batchSize || 5;
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
+    var BATCH_STATUS = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+    var DONE_STATUS = jiraConfig.statuses.DONE;
 
     function releaseLock() {
         if (ticketKey && removeLabel) {
@@ -84,7 +87,7 @@ function action(params) {
         // Only group bugs that have not been individually picked up yet.
         // In Development / In Progress bugs are left for the single-bug pipeline.
         var jql = 'issue in linkedIssues("' + storyKey + '") AND issuetype = Bug ' +
-            'AND status in ("' + (STATUSES.BACKLOG || 'Backlog') + '", "' + (STATUSES.TODO || 'To Do') + '", "' + (STATUSES.READY_FOR_DEVELOPMENT || 'Ready For Development') + '") ' +
+            'AND status in ("' + jiraConfig.statuses.BACKLOG + '", "' + jiraConfig.statuses.TODO + '", "' + jiraConfig.statuses.READY_FOR_DEVELOPMENT + '") ' +
             'AND (labels is EMPTY OR labels NOT IN ("' + BUG_FIX_BATCH_LABEL + '")) ' +
             'ORDER BY created ASC';
         return searchIssues(jql, ['key', 'status', 'summary', 'labels']);
@@ -101,7 +104,7 @@ function action(params) {
 
     function bugStillRelevant(bugKey) {
         var jql = 'issue in linkedIssues("' + bugKey + '") AND issuetype = "Test Case" ' +
-            'AND status in ("' + (STATUSES.FAILED || 'Failed') + '", "' + (STATUSES.BUG_TO_FIX || 'Bug To Fix') + '")';
+            'AND status in ("' + jiraConfig.statuses.FAILED + '", "' + jiraConfig.statuses.BUG_TO_FIX + '")';
         var tcs = searchIssues(jql, ['key', 'status'], 1);
         return tcs.length > 0;
     }
@@ -118,7 +121,7 @@ function action(params) {
         var fieldsJson = {
             summary: summary,
             description: description,
-            issuetype: { name: ISSUE_TYPES.EPIC || 'Epic' },
+            issuetype: { name: jiraConfig.issueTypes.EPIC || 'Epic' },
             labels: [BUG_FIX_BATCH_LABEL]
         };
 

--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -19,7 +19,7 @@
  */
 
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS, resolveStatuses } = require('./config.js');
+const { LABELS, resolveStatuses } = require('./config.js');
 const developTicket = require('./developTicketAndCreatePR.js');
 const outputFiles = require('./common/outputFiles.js');
 
@@ -73,6 +73,7 @@ function action(params) {
         const actualParams = params.ticket ? params : (params.jobParams || params);
         const ticketKey = actualParams.ticket.key;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var scm = configLoader.createScm(config);
         const _customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         const statuses = resolveStatuses(_customParams);
@@ -150,7 +151,7 @@ function action(params) {
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
                 console.log('✅ Moved', ticketKey, 'to Blocked');
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
@@ -185,7 +186,7 @@ function action(params) {
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.DONE });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.DONE });
                 console.log('✅ Moved', ticketKey, 'to Done');
             } catch (e) {
                 console.warn('Failed to move to Done:', e);

--- a/js/finishTestCasesGeneration.js
+++ b/js/finishTestCasesGeneration.js
@@ -7,7 +7,7 @@
  *    story_test_automation.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -15,12 +15,14 @@ function action(params) {
     if (!ticketKey) {
         return { success: false, error: 'No ticket key found in params' };
     }
+    const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = projectConfig.jira;
 
     console.log('=== Finishing test case generation for', ticketKey, '===');
 
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.READY_FOR_TESTING });
-        console.log('✅ Moved', ticketKey, 'to', STATUSES.READY_FOR_TESTING);
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.READY_FOR_TESTING });
+        console.log('✅ Moved', ticketKey, 'to', jiraConfig.statuses.READY_FOR_TESTING);
     } catch (e) {
         console.warn('Could not move Story to Ready For Testing:', e);
     }

--- a/js/mergeStoryTestAutomationPR.js
+++ b/js/mergeStoryTestAutomationPR.js
@@ -4,7 +4,7 @@
  * from In Review - Passed/Failed to Passed/Failed.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
@@ -78,19 +78,19 @@ function fetchLinkedTestCases(storyKey, testCaseType) {
     }
 }
 
-function resolveFinalStatus(currentStatus) {
-    if (currentStatus === STATUSES.IN_REVIEW_PASSED) return STATUSES.PASSED;
-    if (currentStatus === STATUSES.IN_REVIEW_FAILED) return STATUSES.FAILED;
+function resolveFinalStatus(currentStatus, jiraConfig) {
+    if (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) return jiraConfig.statuses.PASSED;
+    if (currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED) return jiraConfig.statuses.FAILED;
     return null;
 }
 
-function moveLinkedTestCases(storyKey, testCaseType) {
+function moveLinkedTestCases(storyKey, testCaseType, jiraConfig) {
     var testCases = fetchLinkedTestCases(storyKey, testCaseType);
     var moved = 0;
     var skipped = 0;
     testCases.forEach(function(tc) {
         var currentStatus = tc.fields && tc.fields.status ? tc.fields.status.name : '';
-        var finalStatus = resolveFinalStatus(currentStatus);
+        var finalStatus = resolveFinalStatus(currentStatus, jiraConfig);
         if (!finalStatus) {
             console.log('Skipping linked TC', tc.key, '— current status', currentStatus);
             skipped++;
@@ -108,7 +108,7 @@ function moveLinkedTestCases(storyKey, testCaseType) {
     return { moved: moved, skipped: skipped, total: testCases.length };
 }
 
-function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams) {
+function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, customParams, jiraConfig) {
     const prNumber = pr.number;
     const prUrl = pr.html_url;
     console.log('PR #' + prNumber + ' already merged for story ' + storyKey + ' — finalizing');
@@ -116,7 +116,7 @@ function finalizeAlreadyMergedPR(params, scm, storyKey, pr, testCaseType, custom
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
-    var tcResult = moveLinkedTestCases(storyKey, testCaseType);
+    var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
 
     // Bug stays In Testing; bug_done_check will move it to Done only when all
     // directly linked Test Cases are Passed. Moving it here allowed bugs to be
@@ -177,12 +177,10 @@ function attemptMerge(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
-    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-    var testCaseType = projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE
-        ? projectConfig.jira.issueTypes.TEST_CASE
-        : 'Test Case';
+    var testCaseType = jiraConfig.issueTypes.TEST_CASE || 'Test Case';
     var issueType = params.ticket && params.ticket.fields &&
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
@@ -199,7 +197,7 @@ function attemptMerge(params) {
     }
 
     if (found.merged) {
-        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams);
+        finalizeAlreadyMergedPR(params, scm, storyKey, found.pr, testCaseType, customParams, jiraConfig);
         return {
             success: true,
             alreadyMerged: true,
@@ -276,7 +274,7 @@ function attemptMerge(params) {
 
         try { scm.removeLabel(prNumber, LABELS.PR_APPROVED); } catch (e) {}
 
-        var tcResult = moveLinkedTestCases(storyKey, testCaseType);
+        var tcResult = moveLinkedTestCases(storyKey, testCaseType, jiraConfig);
 
         try {
             jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED });
@@ -354,6 +352,7 @@ function action(params) {
         params.ticket.fields.issuetype && params.ticket.fields.issuetype.name;
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
 
     const mergeResult = attemptMerge(params);
@@ -384,7 +383,7 @@ function action(params) {
     }
     try { jira_remove_label({ key: storyKey, label: LABELS.PR_APPROVED }); } catch (e) {}
     try { jira_add_label({ key: storyKey, label: LABELS.TEST_PR_REWORK_NEEDED }); } catch (e) {}
-    var reworkSkipLabel = issueType === 'Bug' ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
+    var reworkSkipLabel = issueType === jiraConfig.issueTypes.BUG ? 'sm_bug_test_rework_triggered' : 'sm_story_test_rework_triggered';
     try { jira_remove_label({ key: storyKey, label: reworkSkipLabel }); } catch (e) {}
 
     releaseLock(storyKey, customParams);
@@ -400,7 +399,7 @@ function action(params) {
         key: storyKey,
         comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *' + panelTitle + '* — Could not merge PR #' + (prNumber || 'unknown') + ': ' + reasonText + '.\n\n' + (prUrl ? '[View PR|' + prUrl + ']' : '') + '{panel}'
     });
-    jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_REWORK });
+    jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_REWORK });
     return true;
 }
 

--- a/js/moveToDone.js
+++ b/js/moveToDone.js
@@ -4,7 +4,7 @@
  * If tests fail later, AI creates a new bug instead of re-opening this one.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -13,12 +13,14 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.DONE + ' (bug with test cases generated)');
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.DONE + ' (bug with test cases generated)');
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.DONE
+            statusName: jiraConfig.statuses.DONE
         });
 
         try {
@@ -32,7 +34,7 @@ function action(params) {
             comment: 'Test cases generated. Bug marked as Done. If regression is detected, a new bug will be created automatically.'
         });
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.DONE);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.DONE);
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider
         // wrote outputs/*_usage.json during the agent run.
@@ -44,7 +46,7 @@ function action(params) {
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.DONE
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.DONE
         };
 
     } catch (error) {

--- a/js/moveToInTesting.js
+++ b/js/moveToInTesting.js
@@ -3,7 +3,7 @@
  * Moves the ticket to "In Testing" status after test cases are generated.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function action(params) {
@@ -12,12 +12,14 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.IN_TESTING);
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.IN_TESTING);
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.IN_TESTING
+            statusName: jiraConfig.statuses.IN_TESTING
         });
 
         try {
@@ -26,7 +28,7 @@ function action(params) {
             console.log('Label sm_test_cases_triggered not found or already removed');
         }
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.IN_TESTING);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.IN_TESTING);
 
         // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider
         // wrote outputs/*_usage.json during the agent run.
@@ -38,7 +40,7 @@ function action(params) {
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.IN_TESTING
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.IN_TESTING
         };
 
     } catch (error) {

--- a/js/moveToReadyForTesting.js
+++ b/js/moveToReadyForTesting.js
@@ -3,7 +3,7 @@
  * Moves the ticket to "Ready For Testing" status after test cases are generated.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 
 function action(params) {
     try {
@@ -11,19 +11,21 @@ function action(params) {
         if (!ticketKey) {
             return { success: false, error: 'No ticket key found in params' };
         }
+        const projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = projectConfig.jira;
 
-        console.log('Moving ' + ticketKey + ' to ' + STATUSES.READY_FOR_TESTING);
+        console.log('Moving ' + ticketKey + ' to ' + jiraConfig.statuses.READY_FOR_TESTING);
 
         jira_move_to_status({
             key: ticketKey,
-            statusName: STATUSES.READY_FOR_TESTING
+            statusName: jiraConfig.statuses.READY_FOR_TESTING
         });
 
-        console.log('✅ ' + ticketKey + ' moved to ' + STATUSES.READY_FOR_TESTING);
+        console.log('✅ ' + ticketKey + ' moved to ' + jiraConfig.statuses.READY_FOR_TESTING);
 
         return {
             success: true,
-            message: ticketKey + ' moved to ' + STATUSES.READY_FOR_TESTING
+            message: ticketKey + ' moved to ' + jiraConfig.statuses.READY_FOR_TESTING
         };
 
     } catch (error) {

--- a/js/postBugCreation.js
+++ b/js/postBugCreation.js
@@ -12,7 +12,8 @@
  * Link direction: Bug "blocks" TC (TC is blocked by the Bug until it's fixed).
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function readFile(path) {
@@ -61,9 +62,9 @@ function linkBugToTC(ticketKey, bugKey) {
     console.log('✅ Linked:', bugKey, 'blocks', ticketKey);
 }
 
-function moveFailedTcToRework(ticketKey) {
-    jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK || 'In Rework' });
-    console.log('🔧 Moved', ticketKey, 'to', STATUSES.IN_REWORK || 'In Rework');
+function moveFailedTcToRework(ticketKey, jiraConfig) {
+    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
+    console.log('🔧 Moved', ticketKey, 'to', jiraConfig.statuses.IN_REWORK);
     try {
         jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
         console.log('✅ Removed sm_test_automation_triggered');
@@ -73,6 +74,8 @@ function moveFailedTcToRework(ticketKey) {
 function action(params) {
     try {
         var ticketKey = params.ticket.key;
+        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         console.log('=== Processing bug creation decision for', ticketKey, '===');
 
         var customParams = params.jobParams && params.jobParams.customParams;
@@ -158,8 +161,8 @@ function action(params) {
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.PASSED });
-                console.log('✅ Tests pass — moved', ticketKey, 'to', STATUSES.PASSED);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.PASSED });
+                console.log('✅ Tests pass — moved', ticketKey, 'to', jiraConfig.statuses.PASSED);
             } catch (e) {
                 console.warn('Failed to move to Passed:', e);
             }
@@ -176,7 +179,7 @@ function action(params) {
                 '\n\n_TC moved to *In Rework* so the test automation can be fixed instead of staying in *Failed*._';
 
             try { jira_post_comment({ key: ticketKey, comment: comment }); } catch (e) {}
-            moveFailedTcToRework(ticketKey);
+            moveFailedTcToRework(ticketKey, jiraConfig);
             try { jira_remove_label({ key: ticketKey, label: wipLabel }); } catch (e) {}
             if (smTriggerLabel) {
                 try { jira_remove_label({ key: ticketKey, label: smTriggerLabel }); } catch (e) {}
@@ -195,8 +198,8 @@ function action(params) {
         // Move TC to Bug To Fix after successful link or create
         if (bugLinked) {
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BUG_TO_FIX });
-                console.log('✅ Moved', ticketKey, 'to', STATUSES.BUG_TO_FIX);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
+                console.log('✅ Moved', ticketKey, 'to', jiraConfig.statuses.BUG_TO_FIX);
             } catch (e) {
                 console.warn('Failed to move to Bug To Fix:', e);
             }
@@ -204,8 +207,8 @@ function action(params) {
             // Move the bug to Ready For Development so it gets picked up
             if (bugKey) {
                 try {
-                    jira_move_to_status({ key: bugKey, statusName: STATUSES.READY_FOR_DEVELOPMENT });
-                    console.log('✅ Moved bug', bugKey, 'to', STATUSES.READY_FOR_DEVELOPMENT);
+                    jira_move_to_status({ key: bugKey, statusName: jiraConfig.statuses.READY_FOR_DEVELOPMENT });
+                    console.log('✅ Moved bug', bugKey, 'to', jiraConfig.statuses.READY_FOR_DEVELOPMENT);
                 } catch (e) {
                     console.warn('Failed to move bug to Ready For Development:', e);
                 }

--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -456,7 +456,7 @@ function action(params) {
             console.log('  Linking', tcKey, '→', bugKey);
             try {
                 linkBugToTC(tcKey, bugKey);
-                moveToBugToFix(tcKey);
+                moveToBugToFix(tcKey, jiraConfig);
                 removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 postComment(tcKey,
                     'h3. 🔗 Existing Bug Linked (Batch)\n\n' +
@@ -503,7 +503,7 @@ function action(params) {
             console.warn('  ⚠️ Processed TC has no successful bulk outcome:', tcKey);
             var linkedBugKey = findLinkedNonDoneBug(tcKey);
             if (linkedBugKey) {
-                moveToBugToFix(tcKey);
+                moveToBugToFix(tcKey, jiraConfig);
                 removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 postComment(tcKey,
                     'h3. 🔗 Existing Bug Found After Batch\n\n' +

--- a/js/postBulkBugsCreation.js
+++ b/js/postBulkBugsCreation.js
@@ -24,7 +24,7 @@
  * For skipped:  move TC to Backlog so test automation can be re-automated/reworked
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var feedbackLoop = require('./common/feedbackLoop.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 var configLoader = require('./configLoader.js');
@@ -154,9 +154,9 @@ function findAnyLinkedNonDoneBug(tcKeys) {
     return null;
 }
 
-function moveToBugToFix(tcKey) {
+function moveToBugToFix(tcKey, jiraConfig) {
     try {
-        jira_move_to_status({ key: tcKey, statusName: STATUSES.BUG_TO_FIX || 'Bug To Fix' });
+        jira_move_to_status({ key: tcKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
         console.log('  📋 Moved to Bug To Fix:', tcKey);
     } catch (e) {
         console.warn('  ⚠️ Could not move to Bug To Fix:', tcKey, e);
@@ -248,9 +248,9 @@ function markResolved(resolvedSet, tcKey) {
     if (tcKey) resolvedSet[tcKey] = true;
 }
 
-function moveSkippedTcToBacklog(tcKey) {
-    jira_move_to_status({ key: tcKey, statusName: STATUSES.BACKLOG || 'Backlog' });
-    console.log('  🔧 Moved to ' + (STATUSES.BACKLOG || 'Backlog') + ':', tcKey);
+function moveSkippedTcToBacklog(tcKey, jiraConfig) {
+    jira_move_to_status({ key: tcKey, statusName: jiraConfig.statuses.BACKLOG });
+    console.log('  🔧 Moved to ' + jiraConfig.statuses.BACKLOG + ':', tcKey);
     try {
         jira_remove_label({ key: tcKey, label: 'sm_test_automation_triggered' });
     } catch (e) {}
@@ -263,6 +263,7 @@ function action(params) {
         var triggerLabel = customParams.removeLabel || 'sm_bug_creation_triggered';
         var smTriggerLabel = customParams.smTriggerLabel || 'sm_bulk_bugs_creation_triggered';
         var projectConfig = configLoader.loadProjectConfig(actualParams);
+        var jiraConfig = projectConfig.jira;
         var failedReasonFieldName = getFailedReasonFieldName(projectConfig, customParams);
 
         console.log('=== Processing bulk bug creation decisions ===');
@@ -367,7 +368,7 @@ function action(params) {
                     }
                     try {
                         linkBugToTC(tcKey, existingBugKey);
-                        moveToBugToFix(tcKey);
+                        moveToBugToFix(tcKey, jiraConfig);
                         removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                         postComment(tcKey,
                             'h3. 🔗 Existing Bug Linked (Batch Live Re-check)\n\n' +
@@ -419,7 +420,7 @@ function action(params) {
                 }
                 try {
                     linkBugToTC(tcKey, bugKey);
-                    moveToBugToFix(tcKey);
+                    moveToBugToFix(tcKey, jiraConfig);
                     removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                     postComment(tcKey,
                         'h3. 🐛 New Bug Created (Batch)\n\n' +
@@ -481,7 +482,7 @@ function action(params) {
                 return;
             }
             console.log('  Skipping', tcKey, '—', skipDef.reason || 'no reason given');
-            moveSkippedTcToBacklog(tcKey);
+            moveSkippedTcToBacklog(tcKey, jiraConfig);
             try {
                 removeProcessingLabels(tcKey, [triggerLabel, smTriggerLabel]);
                 console.log('  🏷️ Removed trigger labels from', tcKey, '— eligible for re-automation');

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -29,7 +29,7 @@
  */
 
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var prHelper = require('./common/pullRequest.js');
 var outputFiles = require('./common/outputFiles.js');
 
@@ -516,6 +516,7 @@ function action(params) {
         var ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         var jiraComment = params.response || '';
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var automationScm = createScmCompat(config, config.repository && config.repository.owner, config.repository && config.repository.repo);
         var workingDir = config.workingDir;
 
@@ -656,7 +657,7 @@ function action(params) {
             }
             blockedComment += '\nOnce setup is complete, move this ticket back to *Backlog* to trigger re-run.';
             try { jira_post_comment({ key: ticketKey, comment: blockedComment }); } catch (e) {}
-            try { jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED }); } catch (e) {}
+            try { jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED }); } catch (e) {}
 
             removeWipLabel(params, ticketKey);
             removeSMTriggerLabel(params, ticketKey);
@@ -665,7 +666,7 @@ function action(params) {
 
         // Step 8: Move ticket status
         try {
-            var targetStatus = passed ? STATUSES.PASSED : STATUSES.FAILED;
+            var targetStatus = passed ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
             jira_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);
         } catch (e) {

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -13,7 +13,7 @@
 var configLoader = require('./configLoader.js');
 var prHelper = require('./common/pullRequest.js');
 var autoStart = require('./common/autoStart.js');
-const { GIT_CONFIG, STATUSES, LABELS, JIRA_FIELDS, resolveStatuses } = require('./config.js');
+const { GIT_CONFIG, LABELS, JIRA_FIELDS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -433,7 +433,7 @@ function updateFailedReasonField(tcKey, attachmentName, failureSummary, fieldNam
 
 function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     try {
-        var targetStatus = status === 'passed' ? STATUSES.IN_REVIEW_PASSED : STATUSES.IN_REVIEW_FAILED;
+        var targetStatus = status === 'passed' ? config.jira.statuses.IN_REVIEW_PASSED : config.jira.statuses.IN_REVIEW_FAILED;
         jira_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Moved', tcKey, 'to', targetStatus);
 
@@ -454,9 +454,9 @@ function updateTestCaseStatus(tcKey, status, workingDir, storyKey, config) {
     }
 }
 
-function finalizeTestCaseStatus(tcKey, status) {
+function finalizeTestCaseStatus(tcKey, status, jiraConfig) {
     try {
-        var targetStatus = status === 'passed' ? STATUSES.PASSED : STATUSES.FAILED;
+        var targetStatus = status === 'passed' ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
         jira_move_to_status({ key: tcKey, statusName: targetStatus });
         console.log('✅ Finalized', tcKey, 'to', targetStatus, '(no code changes)');
     } catch (e) {
@@ -552,8 +552,8 @@ function action(params) {
         const storyKey = params.ticket.key;
         const storySummary = params.ticket.fields ? params.ticket.fields.summary : storyKey;
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var customParams = (params.jobParams || params).customParams || {};
-        var statuses = resolveStatuses(customParams);
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
         var testFilesPath = customParams.testFilesGlob || 'testing/';
@@ -562,8 +562,7 @@ function action(params) {
         console.log('=== Processing story test automation results for', storyKey, '===');
 
         // Step 1: Read structured result and ensure all linked Test Cases were checked
-        var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-        var testCaseType = (projectConfig.jira && projectConfig.jira.issueTypes && projectConfig.jira.issueTypes.TEST_CASE) || 'Test Case';
+        var testCaseType = (jiraConfig.issueTypes && jiraConfig.issueTypes.TEST_CASE) || 'Test Case';
         var linkedTestCases = readLinkedTestCases(storyKey, testCaseType);
 
         var result = readResultJson(workingDir, storyKey);
@@ -607,14 +606,14 @@ function action(params) {
 
         // For a Bug, a product failure means the fix did not work. Send the Bug
         // straight back to development and finalize the failing Test Cases as Failed.
-        if (issueType === 'Bug' && hasProductFailure) {
+        if (issueType === jiraConfig.issueTypes.BUG && hasProductFailure) {
             console.log('Bug', storyKey, 'has', failedResults.length, 'product failure(s) — returning to development');
             failedResults.forEach(function(item) {
                 updateTestCaseStatus(item.testCaseKey, 'failed', workingDir, storyKey, config);
-                finalizeTestCaseStatus(item.testCaseKey, 'failed');
+                finalizeTestCaseStatus(item.testCaseKey, 'failed', jiraConfig);
             });
 
-            var bugReturnStatus = statuses.READY_FOR_DEVELOPMENT || STATUSES.READY_FOR_DEVELOPMENT;
+            var bugReturnStatus = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
             try {
                 jira_move_to_status({ key: storyKey, statusName: bugReturnStatus });
                 console.log('✅ Moved Bug', storyKey, 'back to', bugReturnStatus);
@@ -706,8 +705,8 @@ function action(params) {
                 'Once setup is complete, move this Story back to *Ready For Testing* to trigger re-run.';
             try {
                 jira_post_comment({ key: storyKey, comment: blockedComment });
-                jira_move_to_status({ key: storyKey, statusName: STATUSES.BLOCKED });
-                console.log('✅ Blocked — moved', storyKey, 'to', STATUSES.BLOCKED);
+                jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', storyKey, 'to', jiraConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to handle blocked story:', e);
             }
@@ -723,14 +722,14 @@ function action(params) {
                     // When there are no test code changes we skip the PR/review/merge flow,
                     // so we must finalize TC statuses immediately so story_done_check can act.
                     if (noCodeChanges) {
-                        finalizeTestCaseStatus(item.testCaseKey, item.status);
+                        finalizeTestCaseStatus(item.testCaseKey, item.status, jiraConfig);
                     }
                 } else if (item.status === 'skipped') {
                     // Skipped tests are final — no PR/review needed.
-                    moveSkippedTcToStatus(item.testCaseKey, statuses.SKIPPED || 'Skipped');
+                    moveSkippedTcToStatus(item.testCaseKey, jiraConfig.statuses.SKIPPED);
                 } else if (item.status === 'irrelevant') {
                     // Legacy/no-longer-applicable tests are final; delete their test code.
-                    moveIrrelevantTcToStatus(item.testCaseKey, statuses.IRRELEVANT || 'Irrelevant', testFilesPath, workingDir);
+                    moveIrrelevantTcToStatus(item.testCaseKey, jiraConfig.statuses.IRRELEVANT, testFilesPath, workingDir);
                 } else {
                     console.log('Skipping status update for', item.testCaseKey, '— status:', item.status);
                 }
@@ -739,8 +738,8 @@ function action(params) {
 
         // Step 8: Move Story to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -554,6 +554,8 @@ function action(params) {
         var config = configLoader.loadProjectConfig(params.jobParams || params);
         var jiraConfig = config.jira;
         var customParams = (params.jobParams || params).customParams || {};
+        // Legacy override channel: customParams.customStatuses still wins over .dmtools/config.js statuses
+        var statuses = Object.assign({}, jiraConfig.statuses, customParams.customStatuses || {});
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
         var testFilesPath = customParams.testFilesGlob || 'testing/';
@@ -613,7 +615,7 @@ function action(params) {
                 finalizeTestCaseStatus(item.testCaseKey, 'failed', jiraConfig);
             });
 
-            var bugReturnStatus = jiraConfig.statuses.READY_FOR_DEVELOPMENT;
+            var bugReturnStatus = statuses.READY_FOR_DEVELOPMENT;
             try {
                 jira_move_to_status({ key: storyKey, statusName: bugReturnStatus });
                 console.log('✅ Moved Bug', storyKey, 'back to', bugReturnStatus);
@@ -726,10 +728,10 @@ function action(params) {
                     }
                 } else if (item.status === 'skipped') {
                     // Skipped tests are final — no PR/review needed.
-                    moveSkippedTcToStatus(item.testCaseKey, jiraConfig.statuses.SKIPPED);
+                    moveSkippedTcToStatus(item.testCaseKey, statuses.SKIPPED);
                 } else if (item.status === 'irrelevant') {
                     // Legacy/no-longer-applicable tests are final; delete their test code.
-                    moveIrrelevantTcToStatus(item.testCaseKey, jiraConfig.statuses.IRRELEVANT, testFilesPath, workingDir);
+                    moveIrrelevantTcToStatus(item.testCaseKey, statuses.IRRELEVANT, testFilesPath, workingDir);
                 } else {
                     console.log('Skipping status update for', item.testCaseKey, '— status:', item.status);
                 }

--- a/js/postTestAutomationResults.js
+++ b/js/postTestAutomationResults.js
@@ -13,7 +13,7 @@
 var configLoader = require('./configLoader.js');
 var prHelper = require('./common/pullRequest.js');
 var autoStart = require('./common/autoStart.js');
-const { GIT_CONFIG, STATUSES, LABELS } = require('./config.js');
+const { GIT_CONFIG, LABELS } = require('./config.js');
 var outputFiles = require('./common/outputFiles.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
@@ -340,6 +340,7 @@ function action(params) {
         const ticketSummary = params.ticket.fields ? params.ticket.fields.summary : ticketKey;
         const projectKey = ticketKey.split('-')[0];
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var customParams = (params.jobParams || params).customParams || {};
         var scm = configLoader.createScm(config);
         var workingDir = config.workingDir || null;
@@ -381,8 +382,8 @@ function action(params) {
 
             jira_post_comment({ key: ticketKey, comment: commentMsg });
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
-                console.log('✅ Missing result — moved', ticketKey, 'to', STATUSES.BACKLOG);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
+                console.log('✅ Missing result — moved', ticketKey, 'to', jiraConfig.statuses.BACKLOG);
             } catch (e) {
                 console.warn('Failed to move missing-result ticket to Backlog:', e);
             }
@@ -443,7 +444,7 @@ function action(params) {
                     console.error('PR creation failed — resetting ticket to Backlog for retry');
                     try {
                         jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ PR Creation Failed\n\nTest code was pushed to branch {code}' + branchName + '{code} but the Pull Request could not be created.\n\nTicket moved back to *Backlog* — will be re-processed automatically. The next run will detect the existing branch and create the PR.\n\nError: ' + (prResult.error || 'unknown') });
-                        jira_move_to_status({ key: ticketKey, statusName: 'Backlog' });
+                        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
                     } catch (e) { console.warn('Could not reset to Backlog:', e); }
                     try {
                         const smTriggerLabel = params.jobParams && params.jobParams.customParams && params.jobParams.customParams.removeLabel;
@@ -467,8 +468,8 @@ function action(params) {
                             'Ticket moved to *Blocked* for human conflict resolution.';
                         try { jira_post_comment({ key: ticketKey, comment: conflictComment }); } catch (e) {}
                         try {
-                            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
-                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', STATUSES.BLOCKED);
+                            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
+                            console.log('✅ Conflicting PR — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
                         } catch (e) {
                             console.warn('Failed to move conflicting PR ticket to Blocked:', e);
                         }
@@ -490,7 +491,7 @@ function action(params) {
                 console.warn('Git operations failed:', gitResult.error);
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Git Operations Failed\n\nFailed to commit/push test code: ' + gitResult.error + '\n\nTicket moved back to *Backlog* — will be re-processed automatically.' });
-                    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
                 } catch (e) { console.warn('Could not reset to Backlog:', e); }
                 try {
                     jira_remove_label({ key: ticketKey, label: 'sm_test_automation_triggered' });
@@ -549,8 +550,8 @@ function action(params) {
             }
 
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.BLOCKED });
-                console.log('✅ Blocked — moved', ticketKey, 'to', STATUSES.BLOCKED);
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BLOCKED });
+                console.log('✅ Blocked — moved', ticketKey, 'to', jiraConfig.statuses.BLOCKED);
             } catch (e) {
                 console.warn('Failed to move to Blocked:', e);
             }
@@ -576,7 +577,7 @@ function action(params) {
 
         if (passed) {
             try {
-                var passedStatus = noCodeChanges ? STATUSES.PASSED : STATUSES.IN_REVIEW_PASSED;
+                var passedStatus = noCodeChanges ? jiraConfig.statuses.PASSED : jiraConfig.statuses.IN_REVIEW_PASSED;
                 jira_move_to_status({ key: ticketKey, statusName: passedStatus });
                 console.log('✅ Passed — moved', ticketKey, 'to', passedStatus);
             } catch (e) {
@@ -585,7 +586,7 @@ function action(params) {
         } else {
             // Bug creation is handled by the bug_creation agent when TC reaches Failed status
             try {
-                var failedStatus = noCodeChanges ? STATUSES.FAILED : STATUSES.IN_REVIEW_FAILED;
+                var failedStatus = noCodeChanges ? jiraConfig.statuses.FAILED : jiraConfig.statuses.IN_REVIEW_FAILED;
                 jira_move_to_status({ key: ticketKey, statusName: failedStatus });
                 console.log('✅ Failed — moved', ticketKey, 'to', failedStatus);
             } catch (e) {

--- a/js/postTestReviewComments.js
+++ b/js/postTestReviewComments.js
@@ -11,7 +11,7 @@
  *   - Moves to In Rework
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 const gh = require('./common/githubHelpers.js');
 const autoStart = require('./common/autoStart.js');
 const configLoader = require('./configLoader.js');
@@ -282,6 +282,7 @@ function action(params) {
         const ticketKey = params.ticket.key;
         const jiraComment = params.response || '';
         const config = configLoader.loadProjectConfig(params.jobParams || params);
+        const jiraConfig = config.jira;
         const customParams = resolveCustomParams(params, config);
         const workingDir = config.workingDir || null;
 
@@ -406,7 +407,7 @@ function action(params) {
             autoStart.triggerSmIfIdle({ config: config, customParams: customParams });
         } else {
             try {
-                jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+                jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 console.log('✅ Changes requested — moved', ticketKey, 'to In Rework');
                 if (!triggerReworkIfConfigured(ticketKey, config, customParams)) {
                     markForSmTestRework(ticketKey);
@@ -436,11 +437,11 @@ function action(params) {
 
         var finalStatus;
         if (isApproved && !mergeSucceeded) {
-            finalStatus = STATUSES.IN_REWORK;
+            finalStatus = jiraConfig.statuses.IN_REWORK;
         } else if (isApproved) {
-            finalStatus = (currentStatus === STATUSES.IN_REVIEW_PASSED) ? STATUSES.PASSED : STATUSES.FAILED;
+            finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
         } else {
-            finalStatus = STATUSES.IN_REWORK;
+            finalStatus = jiraConfig.statuses.IN_REWORK;
         }
         console.log('✅ Test review workflow complete:', isApproved ? (mergeSucceeded ? 'APPROVED' : 'MERGE CONFLICT') : 'CHANGES REQUESTED');
 

--- a/js/postTestReworkResults.js
+++ b/js/postTestReworkResults.js
@@ -14,7 +14,7 @@ var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
 var feedbackLoop = require('./common/feedbackLoop.js');
 var prHelper = require('./common/pullRequest.js');
-const { GIT_CONFIG, STATUSES, LABELS } = require('./config.js');
+const { GIT_CONFIG, LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function cleanCommandOutput(output) {
@@ -387,6 +387,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const ticketKey = actualParams.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = configLoader.createScm(config);
     const customParams = resolveCustomParams(params, actualParams, config);
     const removeLabel = customParams && customParams.removeLabel;
@@ -515,7 +516,7 @@ function action(params) {
 
         // Step 4: Move ticket to In Review - Passed or In Review - Failed
         // Bug creation/linking is handled by the bug_creation agent when TC reaches Failed status
-        const targetStatus = passed ? STATUSES.IN_REVIEW_PASSED : STATUSES.IN_REVIEW_FAILED;
+        const targetStatus = passed ? jiraConfig.statuses.IN_REVIEW_PASSED : jiraConfig.statuses.IN_REVIEW_FAILED;
         try {
             jira_move_to_status({ key: ticketKey, statusName: targetStatus });
             console.log('✅ Moved', ticketKey, 'to', targetStatus);

--- a/js/preCliTestReworkSetup.js
+++ b/js/preCliTestReworkSetup.js
@@ -80,7 +80,7 @@ function action(params) {
                 const err = 'No test PR and no remote branch found for ' + testBranchName + '. Moving to Backlog for re-automation.';
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ❌ Test Rework Setup Failed\n\n' + err });
-                    jira_move_to_status({ key: ticketKey, statusName: 'Backlog' });
+                    jira_move_to_status({ key: ticketKey, statusName: config.jira.statuses.BACKLOG });
                 } catch (e) {}
                 return { success: false, error: err };
             }

--- a/js/prepareTestPRForReview.js
+++ b/js/prepareTestPRForReview.js
@@ -11,7 +11,7 @@ var configLoader = require('./configLoader.js');
 const gh = require('./common/githubHelpers.js');
 const gitOps = require('./common/gitOps.js');
 var prHelper = require('./common/pullRequest.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 
 function getTicketKey(params) {
     if (params.ticket && params.ticket.key) {
@@ -112,14 +112,16 @@ function isWip(pr, ticket) {
     return false;
 }
 
-function resolveFinalStatus(currentStatus, issueType) {
+function resolveFinalStatus(currentStatus, issueType, jiraConfig) {
     // Test Cases finish in Passed/Failed; Stories and Bugs stay in In Testing
     // so the done-check agents (checkStoryTestsPassed / checkBugTestsPassed)
     // can evaluate all linked Test Cases and move to Done / Bug To Fix / Ready For Testing.
-    if (issueType === 'Test Case') {
-        return currentStatus === 'In Review - Failed' ? 'Failed' : 'Passed';
+    if (issueType === jiraConfig.issueTypes.TEST_CASE) {
+        return currentStatus === jiraConfig.statuses.IN_REVIEW_FAILED
+            ? jiraConfig.statuses.FAILED
+            : jiraConfig.statuses.PASSED;
     }
-    return STATUSES.IN_TESTING;
+    return jiraConfig.statuses.IN_TESTING;
 }
 
 function markTestPrMerged(ticketKey) {
@@ -131,14 +133,14 @@ function markTestPrMerged(ticketKey) {
     }
 }
 
-function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType) {
+function finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig) {
     try {
         markTestPrMerged(ticketKey);
         const ticket = jira_get_ticket({ key: ticketKey });
         const currentStatus = ticket && ticket.fields && ticket.fields.status
             ? ticket.fields.status.name
             : '';
-        const finalStatus = resolveFinalStatus(currentStatus, issueType);
+        const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
         jira_move_to_status({ key: ticketKey, statusName: finalStatus });
         jira_post_comment({
             key: ticketKey,
@@ -164,6 +166,7 @@ function action(params) {
         const inputFolder = getInputFolder(params, ticketKey);
         const issueType = getIssueType(params);
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = config.jira;
         var scm = configLoader.createScm(config);
 
         console.log('=== Preparing test PR for review:', ticketKey, '===');
@@ -198,7 +201,7 @@ function action(params) {
                 const err = 'No test PR and no remote branch found for test/' + ticketKey + '. Ticket needs re-automation.';
                 try {
                     jira_post_comment({ key: ticketKey, comment: 'h3. ⚠️ Test PR Review Setup Failed\n\n' + err + '\n\n_Moving to In Rework so it can be re-automated._' });
-                    jira_move_to_status({ key: ticketKey, statusName: 'In Rework' });
+                    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
                 } catch (e) {}
                 return false;
             }
@@ -230,7 +233,7 @@ function action(params) {
             } catch (createErr) {
                 if (isNoCommitsError(createErr)) {
                     console.log('Branch test/' + ticketKey + ' has no commits ahead of main — test code is already merged.');
-                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType);
+                    finalizeAlreadyMergedTestCase(ticketKey, branchName, issueType, jiraConfig);
                     return false;
                 }
                 const err = 'Branch test/' + ticketKey + ' exists but could not create PR: ' + createErr.toString();
@@ -247,7 +250,7 @@ function action(params) {
                 const ticket = jira_get_ticket({ key: ticketKey });
                 const currentStatus = ticket && ticket.fields && ticket.fields.status
                     ? ticket.fields.status.name : '';
-                const finalStatus = resolveFinalStatus(currentStatus, issueType);
+                const finalStatus = resolveFinalStatus(currentStatus, issueType, jiraConfig);
                 jira_move_to_status({ key: ticketKey, statusName: finalStatus });
                 jira_post_comment({
                     key: ticketKey,
@@ -289,7 +292,7 @@ function action(params) {
         var changedFiles = prDetails.changed_files;
         if (typeof changedFiles === 'number' && changedFiles === 0) {
             console.log('PR #' + pr.number + ' has 0 changed files — test code is already in main');
-            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType);
+            finalizeAlreadyMergedTestCase(ticketKey, branchName || ('test/' + ticketKey), issueType, jiraConfig);
             return false;
         }
 

--- a/js/recoverDirtyReviewTestCase.js
+++ b/js/recoverDirtyReviewTestCase.js
@@ -14,7 +14,6 @@
 
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
-var { STATUSES } = require('./config.js');
 
 var PR_CACHE_FILE = 'outputs/.recover_dirty_prs_cache.json';
 var PR_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -102,6 +101,7 @@ function findOpenPRForTicket(scm, config, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
+    var jiraConfig = config.jira;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -145,7 +145,7 @@ function action(params) {
 
     console.log('PR #' + pr.number + ' is dirty — moving ticket to In Rework for conflict resolution');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('Moved', ticketKey, 'to In Rework');
     } catch (e) {
         console.error('Failed to move to In Rework:', e);

--- a/js/recoverFailedTCBugStatus.js
+++ b/js/recoverFailedTCBugStatus.js
@@ -7,7 +7,7 @@
  * new bug creation.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function removeLabel(ticketKey, label) {
@@ -23,11 +23,13 @@ function action(params) {
     if (!ticketKey) {
         throw new Error('params.ticket.key is missing');
     }
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
 
     console.log('=== Failed TC bug status recovery for', ticketKey, '===');
 
     var linkedBugs = jira_search_by_jql({
-        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in (Done)',
+        jql: 'issue in linkedIssues("' + ticketKey + '") AND issuetype = Bug AND status not in ("' + jiraConfig.statuses.DONE + '")',
         maxResults: 50
     }) || [];
 
@@ -41,8 +43,8 @@ function action(params) {
         return { success: true, action: 'released_for_bulk_bug_creation', ticketKey: ticketKey };
     }
 
-    jira_move_to_status({ key: ticketKey, statusName: STATUSES.BUG_TO_FIX });
-    console.log('Moved', ticketKey, 'to', STATUSES.BUG_TO_FIX);
+    jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BUG_TO_FIX });
+    console.log('Moved', ticketKey, 'to', jiraConfig.statuses.BUG_TO_FIX);
 
     removeLabel(ticketKey, 'sm_bug_creation_triggered');
     removeLabel(ticketKey, 'sm_bulk_bugs_creation_triggered');
@@ -52,7 +54,7 @@ function action(params) {
         key: ticketKey,
         comment: 'h3. 🐛 Linked Non-Done Bug Found — Moved to Bug To Fix\n\n' +
             'This failed test case already has linked non-Done Bug issue(s), so it was moved to *' +
-            STATUSES.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
+            jiraConfig.statuses.BUG_TO_FIX + '* instead of staying in *Failed* and re-running bug creation.'
     });
 
     // Post token usage summary comments (e.g. [story_acceptance_criteria]: {...}) if any provider

--- a/js/recoverMergedPRTicket.js
+++ b/js/recoverMergedPRTicket.js
@@ -3,7 +3,7 @@
  * a review/rework status.
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
@@ -68,6 +68,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var pr = findMergedPRForTicket(scm, ticketKey);
 
@@ -81,8 +82,8 @@ function action(params) {
     console.log('Recovered merged PR #' + prNumber + ' for ' + ticketKey);
 
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.MERGED });
-        console.log('Moved', ticketKey, 'to', STATUSES.MERGED);
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
+        console.log('Moved', ticketKey, 'to', jiraConfig.statuses.MERGED);
     } catch (e) {
         console.warn('Could not move ticket to Merged:', e.message || e);
     }
@@ -97,7 +98,7 @@ function action(params) {
             key: ticketKey,
             comment: 'h3. ✅ Merged PR Recovered\n\n' +
                 'Found already merged PR #' + prNumber + (prUrl ? ' — [View PR|' + prUrl + ']' : '') +
-                '. Ticket moved to *' + STATUSES.MERGED + '* so the normal post-merge pipeline can continue.'
+                '. Ticket moved to *' + jiraConfig.statuses.MERGED + '* so the normal post-merge pipeline can continue.'
         });
     } catch (e) {}
 

--- a/js/recoverStuckTestCase.js
+++ b/js/recoverStuckTestCase.js
@@ -19,7 +19,7 @@
 
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function findPRForTicket(scm, ticketKey) {
@@ -40,6 +40,7 @@ function findPRForTicket(scm, ticketKey) {
 function action(params) {
     var ticketKey = params.ticket && params.ticket.key;
     var config = configLoader.loadProjectConfig(params.jobParams || params || {});
+    var jiraConfig = config.jira;
 
     if (!ticketKey) {
         console.error('No ticket key found');
@@ -54,7 +55,7 @@ function action(params) {
     if (!pr) {
         console.log('No open PR found for', ticketKey, '— moving back to Backlog');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
             console.log('✅ Moved', ticketKey, 'to Backlog');
         } catch (e) {
             console.error('Failed to move to Backlog:', e);
@@ -86,7 +87,7 @@ function action(params) {
     if (mergeableState === 'dirty' || mergeableState === 'conflicting' || mergeable === false) {
         console.log('PR has conflicts — moving ticket to In Rework');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
             console.log('✅ Moved', ticketKey, 'to In Rework');
         } catch (e) {
             console.error('Failed to move to In Rework:', e);
@@ -104,7 +105,7 @@ function action(params) {
     // PR is clean/mergeable — move to In Review - Passed for review
     console.log('PR looks clean — moving ticket to In Review - Passed');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REVIEW_PASSED });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REVIEW_PASSED });
         console.log('✅ Moved', ticketKey, 'to In Review - Passed');
     } catch (e) {
         console.error('Failed to move to In Review - Passed:', e);

--- a/js/retryMergePR.js
+++ b/js/retryMergePR.js
@@ -10,7 +10,7 @@
  *  - Conflict / CI failing    → remove pr_approved label, move ticket to In Rework, post comment
  */
 
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var scmModule = require('./common/scm.js');
 var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
@@ -122,6 +122,7 @@ function action(params) {
     }
 
     var config = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = config.jira;
     var scm = scmModule.createScm(config);
     var customParams = resolveCustomParams(params, config);
 
@@ -197,7 +198,7 @@ function action(params) {
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE CONFLICT* — PR #' + prNumber + ' has a merge conflict with main. Please resolve conflicts and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (merge conflict)');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
         return true;
@@ -226,11 +227,11 @@ function action(params) {
         if (isTestCase) {
             var ticketDetail = jira_get_ticket({ key: ticketKey });
             var currentStatus = ticketDetail && ticketDetail.fields && ticketDetail.fields.status && ticketDetail.fields.status.name;
-            var finalStatus = (currentStatus === STATUSES.IN_REVIEW_PASSED) ? STATUSES.PASSED : STATUSES.FAILED;
+            var finalStatus = (currentStatus === jiraConfig.statuses.IN_REVIEW_PASSED) ? jiraConfig.statuses.PASSED : jiraConfig.statuses.FAILED;
             jira_move_to_status({ key: ticketKey, statusName: finalStatus });
             console.log('✅ Ticket moved to ' + finalStatus);
         } else {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.MERGED });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.MERGED });
             console.log('✅ Ticket moved to Merged');
         }
 
@@ -261,7 +262,7 @@ function action(params) {
             key: ticketKey,
             comment: '{panel:bgColor=#FFEBE6|borderColor=#DE350B}⚠️ *MERGE FAILED* — Could not merge PR #' + prNumber + ': ' + reason + '. Please check and re-push.\n\n[View PR|' + prUrl + ']{panel}'
         });
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.IN_REWORK });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.IN_REWORK });
         console.log('✅ Ticket moved to In Rework (' + reason + ')');
         triggerAutoStartRework(ticketKey, customParams, config, scm);
 

--- a/js/storyTestAutomationRework.js
+++ b/js/storyTestAutomationRework.js
@@ -6,7 +6,7 @@
 var configLoader = require('./configLoader.js');
 var autoStart = require('./common/autoStart.js');
 var prHelper = require('./common/pullRequest.js');
-const { STATUSES, LABELS } = require('./config.js');
+const { LABELS } = require('./config.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 function smLabelForContext(contextId) {
@@ -204,6 +204,7 @@ function action(params) {
     const actualParams = params.ticket ? params : (params.jobParams || params);
     const storyKey = actualParams.ticket.key;
     const config = configLoader.loadProjectConfig(params.jobParams || params);
+    const jiraConfig = config.jira;
     const scm = configLoader.createScm(config);
     const customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
     const contextId = actualParams.metadata && actualParams.metadata.contextId;
@@ -274,8 +275,8 @@ function action(params) {
 
         // Step 3: Move Story back to In Testing
         try {
-            jira_move_to_status({ key: storyKey, statusName: STATUSES.IN_TESTING });
-            console.log('✅ Moved Story', storyKey, 'to', STATUSES.IN_TESTING);
+            jira_move_to_status({ key: storyKey, statusName: jiraConfig.statuses.IN_TESTING });
+            console.log('✅ Moved Story', storyKey, 'to', jiraConfig.statuses.IN_TESTING);
         } catch (e) {
             console.warn('Failed to move Story to In Testing:', e);
         }

--- a/js/unblockResolvedDependencies.js
+++ b/js/unblockResolvedDependencies.js
@@ -34,7 +34,9 @@ function action(params) {
         jiraConfig.statuses.DONE,
         jiraConfig.statuses.MERGED,
         jiraConfig.statuses.PASSED,
-        jiraConfig.statuses.IRRELEVANT
+        jiraConfig.statuses.IRRELEVANT,
+        // Not part of STATUSES/config — kept as a literal for backward compatibility
+        'Closed'
     ].filter(Boolean);
 
     console.log('=== Unblock resolved dependencies check for', ticketKey, '===');

--- a/js/unblockResolvedDependencies.js
+++ b/js/unblockResolvedDependencies.js
@@ -8,25 +8,17 @@
  * - Otherwise leaves the ticket in Blocked.
  */
 
-const { STATUSES } = require('./config.js');
+const configLoader = require('./configLoader.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 
-const TERMINAL_STATUSES = [
-    STATUSES.DONE,
-    STATUSES.MERGED,
-    STATUSES.PASSED,
-    'Closed',
-    'Irrelevant'
-];
-
-function isResolved(blocker) {
+function isResolved(blocker, terminalStatuses) {
     // Deleted ticket — no inwardIssue object at all
     if (!blocker) return true;
 
     var statusName = blocker.fields && blocker.fields.status && blocker.fields.status.name;
     if (!statusName) return false;
 
-    return TERMINAL_STATUSES.indexOf(statusName) !== -1;
+    return terminalStatuses.indexOf(statusName) !== -1;
 }
 
 function action(params) {
@@ -35,6 +27,15 @@ function action(params) {
         console.error('No ticket key provided');
         return { success: false, action: 'missing_ticket' };
     }
+
+    var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+    var jiraConfig = projectConfig.jira;
+    var terminalStatuses = [
+        jiraConfig.statuses.DONE,
+        jiraConfig.statuses.MERGED,
+        jiraConfig.statuses.PASSED,
+        jiraConfig.statuses.IRRELEVANT
+    ].filter(Boolean);
 
     console.log('=== Unblock resolved dependencies check for', ticketKey, '===');
 
@@ -64,7 +65,7 @@ function action(params) {
     if (blockers.length === 0) {
         console.log('No active blockers found — moving', ticketKey, 'to Backlog');
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
             jira_post_comment({
                 key: ticketKey,
                 comment: 'h3. ✅ Auto-unblocked — No Active Blockers\n\n' +
@@ -85,7 +86,7 @@ function action(params) {
         var b = blockers[j];
         var bKey = b.key || '?';
         var bStatus = b.fields && b.fields.status && b.fields.status.name || 'Unknown';
-        if (isResolved(b)) {
+        if (isResolved(b, terminalStatuses)) {
             console.log('  Blocker', bKey, 'is resolved (', bStatus, ')');
         } else {
             console.log('  Blocker', bKey, 'is NOT resolved (', bStatus, ')');
@@ -101,7 +102,7 @@ function action(params) {
     // All blockers resolved → move to Backlog
     console.log('All', blockers.length, 'blocker(s) resolved — moving', ticketKey, 'to Backlog');
     try {
-        jira_move_to_status({ key: ticketKey, statusName: STATUSES.BACKLOG });
+        jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.BACKLOG });
     } catch (e) {
         console.warn('Failed to move ticket to Backlog:', e.message || e);
         return { success: false, action: 'move_failed', error: e.toString() };

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -29,6 +29,7 @@
         "js/unit-tests/test_recoverMergedPRTicket.js",
         "js/unit-tests/test_recoverStuckTestCase.js",
         "js/unit-tests/test_recoverFailedTCBugStatus.js",
+        "js/unit-tests/test_unblockResolvedDependencies.js",
         "js/unit-tests/test_feedbackLoop.js",
         "js/unit-tests/test_setupCommands.js",
         "js/unit-tests/test_outputFiles.js",

--- a/js/unit-tests/run_unblockResolvedDependencies.json
+++ b/js/unit-tests/run_unblockResolvedDependencies.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_unblockResolvedDependencies.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/testRunner.js
+++ b/js/unit-tests/testRunner.js
@@ -192,6 +192,53 @@ function makeRequire(moduleMap) {
     };
 }
 
+/**
+ * Default jira section for configLoader mocks — mirrors config.js STATUSES/ISSUE_TYPES.
+ */
+function makeDefaultJiraConfig() {
+    return {
+        issueTypes: configModule.ISSUE_TYPES,
+        statuses: configModule.STATUSES
+    };
+}
+
+/**
+ * configLoader mock that returns default jira statuses/issue types plus optional overrides.
+ */
+function makeDefaultConfigLoaderMock(extraConfig) {
+    return {
+        loadProjectConfig: function(params) {
+            var cfg = extraConfig || {};
+            var result = {
+                jira: makeDefaultJiraConfig()
+            };
+            if (cfg.repository) {
+                result.repository = cfg.repository;
+            }
+            if (cfg.jobParamPatches) {
+                result.jobParamPatches = cfg.jobParamPatches;
+            }
+            if (cfg.jira) {
+                if (cfg.jira.issueTypes) {
+                    for (var it in cfg.jira.issueTypes) {
+                        if (cfg.jira.issueTypes.hasOwnProperty(it)) {
+                            result.jira.issueTypes[it] = cfg.jira.issueTypes[it];
+                        }
+                    }
+                }
+                if (cfg.jira.statuses) {
+                    for (var st in cfg.jira.statuses) {
+                        if (cfg.jira.statuses.hasOwnProperty(st)) {
+                            result.jira.statuses[st] = cfg.jira.statuses[st];
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+    };
+}
+
 // ── Main action ───────────────────────────────────────────────────────────────
 
 function action(params) {

--- a/js/unit-tests/testRunner.js
+++ b/js/unit-tests/testRunner.js
@@ -194,11 +194,12 @@ function makeRequire(moduleMap) {
 
 /**
  * Default jira section for configLoader mocks — mirrors config.js STATUSES/ISSUE_TYPES.
+ * Returns shallow copies so per-test overrides never mutate the shared config module.
  */
 function makeDefaultJiraConfig() {
     return {
-        issueTypes: configModule.ISSUE_TYPES,
-        statuses: configModule.STATUSES
+        issueTypes: Object.assign({}, configModule.ISSUE_TYPES),
+        statuses: Object.assign({}, configModule.STATUSES)
     };
 }
 

--- a/js/unit-tests/test_checkBugTestsPassed.js
+++ b/js/unit-tests/test_checkBugTestsPassed.js
@@ -4,18 +4,14 @@
 
 function loadCheckBugTestsPassed(mocks) {
     mocks = mocks || {};
-    var configLoaderMock = {
-        loadProjectConfig: function() {
-            return {
-                jira: {
-                    issueTypes: {
-                        TEST_CASE: 'Test Case',
-                        BUG: 'Bug'
-                    }
-                }
-            };
+    var configLoaderMock = makeDefaultConfigLoaderMock({
+        jira: {
+            issueTypes: {
+                TEST_CASE: 'Test Case',
+                BUG: 'Bug'
+            }
         }
-    };
+    });
 
     return loadModule(
         'js/checkBugTestsPassed.js',

--- a/js/unit-tests/test_checkBugToFixReady.js
+++ b/js/unit-tests/test_checkBugToFixReady.js
@@ -8,6 +8,7 @@ function loadCheckBugToFixReady(mocks) {
         'js/checkBugToFixReady.js',
         makeRequire({
             './config.js': configModule,
+            './configLoader.js': makeDefaultConfigLoaderMock(),
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         mocks

--- a/js/unit-tests/test_checkStoryTestsPassed.js
+++ b/js/unit-tests/test_checkStoryTestsPassed.js
@@ -241,4 +241,32 @@ suite('checkStoryTestsPassed', function() {
         assert.deepEqual(removedLabels, [{ key: 'TS-60', label: 'sm_story_done_check_triggered' }]);
     });
 
+    test('honors customParams.customStatuses override over config statuses', function() {
+        var moved = [];
+
+        var module = loadCheckStoryTestsPassed({
+            jira_search_by_jql: function(args) {
+                if (args.jql.indexOf('issuetype = "Test Case"') !== -1) {
+                    return [makeTc('TS-81', 'Bug To Fix')];
+                }
+                if (args.jql.indexOf('issuetype = "Bug"') !== -1) {
+                    return [{ key: 'TS-90', fields: { status: { name: 'Done' } } }];
+                }
+                return [];
+            },
+            jira_move_to_status: function(args) { moved.push(args); },
+            jira_post_comment: function() {},
+            jira_remove_label: function() {}
+        });
+
+        var result = module.action({
+            ticket: { key: 'TS-80' },
+            jobParams: { customParams: { customStatuses: { READY_FOR_TESTING: 'Retest Needed' } } }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.action, 'moved_to_ready_for_testing');
+        assert.deepEqual(moved, [{ key: 'TS-80', statusName: 'Retest Needed' }]);
+    });
+
 });

--- a/js/unit-tests/test_checkStoryTestsPassed.js
+++ b/js/unit-tests/test_checkStoryTestsPassed.js
@@ -4,18 +4,14 @@
 
 function loadCheckStoryTestsPassed(mocks) {
     mocks = mocks || {};
-    var configLoaderMock = {
-        loadProjectConfig: function() {
-            return {
-                jira: {
-                    issueTypes: {
-                        TEST_CASE: 'Test Case',
-                        BUG: 'Bug'
-                    }
-                }
-            };
+    var configLoaderMock = makeDefaultConfigLoaderMock({
+        jira: {
+            issueTypes: {
+                TEST_CASE: 'Test Case',
+                BUG: 'Bug'
+            }
         }
-    };
+    });
 
     return loadModule(
         'js/checkStoryTestsPassed.js',

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -116,13 +116,31 @@ suite('configLoader.mergeProjectConfig', function() {
         assert.equal(result.git.authorName, defaults.git.authorName, 'other git fields preserved');
     });
 
-    test('fully replaces jira.statuses when provided', function() {
+    test('merges jira.statuses over defaults when provided', function() {
         var customStatuses = { DONE: 'Closed', IN_REVIEW: 'Under Review' };
         var result = configLoaderModule.mergeProjectConfig(defaults, {
             jira: { statuses: customStatuses }
         });
-        assert.deepEqual(result.jira.statuses, customStatuses);
-        assert.notOk(result.jira.statuses.BACKLOG, 'old statuses removed');
+        assert.equal(result.jira.statuses.DONE, 'Closed', 'override applied');
+        assert.equal(result.jira.statuses.IN_REVIEW, 'Under Review', 'override applied');
+        assert.equal(result.jira.statuses.BACKLOG, 'Backlog', 'unspecified keys keep defaults');
+    });
+
+    test('merges jira.issueTypes over defaults when provided', function() {
+        var result = configLoaderModule.mergeProjectConfig(defaults, {
+            jira: { issueTypes: { TEST_CASE: 'XRay Test' } }
+        });
+        assert.equal(result.jira.issueTypes.TEST_CASE, 'XRay Test', 'override applied');
+        assert.equal(result.jira.issueTypes.BUG, 'Bug', 'unspecified keys keep defaults');
+        assert.equal(result.jira.issueTypes.STORY, 'Story', 'unspecified keys keep defaults');
+    });
+
+    test('explicit null jira.statuses/issueTypes falls back to defaults', function() {
+        var result = configLoaderModule.mergeProjectConfig(defaults, {
+            jira: { statuses: null, issueTypes: null }
+        });
+        assert.equal(result.jira.statuses.DONE, 'Done', 'default statuses restored');
+        assert.equal(result.jira.issueTypes.BUG, 'Bug', 'default issueTypes restored');
     });
 
     test('preserves default statuses when not overridden', function() {
@@ -672,7 +690,7 @@ suite('configLoader: testCaseIssueType', function() {
         assert.equal(configModule.ISSUE_TYPES.TEST_CASE, 'Test Case');
     });
 
-    test('custom testCaseIssueType survives mergeProjectConfig as full replacement', function() {
+    test('custom testCaseIssueType survives mergeProjectConfig merge', function() {
         var config = configLoaderModule.mergeProjectConfig(configLoaderModule.DEFAULTS, {
             jira: {
                 issueTypes: {

--- a/js/unit-tests/test_finishTestCasesGeneration.js
+++ b/js/unit-tests/test_finishTestCasesGeneration.js
@@ -8,6 +8,7 @@ function loadFinishTestCasesGeneration(mocks) {
         'js/finishTestCasesGeneration.js',
         makeRequire({
             './config.js': configModule,
+            './configLoader.js': makeDefaultConfigLoaderMock(),
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         mocks

--- a/js/unit-tests/test_postBugCreation.js
+++ b/js/unit-tests/test_postBugCreation.js
@@ -16,6 +16,7 @@ function loadPostBugCreation(mocks) {
         'js/postBugCreation.js',
         makeRequire({
             './config.js': configModule,
+            './configLoader.js': makeDefaultConfigLoaderMock(),
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         Object.assign({}, defaults, mocks)

--- a/js/unit-tests/test_recoverFailedTCBugStatus.js
+++ b/js/unit-tests/test_recoverFailedTCBugStatus.js
@@ -24,6 +24,7 @@ function loadRecoverFailedTCBugStatus(mocks) {
         'js/recoverFailedTCBugStatus.js',
         makeRequire({
             './config.js': configModule,
+            './configLoader.js': makeDefaultConfigLoaderMock(),
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         Object.assign({}, defaults, mocks || {})
@@ -38,7 +39,7 @@ suite('recoverFailedTCBugStatus', function() {
         var loaded = loadRecoverFailedTCBugStatus({
             jira_search_by_jql: function(args) {
                 loaded.calls.searches.push(args);
-                if (args.jql.indexOf('status not in (Done)') !== -1) {
+                if (args.jql.indexOf('status not in ("Done")') !== -1) {
                     return [{ key: 'TS-1289' }];
                 }
                 return [];
@@ -63,7 +64,7 @@ suite('recoverFailedTCBugStatus', function() {
         var loaded = loadRecoverFailedTCBugStatus({
             jira_search_by_jql: function(args) {
                 loaded.calls.searches.push(args);
-                if (args.jql.indexOf('status not in (Done)') !== -1) {
+                if (args.jql.indexOf('status not in ("Done")') !== -1) {
                     return [];
                 }
                 return [];

--- a/js/unit-tests/test_recoverMergedPRTicket.js
+++ b/js/unit-tests/test_recoverMergedPRTicket.js
@@ -15,11 +15,9 @@ function loadRecoverMergedPRTicket(options) {
         'js/recoverMergedPRTicket.js',
         makeRequire({
             './config.js': configModule,
-            './configLoader.js': {
-                loadProjectConfig: function() {
-                    return { repository: { owner: 'IstiN', repo: 'trackstate' } };
-                }
-            },
+            './configLoader.js': makeDefaultConfigLoaderMock({
+                repository: { owner: 'IstiN', repo: 'trackstate' }
+            }),
             './common/scm.js': { createScm: function() { return scm; } },
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),

--- a/js/unit-tests/test_recoverStuckTestCase.js
+++ b/js/unit-tests/test_recoverStuckTestCase.js
@@ -15,11 +15,9 @@ function loadRecoverStuckTestCase(options) {
         'js/recoverStuckTestCase.js',
         makeRequire({
             './config.js': configModule,
-            './configLoader.js': {
-                loadProjectConfig: function() {
-                    return { repository: { owner: 'IstiN', repo: 'trackstate' } };
-                }
-            },
+            './configLoader.js': makeDefaultConfigLoaderMock({
+                repository: { owner: 'IstiN', repo: 'trackstate' }
+            }),
             './common/scm.js': { createScm: function() { return scm; } },
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),

--- a/js/unit-tests/test_retryMergePR.js
+++ b/js/unit-tests/test_retryMergePR.js
@@ -7,6 +7,10 @@ function loadRetryMergePR(options) {
     var autoStartCalls = [];
     var config = options.config || {
         repository: { owner: 'IstiN', repo: 'trackstate' },
+        jira: {
+            issueTypes: configModule.ISSUE_TYPES,
+            statuses: configModule.STATUSES
+        },
         jobParamPatches: {
             retry_merge: {
                 customParams: {

--- a/js/unit-tests/test_unblockResolvedDependencies.js
+++ b/js/unit-tests/test_unblockResolvedDependencies.js
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for js/unblockResolvedDependencies.js.
+ */
+
+function loadUnblockResolvedDependencies(mocks) {
+    var calls = {
+        statusMoves: [],
+        comments: []
+    };
+
+    var defaults = {
+        jira_get_ticket: function() {
+            return { fields: { issuelinks: [] } };
+        },
+        jira_move_to_status: function(args) { calls.statusMoves.push(args); },
+        jira_post_comment: function(args) { calls.comments.push(args); }
+    };
+
+    var mod = loadModule(
+        'js/unblockResolvedDependencies.js',
+        makeRequire({
+            './config.js': configModule,
+            './configLoader.js': makeDefaultConfigLoaderMock(),
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+        }),
+        Object.assign({}, defaults, mocks || {})
+    );
+
+    return { mod: mod, calls: calls };
+}
+
+function ticketBlockedBy(statusName) {
+    return {
+        fields: {
+            issuelinks: [
+                {
+                    type: { name: 'Blocks' },
+                    inwardIssue: { key: 'PROJ-1', fields: { status: { name: statusName } } }
+                }
+            ]
+        }
+    };
+}
+
+suite('unblockResolvedDependencies', function() {
+
+    test('blocker in literal "Closed" status counts as resolved', function() {
+        var loaded = loadUnblockResolvedDependencies({
+            jira_get_ticket: function() { return ticketBlockedBy('Closed'); }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'PROJ-2' } });
+
+        assert.equal(result.action, 'moved_to_backlog');
+        assert.deepEqual(loaded.calls.statusMoves, [
+            { key: 'PROJ-2', statusName: 'Backlog' }
+        ]);
+    });
+
+    test('blocker in a non-terminal status keeps ticket Blocked', function() {
+        var loaded = loadUnblockResolvedDependencies({
+            jira_get_ticket: function() { return ticketBlockedBy('In Progress'); }
+        });
+
+        var result = loaded.mod.action({ ticket: { key: 'PROJ-2' } });
+
+        assert.equal(result.action, 'still_blocked');
+        assert.deepEqual(loaded.calls.statusMoves, []);
+    });
+
+    test('ticket without blockers is moved to Backlog', function() {
+        var loaded = loadUnblockResolvedDependencies();
+
+        var result = loaded.mod.action({ ticket: { key: 'PROJ-2' } });
+
+        assert.equal(result.action, 'moved_to_backlog_no_blockers');
+        assert.deepEqual(loaded.calls.statusMoves, [
+            { key: 'PROJ-2', statusName: 'Backlog' }
+        ]);
+    });
+
+});

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -14,7 +14,7 @@
  *                   Useful for tickets (e.g. bugs) where the field already has content that must be preserved.
  */
 
-const { LABELS, DIAGRAM_FORMAT, JIRA_FIELDS, STATUSES } = require('./config.js');
+const { LABELS, DIAGRAM_FORMAT, JIRA_FIELDS } = require('./config.js');
 const configLoader = require('./configLoader.js');
 const scmModule = require('./common/scm.js');
 const autoStart = require('./common/autoStart.js');
@@ -32,6 +32,7 @@ function action(params) {
         // Resolve field names from customParams if provided
         var customParams = (params.customParams) || (params.jobParams && params.jobParams.customParams) || {};
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
+        var jiraConfig = projectConfig.jira;
         var solutionField = customParams.solutionField || JIRA_FIELDS.SOLUTION;
         var diagramField  = (customParams.diagramField !== undefined) ? customParams.diagramField : JIRA_FIELDS.DIAGRAMS;
         var outputType    = customParams.outputType || 'replace'; // 'replace' | 'append'
@@ -122,7 +123,7 @@ function action(params) {
 
         // 7. Move to Ready For Development
         try {
-            jira_move_to_status({ key: ticketKey, statusName: STATUSES.READY_FOR_DEVELOPMENT });
+            jira_move_to_status({ key: ticketKey, statusName: jiraConfig.statuses.READY_FOR_DEVELOPMENT });
             console.log('Moved ' + ticketKey + ' to Ready For Development');
         } catch (e) {
             console.warn('Failed to move to Ready For Development:', e);


### PR DESCRIPTION
## Summary

Replaces hardcoded `STATUSES` / `ISSUE_TYPES` imports from static `config.js` with project-specific values resolved via `configLoader.loadProjectConfig()` → `projectConfig.jira`. This makes ~30 `postJSAction` scripts work correctly when a target repo overrides workflow names in `.dmtools/config.js`.

Supersedes #277 and #278 with a focused branch (`feat/jira-config-statuses`) that includes post-cherry-pick source fixes and updated unit test mocks.

## Test results

**All 617 unit tests passed** (`dmtools run js/unit-tests/run_all.json`).

```
$env:JIRA_BASE_PATH="https://example.atlassian.net"
$env:JIRA_EMAIL="test@example.com"
$env:JIRA_API_TOKEN="dummy-token"
dmtools run js/unit-tests/run_all.json --debug
```

(Dummy JIRA env vars are required because dmtools 1.7.226 initializes a tracker client even for unit tests.)

## What changed

- **Tier 1** (already called `loadProjectConfig`): added `jiraConfig` alias; replaced `STATUSES.*` / `ISSUE_TYPES.*`
- **Tier 2** (no prior config load): added `configLoader` import + `loadProjectConfig` at `action()` entry
- **Helpers** outside `action()`: `jiraConfig` threaded as explicit parameter
- **JQL strings**: status literals interpolated from `jiraConfig.statuses.*`
- **Follow-up fixes**: corrected `jiraConfig.jiraConfig` typo, leftover `STATUSES.DONE`, missing `jiraConfig` args in `postBulkBugsCreation.js`, and unit test mocks via `makeDefaultConfigLoaderMock()`

## Backward compatibility

No breaking changes. Projects without `.dmtools/config.js` continue using the same defaults from `config.js`.

## Test plan

- [x] Full unit test suite: 617/617 passed
- [ ] Deploy to a project with custom status names in `.dmtools/config.js` and confirm transitions use overridden names
