### PR TITLE
fix(emulator): verify package.xml, not just directory, before trusting system-image install

### DIFF
--- a/setup/emulator.sh
+++ b/setup/emulator.sh
@@ -89,13 +89,23 @@ install_image() {
   yes | sdkmanager "emulator" "${IMAGE}" --sdk_root="${ANDROID_HOME}" > "${SDK_INSTALL_LOG}" 2>&1
 }
 
+# A merely-existing IMAGE_DIR is NOT proof of a complete install: sdkmanager
+# creates the directory up front and can still leave it truncated (e.g. a
+# dropped download mid-transfer) while still exiting 0 and even reaching this
+# far. The one file every complete SDK package always has — and the same
+# manifest avdmanager itself reads to build its "valid system image paths"
+# list — is package.xml directly under the package directory. Checking for
+# it (instead of just `-d`) is what actually predicts whether avdmanager
+# will recognize the image, rather than just whether *some* files landed.
+image_installed() { [ -f "${IMAGE_DIR}/package.xml" ]; }
+
 install_image || true
-if [ ! -d "${IMAGE_DIR}" ]; then
-  echo "⚠️  ${IMAGE_DIR} missing after first attempt — retrying once..."
+if ! image_installed; then
+  echo "⚠️  ${IMAGE_DIR}/package.xml missing after first attempt — retrying once..."
   install_image || true
 fi
-if [ ! -d "${IMAGE_DIR}" ]; then
-  echo "❌ System image did not install: ${IMAGE_DIR} not found after 2 attempts." >&2
+if ! image_installed; then
+  echo "❌ System image did not install completely: ${IMAGE_DIR}/package.xml not found after 2 attempts." >&2
   echo "── sdkmanager output (${SDK_INSTALL_LOG}) ──────────────────────────" >&2
   tail -n 40 "${SDK_INSTALL_LOG}" >&2 || true
   exit 1


### PR DESCRIPTION
## Bug
The install-verification added in #282 only checked `[ -d "${IMAGE_DIR}" ]`. `sdkmanager` creates the target directory up front, so a truncated/dropped download can still leave that check passing while the package is incomplete.

Confirmed live on a re-run Bitrise session:
```
✅ system-images;android-35;google_apis;arm64-v8a present on disk
🛠  Creating AVD 'agent_avd'...
Error: Package path is not valid. Valid system image paths are:
null
```
avdmanager's own scan found *nothing* despite the directory existing on disk.

## Fix
Check for `package.xml` directly under the package directory instead of just the directory — that manifest file is what every complete SDK package has, and it's the same file avdmanager's scan actually reads to build its system-image list. Verified against a real installed image on a local Mac (`/tmp/probe_sdk`) that `package.xml` sits at the top level of a properly completed package.