### PR TITLE
fix(warmup): run toolchain install inside the target repo; make emulator install verifiable

### DIFF
--- a/scripts/warmup-session.sh
+++ b/scripts/warmup-session.sh
@@ -106,7 +106,14 @@ for tool in ${EXCLUDE_TOOLS}; do
 done
 
 echo "── Installing/pre-warming toolchain ───────────────────────────────────"
+# Run install.sh with the product repo as CWD — several tools resolve
+# relative to the current working directory (gradle.sh looks for ./gradlew
+# to pre-warm; CodeGraph's auto-init checks whether CWD is a git repo before
+# indexing it). Without this, both silently no-op when warmup-session.sh
+# itself was invoked from outside the target repo (the common case: the
+# Bitrise "warmup" script field clones into --dir first, then calls this
+# script from the session's home directory, not from inside --dir).
 # shellcheck disable=SC2086
-bash "${AGENTS_DIR}/setup/install.sh" all "${EXCLUDE_FLAGS[@]}" ${INSTALL_ARGS}
+( cd "${TARGET_DIR}" && bash "${AGENTS_DIR}/setup/install.sh" all "${EXCLUDE_FLAGS[@]}" ${INSTALL_ARGS} )
 
 echo "✅ Session warmed up. Repo is at ${TARGET_DIR} (branch: $(git -C "${TARGET_DIR}" rev-parse --abbrev-ref HEAD))."

--- a/setup/emulator.sh
+++ b/setup/emulator.sh
@@ -67,12 +67,40 @@ case "${ARCH}" in
 esac
 
 IMAGE="system-images;android-${API};${TAG};${ABI}"
+IMAGE_DIR="${ANDROID_HOME}/system-images/android-${API}/${TAG}/${ABI}"
 echo "🤖 Android emulator [avd=${AVD_NAME} image=${IMAGE} profile=${PROFILE} arch=${ARCH}]"
 
 # ── Install the system image + emulator binary (idempotent) ──────────────────
+# `sdkmanager` can exit 0 without actually laying the package down on disk if
+# an unexpected license prompt eats stdin mid-install (only --licenses' own
+# prompts are pre-answered by the `yes` below, not ones triggered later by
+# this specific package) or a transient network blip drops the download —
+# and it prints nothing distinctive when that happens. Rather than trust the
+# exit code, verify the package actually landed under IMAGE_DIR afterwards,
+# retry once, and only then fail loudly with the captured log tail — this
+# turns what was previously a silent no-op into either a working emulator or
+# an actionable error (instead of avdmanager's cryptic downstream
+# "Package path is not valid ... null").
 echo "📥 Ensuring ${IMAGE} + emulator package are installed..."
 yes | sdkmanager --licenses > /dev/null 2>&1 || true
-sdkmanager "emulator" "${IMAGE}" --sdk_root="${ANDROID_HOME}" > /dev/null
+
+SDK_INSTALL_LOG="/tmp/sdkmanager-install-${AVD_NAME}.log"
+install_image() {
+  yes | sdkmanager "emulator" "${IMAGE}" --sdk_root="${ANDROID_HOME}" > "${SDK_INSTALL_LOG}" 2>&1
+}
+
+install_image || true
+if [ ! -d "${IMAGE_DIR}" ]; then
+  echo "⚠️  ${IMAGE_DIR} missing after first attempt — retrying once..."
+  install_image || true
+fi
+if [ ! -d "${IMAGE_DIR}" ]; then
+  echo "❌ System image did not install: ${IMAGE_DIR} not found after 2 attempts." >&2
+  echo "── sdkmanager output (${SDK_INSTALL_LOG}) ──────────────────────────" >&2
+  tail -n 40 "${SDK_INSTALL_LOG}" >&2 || true
+  exit 1
+fi
+echo "✅ ${IMAGE} present on disk"
 
 # ── Create the AVD if it doesn't already exist (idempotent) ──────────────────
 if avdmanager list avd | grep -qx "Name: ${AVD_NAME}"; then


### PR DESCRIPTION
## Bugs found live on a Bitrise Dev Environments session (SH_ANDR_WIP)

### 1. install.sh ran from the wrong CWD
`warmup-session.sh` ran `install.sh` from whatever directory the warmup script itself was invoked from (the session home dir), not from `--dir` (the cloned product repo). Several tools resolve paths relative to CWD:
- `gradle.sh` looks for `./gradlew` to pre-warm — silently skipped: `⚠️  No gradlew found in working directory — skipping`
- CodeGraph's auto-init checks whether CWD is a git repo before indexing — silently skipped: `ℹ️  Not a git repository — skipping CodeGraph init`

Fix: wrap the `install.sh` call in a subshell that `cd`s into `TARGET_DIR` first.

### 2. emulator.sh trusted sdkmanager's exit code blindly
The system-image install redirected all output to `/dev/null` and assumed exit 0 meant the package landed on disk. On the same session, `sdkmanager` returned 0 without actually installing the arm64-v8a system image, so `avdmanager` failed downstream with a cryptic:
```
Error: Package path is not valid. Valid system image paths are:
null
```

Fix: capture output to a log file, verify the real on-disk package directory (`${ANDROID_HOME}/system-images/android-${API}/${TAG}/${ABI}`) after install, retry once on a miss, and only then fail loudly with the log tail. Turns a silent no-op into either a working emulator or an actionable error.

## Testing
- `bash -n` on both changed scripts — syntax OK.
- Reproduced/diagnosed against real Bitrise session logs; the system-image package itself was confirmed present in `sdkmanager --list`'s catalog (`system-images;android-35;google_apis;arm64-v8a`) and confirmed installable stand-alone on an Apple Silicon Mac, isolating the bug to the install-verification gap rather than a nonexistent package.