### PR TITLE
Local-teammate: checkout deps + testable-stories rule

### DIFF
--- a/instructions/intake/intake_instructions.md
+++ b/instructions/intake/intake_instructions.md
@@ -34,6 +34,7 @@ flowchart TD
         R4["Summaries: concise, actionable, imperative"]
         R5["Stories: 1-2 sprints worth, split if needed"]
         R6["NO code, only analysis & structured content"]
+        R7["Stories MUST be Testable: if autotest/integration coverage isn't realistic, don't create a separate story OR explicitly state 'no integration testing required — must be skipped, no test cases required, prerequisite story' (unit tests still required)"]
     end
 
     INPUTS --> TASK

--- a/instructions/intake/workflow.md
+++ b/instructions/intake/workflow.md
@@ -54,6 +54,7 @@ flowchart TD
     end
 
     CR1["CRITICAL: Tech prerequisites → separate epics/stories | Max 5SP per story | No duplicate content | No water in descriptions | MVP thinking always | Follow all input instructions exactly"]
+    CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -63,4 +64,5 @@ flowchart TD
     OUTPUT --> E2E
     E2E --> VALIDATE
     CR1 -.-> OUTPUT
+    CR2 -.-> OUTPUT
 ```

--- a/prompts/intake_prompt.md
+++ b/prompts/intake_prompt.md
@@ -40,6 +40,7 @@ flowchart TD
     F1["attachments JSON: {summary: ..., description: outputs/stories/story-1.md, attachments: [outputs/attachments/design.png, outputs/attachments/spec.pdf]}"]
 
     CR1["CRITICAL: Tech prerequisites → separate epics/stories | Max 5SP per story | No duplicate content | No water in descriptions | MVP thinking always | Follow all input instructions exactly"]
+    CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -48,4 +49,5 @@ flowchart TD
     OUTPUT --> VALIDATE
     F1 -.-> OUTPUT
     CR1 -.-> OUTPUT
+    CR2 -.-> OUTPUT
 ```

--- a/scripts/run-teammate-local.sh
+++ b/scripts/run-teammate-local.sh
@@ -114,6 +114,22 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
 EXCLUDE_FILE="${GIT_DIR}/info/exclude"
 SCRATCH_PATTERNS=(".dmtools/local-run-*" "input/" "outputs/")
+
+# Also self-ignore project dependency checkouts (e.g. an iOS reference repo)
+# declared in .dmtools/repositories.json — see setup/checkout.sh below. These
+# are checked out at the repo root (same convention as ai-teammate.yml's
+# "Checkout project dependencies" step), so they are untracked by construction
+# just like the other scratch paths above and would otherwise falsely trip the
+# dirty-tree guard on every run. Gathered from ALL project keys in the config
+# (not just the auto-detected one) so the exclusion is a safe superset.
+DEPS_REPO_CONFIG=".dmtools/repositories.json"
+if [ -f "${DEPS_REPO_CONFIG}" ] && is_installed jq; then
+  while IFS= read -r repo_name; do
+    [ -n "${repo_name}" ] || continue
+    SCRATCH_PATTERNS+=("${repo_name}/")
+  done < <(jq -r '.repositories // {} | to_entries[].value[]?.repo | split("/") | last' "${DEPS_REPO_CONFIG}" 2>/dev/null || true)
+fi
+
 mkdir -p "$(dirname "${EXCLUDE_FILE}")"
 touch "${EXCLUDE_FILE}"
 for pattern in "${SCRATCH_PATTERNS[@]}"; do
@@ -147,6 +163,19 @@ echo "🔄 Syncing ${BASE_BRANCH}..."
 git fetch origin "${BASE_BRANCH}"
 git checkout "${BASE_BRANCH}"
 git pull --ff-only origin "${BASE_BRANCH}"
+
+# ── Checkout project dependencies (e.g. an iOS reference repo) if configured ──
+# Mirrors the "Checkout project dependencies" step in ai-teammate.yml — without
+# this, agents running via localTeammate/forceLocalTeammate never see the same
+# reference repos a GitHub Actions run would have checked out, silently degrading
+# their context. Safe no-op if .dmtools/repositories.json doesn't exist or has no
+# repositories (most projects never define it) — see setup/checkout.sh for the
+# config format. Uses --dest . to match ai-teammate.yml's convention (checked out
+# at the repo root, e.g. ./soho-mobile-android/), not the script's ./dependencies
+# default.
+if [ -f "${SCRIPT_DIR}/../setup/checkout.sh" ]; then
+  bash "${SCRIPT_DIR}/../setup/checkout.sh" --dest .
+fi
 
 # ── Optional tool install (idempotent — reuses whatever setup/cache.sh cached) ─
 if [ -n "${INSTALL_TOOLS}" ]; then


### PR DESCRIPTION
Fixes two issues discovered while running the intake agent locally via forceLocalTeammate:

1. run-teammate-local.sh never invoked agents/setup/checkout.sh, so any project defining .dmtools/repositories.json (e.g. SH_ANDR_WIP's iOS reference repo) never got that dependency checked out for local runs, unlike ai-teammate.yml's GitHub Actions path. Now calls checkout.sh --dest . after syncing the base branch, and self-ignores the resulting dependency dir(s) via the same scratch-pattern mechanism used for input/outputs/.dmtools/local-run-*.
2. Adds a CRITICAL rule to intake instructions: generated User Stories must be Testable — if autotest/integration coverage isn't realistic, either skip the separate story or explicitly mark it as a no-integration-testing prerequisite (unit tests still required).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>