### PR TITLE
fix(sm): wire config.git.baseBranch into local-teammate runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,11 @@ module.exports = {
         parentTicket: 'PROJ-1'
     },
     git: {
-        baseBranch: 'master'  // default is 'main'
+        baseBranch: 'master'  // default is 'main' — also passed as --base-branch to
+                               // scripts/run-teammate-local.sh for localTeammate/
+                               // forceLocalTeammate runs, so this must match the
+                               // repo's actual default branch or local runs fail with
+                               // "fatal: couldn't find remote ref main"
     }
 };
 ```

--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -354,11 +354,19 @@ function runTeammateLocally(ticketKey, rule, effectiveConfig) {
         }
     }
 
+    // config.git.baseBranch (project override) takes precedence over rule.baseBranch;
+    // run-teammate-local.sh itself defaults to "main" when --base-branch is omitted,
+    // which silently breaks on any project whose default branch is named differently
+    // (e.g. "master") — always pass it explicitly when we know it.
+    var baseBranch = (effectiveConfig && effectiveConfig.git && effectiveConfig.git.baseBranch)
+        || rule.baseBranch || '';
+
     var cmd = 'bash ' + scriptPath +
         ' --config-file ' + resolvedCf +
         ' --ticket ' + ticketKey +
         (encodedConfigFile ? ' --encoded-config-file ' + encodedConfigFile : '') +
-        (projectKey ? ' --project-key ' + projectKey : '');
+        (projectKey ? ' --project-key ' + projectKey : '') +
+        (baseBranch ? ' --base-branch ' + baseBranch : '');
 
     console.log('  🖥️  [local] ' + cmd);
 

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -702,6 +702,27 @@ suite('smAgent: localTeammate execution mode', function() {
         assert.ok(cmd.indexOf('--ticket P-1') !== -1, 'passes ticket key');
     });
 
+    test('passes --base-branch from config.git.baseBranch (e.g. repos defaulting to master)', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" }, git: { baseBranch: "master" } };'
+            },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject} AND status = 'Ready'", {
+                configFile: 'agents/story_development.json',
+                localTeammate: true
+            })
+        ]));
+
+        var runs = localRunCommands(sm);
+        assert.equal(runs.length, 1, 'exactly one local run invoked');
+        assert.ok(runs[0].command.indexOf('--base-branch master') !== -1,
+            'passes the project-configured base branch instead of silently defaulting to "main"');
+    });
+
     test('adds rule labels after a successful local run', function() {
         var sm = makeSmAgent({
             fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },


### PR DESCRIPTION
runTeammateLocally() never passed --base-branch to run-teammate-local.sh, so any repo whose default branch isn't literally 'main' fails local-teammate runs with 'fatal: couldn'\''t find remote ref main'. Now resolves it from config.git.baseBranch (already used for PR targeting elsewhere).