### PR TITLE
fix(warmup-session): auto-authenticate git for private GitHub repos

### DIFF
--- a/scripts/warmup-session.md
+++ b/scripts/warmup-session.md
@@ -48,6 +48,14 @@ this fast, just a repo sync).
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Private repo: a fresh session has no credential helper and no TTY, so a
+# plain `git clone https://github.com/...` fails with "could not read
+# Username ... Device not configured". Authenticate before the FIRST clone
+# (warmup-session.sh itself repeats this line internally for everything it
+# clones/fetches afterwards, but that's too late for this bootstrap clone).
+# Skip this line entirely if your-org/your-product-repo is public.
+git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
 git clone --recurse-submodules https://github.com/your-org/your-product-repo.git repo
 bash repo/agents/scripts/warmup-session.sh \
   --repo https://github.com/your-org/your-product-repo.git \
@@ -65,6 +73,13 @@ twice on a truly fresh session.)
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Needed again here for private repos: the `git config --global` from the
+# warmup script only persists if the session's home directory is on a
+# persistent disk carried over between starts. Setting it unconditionally in
+# both scripts is cheap and avoids depending on that persistence guarantee.
+git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
 cd repo
 git fetch origin
 git checkout main

--- a/scripts/warmup-session.sh
+++ b/scripts/warmup-session.sh
@@ -53,6 +53,24 @@ done
 [ -n "${REPO_URL}" ] || { echo "❌ --repo is required" >&2; usage; }
 [ -n "${TARGET_DIR}" ] || { echo "❌ --dir is required" >&2; usage; }
 
+# ── Auto-configure GitHub HTTPS auth for private repos ───────────────────────
+# A fresh cloud session (Bitrise Dev Environments, throwaway VM/container, ...)
+# has no git credential helper and no TTY, so a plain `git clone
+# https://github.com/...` against a private repo fails hard with:
+#   fatal: could not read Username for 'https://github.com': Device not configured
+# If GH_TOKEN or PAT_TOKEN is already exported (as it should be — see the
+# "Secrets" note above), rewrite all https://github.com/ URLs to embed it, so
+# every clone/fetch/pull/submodule-update below (and anything a later
+# `run-agent.sh`/`run-teammate-local.sh` does) authenticates transparently —
+# including submodules hosted under a different GitHub org (e.g. this
+# `agents` submodule). No-op if neither var is set (public repo, or the
+# session template already configured its own credential helper/SSH key).
+GH_AUTH_TOKEN="${GH_TOKEN:-${PAT_TOKEN:-}}"
+if [ -n "${GH_AUTH_TOKEN}" ]; then
+  git config --global "url.https://x-access-token:${GH_AUTH_TOKEN}@github.com/.insteadOf" "https://github.com/"
+  echo "🔑 Configured git to authenticate github.com HTTPS clones with GH_TOKEN/PAT_TOKEN"
+fi
+
 echo "── Bootstrapping session ──────────────────────────────────────────────"
 echo "Repo:    ${REPO_URL}"
 echo "Dir:     ${TARGET_DIR}"


### PR DESCRIPTION
## Problem
A fresh dev-environment session (Bitrise Dev Environments, throwaway VM/container, ...) has no git credential helper and no TTY. A plain `git clone https://github.com/...` against a **private** repo fails hard:

```
fatal: could not read Username for 'https://github.com': Device not configured
```

Observed live on a Bitrise Dev Environments macOS session bootstrapping `EPAM-DarkFactory/SH_ANDR_WIP`: the warmup script's clone failed at this exact error, so the target directory never got created, the startup script then failed on `cd repo: No such file or directory`, and `agents/scripts/install.sh` (java/node/dmtools/android/...) never ran — leaving the session with **no Android SDK and no dmtools at all**.

## Fix
- `warmup-session.sh` now rewrites all `https://github.com/` URLs to embed `GH_TOKEN`/`PAT_TOKEN` (whichever is set) via `git config --global url.insteadOf` at the very start, before its own clone/fetch/pull/submodule-update calls. No-op when neither var is set (public repo, or the platform already configured its own credential helper/SSH key).
- `warmup-session.md`: the Bitrise example does a bootstrap `git clone` *before* calling `warmup-session.sh` (to fetch the script itself), so that clone can't benefit from the fix above — added the same `git config` line explicitly to both the warmup and startup script field examples.

## Testing
- `bash -n scripts/warmup-session.sh` — syntax OK.
- Manually verified the failure mode against the real Bitrise session logs (clone failure → cascading startup failure → toolchain never installed).