### PR TITLE
fix(install): stop failing install.sh over gradlew "not on PATH"

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -204,12 +204,28 @@ for tool in ${TOOL_LIST}; do
     codegraph) BIN="codegraph" ;;
     playwright) BIN="playwright" ;;
     kimi)    BIN="kimi" ;;
-    gradle)  BIN="gradlew" ;;
+    gradle)  BIN="./gradlew" ;;  # project-local wrapper, never on PATH — see below
     android) BIN="sdkmanager" ;;
     emulator) BIN="emulator" ;;
     konan)   continue ;;  # no standalone binary — toolchain lives in ~/.konan
     *)       continue ;;
   esac
+
+  # `gradlew` is a committed wrapper script in the repo working directory,
+  # never a PATH binary — `command -v gradlew` is a structural false
+  # negative (confirmed live: gradle.sh itself printed "✅ gradlew is
+  # executable" moments earlier in the same run, then this check failed the
+  # whole install with "NOT FOUND on PATH"). Check executability in place
+  # instead of resolving it as a command.
+  if [ "${tool}" = "gradle" ]; then
+    if [ -x "${BIN}" ]; then
+      echo "  ✓ ${BIN} → $(cd "$(dirname "${BIN}")" && pwd)/$(basename "${BIN}")"
+    else
+      echo "  ✗ ${BIN} — not found or not executable in $(pwd)" >&2
+      VERIFY_FAIL=1
+    fi
+    continue
+  fi
 
   if command -v "${BIN}" &>/dev/null; then
     LOC="$(command -v "${BIN}")"


### PR DESCRIPTION
fix(install): stop failing install.sh over gradlew "not on PATH"

Root-caused live on a Bitrise Linux Dev Environment VM: after the
Android emulator fix (#292), install.sh ran to completion cleanly -
Java, Maven, Node, DMtools, Copilot CLI, CodeGraph, Gradle, Android
SDK, the emulator (booted and online), and Konan pre-warm all
succeeded - but the run still exited non-zero at the very last step:

  ✓ emulator  -> /home/ubuntu/Android/Sdk/emulator/emulator
  ✗ gradlew   -- NOT FOUND on PATH
  ❌ Some tools are missing from PATH!

gradlew is a committed wrapper script in the repo's working directory
(./gradlew), never a PATH binary - gradle.sh itself confirms this a
few lines earlier in the same run ("✅ gradlew is executable"), which
checks `[ -f "./gradlew" ]`, not PATH resolution. The final PATH-only
verification loop mapped tool "gradle" to `command -v gradlew`, which
can never succeed regardless of whether the wrapper exists - a
structural false positive that failed every single run.

Fixed by special-casing the gradle check to test executability of
"./gradlew" directly (mirroring gradle.sh's own check) instead of
resolving it via `command -v`. Verified the corrected logic against
both existing-and-executable and missing "./gradlew" cases in
isolation.
