### PR TITLE
fix(docs): CLI jobParams override needs outer "params" wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,19 @@ fills in anything missing from `./dmtools.env` (same `KEY=VALUE` format
 
 **Switching an entire SM run to local without editing any rule:** rather than adding
 `localTeammate: true` to every rule in `sm.json`/`.dmtools/config.js`, pass a CLI JSON
-override (dmtools deep-merges this into `jobParams`) when invoking the SM job:
+override when invoking the SM job. `dmtools run <config_file> <override>` deep-merges
+`<override>` into the *whole* job config object (`{name, params}`), not just into
+`params.jobParams` directly — so the override must be wrapped in `params` too, mirroring
+the same shape as the job config file itself:
 
 ```bash
-dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'
+dmtools run agents/sm.json '{"params":{"jobParams":{"forceLocalTeammate":true}}}'
 ```
+
+A bare `{"jobParams":{"forceLocalTeammate":true}}` (without the outer `params` wrapper)
+is silently ignored — it doesn't raise an error, the SM job just runs with the
+unmodified default `jobParams` from `sm.json`, so every rule falls through to its
+normal dispatch behavior as if the override had never been passed.
 
 With `forceLocalTeammate: true`, every default-dispatch rule for that run behaves as if
 it had `localTeammate: true` — no GitHub Actions dispatch, everything runs through

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -21,11 +21,14 @@
  *   jobParams.maxTriggeredWorkflows (or maxWorkflowsPerRun) limits total active plus newly
  *   dispatched workflows across all non-local rules.
  *   Override priority: config.smMaxWorkflows (from .dmtools/config.js) > sm.json value.
- *   jobParams.forceLocalTeammate — set via a CLI JSON override (e.g.
- *   `dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'`) to switch
- *   EVERY default-dispatch rule to the local teammate pipeline for that run, without
- *   editing sm.json/.dmtools/config.js. Rules with localExecution:true are unaffected;
- *   a rule can still opt out with an explicit `localTeammate: false`.
+ *   jobParams.forceLocalTeammate — set via a CLI JSON override (note the outer `params`
+ *   wrapper — `dmtools run <file> <override>` deep-merges into the whole {name, params}
+ *   job config, not directly into params.jobParams; a bare {"jobParams":{...}} override
+ *   is silently ignored):
+ *   `dmtools run agents/sm.json '{"params":{"jobParams":{"forceLocalTeammate":true}}}'`
+ *   to switch EVERY default-dispatch rule to the local teammate pipeline for that run,
+ *   without editing sm.json/.dmtools/config.js. Rules with localExecution:true are
+ *   unaffected; a rule can still opt out with an explicit `localTeammate: false`.
  *
  * Rule fields:
  *   jql            (required) — JQL to find tickets (supports {jiraProject}, {parentTicket})
@@ -757,12 +760,16 @@ function action(params) {
     }
 
     // Global "run everything locally" override — set via a CLI JSON override, e.g.:
-    //   dmtools run agents/sm.json '{"jobParams":{"forceLocalTeammate":true}}'
+    //   dmtools run agents/sm.json '{"params":{"jobParams":{"forceLocalTeammate":true}}}'
+    // NOTE the outer "params" wrapper: `dmtools run <file> <override>` deep-merges the
+    // override into the whole {name, params} job config object, not directly into
+    // params.jobParams — a bare {"jobParams":{...}} override (missing the "params"
+    // wrapper) is silently ignored, no error, jobParams just stays at sm.json's defaults.
     // Forces every default-dispatch rule to run through the local teammate pipeline
     // (as if it had localTeammate:true) instead of a GitHub Actions workflow_dispatch —
-    // no env var needed; dmtools' own CLI JSON-override mechanism (deep-merged into
-    // jobParams) is the switch. Rules already using localExecution:true (pure-JS, no
-    // checkout/AI CLI) are left untouched. A rule can opt out even while the override is
+    // no env var needed; dmtools' own CLI JSON-override mechanism is the switch. Rules
+    // already using localExecution:true (pure-JS, no checkout/AI CLI) are left untouched.
+    // A rule can opt out even while the override is
     // active by setting `localTeammate: false` explicitly.
     if (p.forceLocalTeammate && rules) {
         var forcedCount = 0;


### PR DESCRIPTION
Fixes silently-ignored `dmtools run agents/sm.json '{"jobParams":{...}}'` examples — the CLI override must be wrapped in `params` to match the job config's own `{name, params}` shape, otherwise it's a no-op. Verified live via a temporary debug log on a Bitrise dev VM.