### PR TITLE
fix(install): propagate registered PATH entries between tools in the same install.sh run

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -102,15 +102,34 @@ fi
 INSTALLED=0
 SKIPPED=0
 
-# Restore paths accumulated by previous install.sh calls (file survives across calls)
-if [ -f /tmp/_registered_paths ]; then
+# Each tool below runs as its own `bash "${SCRIPT}"` subprocess, so a
+# register_path call made INSIDE one tool's script (e.g. node.sh registering
+# its nvm-installed bin dir) only updates that subprocess's own PATH and
+# /tmp/_registered_paths — it can never propagate back into install.sh's own
+# PATH by itself. Re-reading /tmp/_registered_paths after every tool (not
+# just once before/after the whole loop) is what makes a later tool in the
+# SAME install.sh run (e.g. copilot, which needs npm) actually see an
+# earlier tool's PATH additions (e.g. node's).
+#
+# This was masked on Bitrise's macOS images because they ship a pre-existing
+# asdf-managed Node.js already on PATH (independent of anything node.sh
+# does), so copilot.sh's `is_installed npm` check happened to pass by pure
+# coincidence. A clean Bitrise Linux image has no such pre-baked Node, which
+# is what exposed the real bug: `❌ npm not found. Run node.sh first.` even
+# though node.sh had just run successfully immediately before it in the
+# very same install.sh invocation.
+_sync_registered_paths() {
+  [ -f /tmp/_registered_paths ] || return 0
   while IFS= read -r dir; do
     case ":${PATH}:" in
       *":${dir}:"*) ;;
       *) export PATH="${dir}:${PATH}" ;;
     esac
   done < /tmp/_registered_paths
-fi
+}
+
+# Restore paths accumulated by previous install.sh calls (file survives across calls)
+_sync_registered_paths
 
 for tool in ${TOOL_LIST}; do
   # Apply exclusions
@@ -139,19 +158,20 @@ for tool in ${TOOL_LIST}; do
     bash "${SCRIPT}"
   fi
   INSTALLED=$((INSTALLED + 1))
+
+  # Pick up any PATH entries the tool we just ran registered, so the NEXT
+  # tool in this loop (e.g. copilot right after node) can see them.
+  _sync_registered_paths
 done
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ── Accumulate PATH from all child processes and call envman once ─────────────
+# (PATH is already fully up to date here thanks to _sync_registered_paths
+# being called after every tool above — this final sync is now mostly a
+# no-op, kept only so the envman call below sees the definitely-final PATH.)
+_sync_registered_paths
 if [ -f /tmp/_registered_paths ]; then
-  while IFS= read -r dir; do
-    case ":${PATH}:" in
-      *":${dir}:"*) ;;  # already in PATH
-      *) export PATH="${dir}:${PATH}" ;;
-    esac
-  done < /tmp/_registered_paths
-
   # DON'T delete — next install.sh call needs these paths too
   # rm -f /tmp/_registered_paths
 


### PR DESCRIPTION
## Bug (found live on a fresh Bitrise Linux session)
`install.sh all` ran `node` successfully, then immediately failed on `copilot` right after it in the SAME run:
```
🟩 Node.js 20 [OS=linux CI=local]
...
✅ v20.20.2 · npm 10.8.2
...
🤖 GitHub Copilot CLI latest
❌ npm not found. Run node.sh first.
```

## Root cause
Each tool runs as its own `bash "${SCRIPT}"` subprocess. `register_path` (called by node.sh to add its nvm bin dir) only exports PATH inside that subprocess and appends the dir to `/tmp/_registered_paths` — it can never propagate back into install.sh's own PATH env var by itself (subprocesses can't mutate a parent's environment). install.sh only re-read `/tmp/_registered_paths` **once before** the whole tool loop and **once after** it — never between individual tools — so any tool that depends on an earlier tool in the *same* run (copilot/codemie/codegraph all need node's npm) could never see that earlier tool's PATH additions.

This was silently masked on Bitrise's macOS images, which ship a pre-existing asdf-managed Node.js already on PATH regardless of anything node.sh does (confirmed by the `Reshimming asdf nodejs...` line in copilot's own npm install output on macOS) — so `is_installed npm` happened to pass there by pure coincidence, not because the mechanism actually worked. A clean Bitrise Linux image has no such pre-baked Node, which is what exposed the real bug.

## Fix
Factored the existing restore-PATH logic into `_sync_registered_paths()` and call it after every tool completes inside the loop, not just once before/after the whole loop — so each tool's freshly-registered paths become visible to every subsequent tool in the same `install.sh` invocation.

## Verification
Reproduced in isolation: two subprocess scripts using the exact same register_path/`/tmp/_registered_paths` file mechanism — one registers a PATH dir, the other depends on finding a binary there. Fails under the old (before/after-loop-only) sync, passes under the fixed (per-iteration) sync. `bash -n` syntax-clean.