### PR TITLE
checkout.sh: fast-forward GitHub deps on repeat runs

### DIFF
--- a/setup/checkout.sh
+++ b/setup/checkout.sh
@@ -274,6 +274,14 @@ while IFS= read -r entry; do
         "https://x-access-token:${GH_TOKEN}@${GH_HOST}/${REPO}.git"
       git -C "${DEST}" fetch --filter="${GIT_FILTER}" origin "${BRANCH}"
       git -C "${DEST}" checkout "${BRANCH}"
+      # `checkout` alone only switches to the local branch ref — it does NOT
+      # fast-forward it to the freshly fetched origin/${BRANCH}, so a repeated
+      # call (e.g. every local-teammate run reusing the same on-disk clone)
+      # would silently keep serving a stale snapshot forever even as the
+      # reference repo moves forward. Matches the explicit `pull --ff-only`
+      # already done for the ADO/GitLab entries above — bring this path in
+      # line with them.
+      git -C "${DEST}" pull origin "${BRANCH}" --ff-only 2>/dev/null || true
       echo "  ↻ updated"
     else
       git clone \


### PR DESCRIPTION
Fixes a staleness bug found while verifying idempotent re-checkout of the iOS reference dependency for SH_ANDR_WIP: the GitHub-provider branch of checkout.sh fetched but never fast-forwarded an already-checked-out local clone, so repeated calls kept serving the commit from the first clone forever, unlike the ADO/GitLab entries which already do 'pull --ff-only'.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>