### PR TITLE
fix(warmup): resolve AGENTS_DIR to an absolute path before cd'ing into TARGET_DIR

### DIFF
--- a/scripts/warmup-session.sh
+++ b/scripts/warmup-session.sh
@@ -98,6 +98,12 @@ if [ ! -f "${AGENTS_DIR}/setup/install.sh" ]; then
   echo "❌ ${AGENTS_DIR}/setup/install.sh not found — is the 'agents' submodule checked out?" >&2
   exit 1
 fi
+# Resolve to an absolute path NOW, before the `cd "${TARGET_DIR}"` below —
+# TARGET_DIR is typically a relative path (e.g. "repo"), so a relative
+# AGENTS_DIR would otherwise be re-resolved against the new CWD after cd'ing
+# INTO that same directory (producing "repo/repo/agents/..." — "No such
+# file or directory").
+AGENTS_DIR="$(cd "${AGENTS_DIR}" && pwd)"
 
 # Build the exclusion flags for install.sh ("all -tool1 -tool2 ...")
 EXCLUDE_FLAGS=()


### PR DESCRIPTION
## Regression from #282
The previous fix wrapped the `install.sh` call in `( cd "${TARGET_DIR}" && bash "${AGENTS_DIR}/setup/install.sh" ... )`, but `AGENTS_DIR` was still a path relative to the *original* cwd ("${TARGET_DIR}/agents", e.g. "repo/agents"). Once cd'd into `TARGET_DIR`, that same relative string re-resolves against the NEW cwd — effectively looking for "repo/repo/agents/setup/install.sh", which doesn't exist.

Confirmed live on a re-run Bitrise session:
```
bash: repo/agents/setup/install.sh: No such file or directory
```
This failed before `install.sh` executed a single line — so **nothing** installed this run, not just gradle/emulator but java/node/dmtools/copilot/everything.

## Fix
Resolve `AGENTS_DIR` to an absolute path (`$(cd "${AGENTS_DIR}" && pwd)`) right after validating it exists, before the later `cd`.

## Testing
- `bash -n` — syntax OK.
- Standalone simulation of the exact resolution flow (mkdir tmp dir, replicate variable assignments + subshell cd) confirms the script now finds `install.sh` correctly after cd'ing into TARGET_DIR.