### PR TITLE
fix(run-agent): load dmtools.env by splitting on first '=', not via bash source

### DIFF
--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -66,13 +66,22 @@ for arg in "$@"; do
 done
 
 # Load dmtools.env if exists (for local runs)
-# Uses grep to filter only valid KEY=VALUE lines — avoids bash executing bare values
-# (e.g. a multi-line API key where the continuation line has no KEY= prefix)
+# `while IFS='=' read -r k v; ... export "${k}=${v}"` (matching
+# run-teammate-local.sh's loader) instead of `source <(grep ...)`: `source`
+# executes each line as a shell command, so any UNQUOTED value containing
+# spaces (e.g. `JIRA_EXTRA_FIELDS=Acceptance criteria,Solution,...`) is
+# parsed as `KEY=firstword secondword...` — a command invocation, not an
+# assignment — which either errors ("command not found") or, worse, silently
+# leaves that var (and, depending on shell/error-handling quirks, everything
+# defined further down the file) unset. Splitting on the first '=' via `read`
+# preserves the rest of the line — spaces included — as one literal value,
+# with no shell re-evaluation.
 if [ -f "dmtools.env" ]; then
   echo "Loading environment from dmtools.env"
-  set -a
-  source <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' dmtools.env)
-  set +a
+  while IFS='=' read -r k v; do
+    [[ "${k}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    export "${k}=${v}"
+  done < <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' dmtools.env)
 fi
 
 # Extract prompt (last argument).


### PR DESCRIPTION
## Bug
`run-agent.sh` loaded `dmtools.env` via `source <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' dmtools.env)`. `source` executes every line as a shell command — any UNQUOTED value containing spaces (e.g. `JIRA_EXTRA_FIELDS=Acceptance criteria,Solution,Answer,Diagrams,Failed Reason`) is parsed as an env-prefixed command invocation (`KEY=firstword secondword...`), not a plain assignment. This either errors (`command not found`) or silently leaves that variable — and everything else defined further down the file — unset.

Reproduced locally: in this consuming repo's real `dmtools.env`, `FIGMA_TOKEN` sits below the offending `JIRA_EXTRA_FIELDS` line and ended up completely unset (`set -u`: unbound variable) after the old loader ran, despite the token itself being valid (verified with a direct `curl` to `api.figma.com/v1/me` → HTTP 200).

## Fix
Switch to the same safe loader `run-teammate-local.sh` already uses: `while IFS='=' read -r k v; ... export "${k}=${v}"` — splits only on the first `=`, treats everything after it (spaces included) as one literal value, no shell re-evaluation.

## Testing
Reproduced the exact failure and the fix against the real `dmtools.env` from `EPAM-DarkFactory/SH_ANDR_WIP` — old loader left `FIGMA_TOKEN` unset, new loader preserves it (and the multi-word `JIRA_EXTRA_FIELDS` value) intact.