### PR TITLE
intake: iOS reference is sole source of truth for scope (CR4/R9)

### DIFF
--- a/instructions/intake/intake_instructions.md
+++ b/instructions/intake/intake_instructions.md
@@ -36,6 +36,7 @@ flowchart TD
         R6["NO code, only analysis & structured content"]
         R7["Stories MUST be Testable: if autotest/integration coverage isn't realistic, don't create a separate story OR explicitly state 'no integration testing required — must be skipped, no test cases required, prerequisite story' (unit tests still required)"]
         R8["For existing/already-implemented features: verify they work correctly end-to-end AND are fully test-covered — code presence alone is not completion; gaps become their own Bug/Story"]
+        R9["iOS reference codebase is the sole source of truth for scope. Decompose from iOS features, not from what Android already has. Similar-looking Android code is NEVER evidence an iOS feature is done — always create/keep the story for that iOS feature so a downstream dev/verification agent independently confirms real completeness. If the project has BMAD tracking artifacts (sprint-status.yaml, deferred-work.md, per-story files), treat their recorded status as ground truth and cross-check every 'already implemented' claim against them before asserting a feature works"]
     end
 
     INPUTS --> TASK

--- a/instructions/intake/workflow.md
+++ b/instructions/intake/workflow.md
@@ -58,6 +58,7 @@ flowchart TD
     CR1["CRITICAL: Tech prerequisites → separate epics/stories | Max 5SP per story | No duplicate content | No water in descriptions | MVP thinking always | Follow all input instructions exactly"]
     CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
     CR3["CRITICAL: For existing/already-implemented Android features, verify they work correctly end-to-end AND are fully covered by tests — do not assume completion just because the code/module exists. Gaps found (broken flow, missing tests) become their own Bug/Story."]
+    CR4["CRITICAL: The iOS reference codebase is the sole source of truth for scope. Decompose from iOS features, not from what Android already has. Android code that looks similar to an iOS feature is NEVER evidence that feature is done — always create/keep the story for that iOS feature so a downstream dev/verification agent can independently confirm real completeness. If the project has BMAD tracking artifacts (e.g. sprint-status.yaml, deferred-work.md, per-story files), treat their recorded status (backlog/in-progress/review/done, deferred items) as ground truth and cross-check every claim of 'already implemented' against them before ever asserting a feature works — a self-run shallow code read is never sufficient grounds to skip or omit a story."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -69,4 +70,5 @@ flowchart TD
     CR1 -.-> OUTPUT
     CR2 -.-> OUTPUT
     CR3 -.-> OUTPUT
+    CR4 -.-> OUTPUT
 ```

--- a/prompts/intake_prompt.md
+++ b/prompts/intake_prompt.md
@@ -44,6 +44,7 @@ flowchart TD
     CR1["CRITICAL: Tech prerequisites → separate epics/stories | Max 5SP per story | No duplicate content | No water in descriptions | MVP thinking always | Follow all input instructions exactly"]
     CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
     CR3["CRITICAL: For existing/already-implemented Android features, verify they work correctly end-to-end AND are fully covered by tests — do not assume completion just because the code/module exists. Gaps found (broken flow, missing tests) become their own Bug/Story."]
+    CR4["CRITICAL: The iOS reference codebase is the sole source of truth for scope. Decompose from iOS features, not from what Android already has. Android code that looks similar to an iOS feature is NEVER evidence that feature is done — always create/keep the story for that iOS feature so a downstream dev/verification agent can independently confirm real completeness. If the project has BMAD tracking artifacts (e.g. sprint-status.yaml, deferred-work.md, per-story files), treat their recorded status (backlog/in-progress/review/done, deferred items) as ground truth and cross-check every claim of 'already implemented' against them before ever asserting a feature works — a self-run shallow code read is never sufficient grounds to skip or omit a story."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -54,4 +55,5 @@ flowchart TD
     CR1 -.-> OUTPUT
     CR2 -.-> OUTPUT
     CR3 -.-> OUTPUT
+    CR4 -.-> OUTPUT
 ```


### PR DESCRIPTION
Adds CR4/R9: the iOS reference codebase — not existing Android code — is the sole source of truth for intake scope/decomposition. Similar-looking Android code must never be treated as evidence a feature is complete; the story must still be created so a downstream dev/verification agent independently confirms real end-to-end completeness. Also requires cross-checking any BMAD tracking artifacts (sprint-status.yaml, deferred-work.md, per-story files) as ground truth before asserting anything is already implemented.

Root cause: a prior intake run found only 7 gap tickets by shallow ad-hoc code reads, while the project's own sprint-status.yaml shows ~146/177 stories still in backlog (not started) and deferred-work.md documents dozens of known stubs — none of which intake consulted.