### PR TITLE
fix(android): bump pinned cmdline-tools build from outdated 11.0 to current 22.0

### DIFF
--- a/setup/android.sh
+++ b/setup/android.sh
@@ -49,9 +49,26 @@ OS="$(detect_os)"
 # ── Install sdkmanager if missing ─────────────────────────────────────────────
 if ! is_installed sdkmanager; then
   echo "📥 Installing Android cmdline-tools..."
-  CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+  # Google's repository has no stable "latest" URL alias — build numbers are
+  # baked into the filename and go stale. This was pinned at build 11076708
+  # (cmdline-tools revision 11.0, ~Aug 2024) for a long time, which is old
+  # enough that avdmanager silently fails to recognize newer system images:
+  # confirmed live — sdkmanager installed system-images;android-35;google_apis;
+  # arm64-v8a correctly (verified complete on disk, and via
+  # `sdkmanager --list_installed`), yet avdmanager still failed with
+  # "Package path is not valid. Valid system image paths are: null" on
+  # every attempt, while the SAME package installed under a locally-tested
+  # newer cmdline-tools revision (12.0+) created the AVD without issue.
+  # Bumped to build 15859902 (revision 22.0, current as of this fix) — and,
+  # for Apple Silicon specifically, to the native mac_arm64 variant instead
+  # of the x86_64 build (avoids running the SDK tools under Rosetta).
+  CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-15859902_latest.zip"
   if [ "${OS}" = "macos" ]; then
-    CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-mac-11076708_latest.zip"
+    if [ "$(uname -m)" = "arm64" ]; then
+      CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-mac_arm64-15859902_latest.zip"
+    else
+      CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-mac_x86_64-15859902_latest.zip"
+    fi
   fi
 
   TMP_ZIP="/tmp/cmdline-tools.zip"


### PR DESCRIPTION
## Root cause found
The recurring `avdmanager` failure:
```
Error: Package path is not valid. Valid system image paths are:
null
```
happened despite the system image being verifiably complete on disk AND listed by `sdkmanager --list_installed` (confirmed on a real failing Bitrise session using the diagnostics added in #288).

`android.sh` pinned cmdline-tools at build `11076708` (revision 11.0, ~Aug 2024) — 10 major revisions behind current. Older avdmanager versions don't recognize newer system-image package manifests.

## Verification
Reproduced locally: moved the exact same real `system-images;android-35;google_apis;arm64-v8a` package (byte-for-byte, from a working probe SDK) into a fresh SDK root managed by cmdline-tools 11.0 — `avdmanager create avd` fails identically. Same package, same command, under cmdline-tools 22.0 — succeeds end-to-end (AVD created, listed via `avdmanager list avd` with correct target/device). Verified under both Java 17 (matching the Bitrise VM's Java version) and local default Java.

## Fix
Bumped to build `15859902` (revision 22.0 — current `cmdline-tools;latest` per Google's own `repository2-3.xml` manifest as of this fix). Also added Apple Silicon-specific arch detection: uses the native `mac_arm64` build instead of forcing SDK tools through Rosetta on M-series Macs.