### PR TITLE
Fix intake tracker markup transform + require Epics ship with Stories

### DIFF
--- a/instructions/intake/formatting_rules.md
+++ b/instructions/intake/formatting_rules.md
@@ -32,22 +32,31 @@
 ## Description files: `outputs/stories/story-N.md`, `epic-N.md`, `bug-N.md`
 
 - Start directly with content — no header line.
-- Use tracker-appropriate heading syntax (e.g. `###` for Markdown-based trackers, `h3.` for Jira wiki).
 - Do NOT include Acceptance Criteria.
 - Avoid filler; be specific.
 
-### Description structure
+### ⚠️ MANDATORY: tracker-specific markup transform
+
+The structure below is a **generic placeholder template only** — the tags such as `<heading3>` and `<bullet>` are NOT literal output. Never write these literal tags (or raw Markdown like `### Goal`, `**bold**`, `- item`) directly into a description file.
+
+Before writing the final `.md` file, transform every placeholder using the tracker-specific transformation table supplied for this run (e.g. `agents/instructions/tracker/jira_markup_transform.md` when the tracker is Jira, `agents/instructions/tracker/ado_markup_transform.md` when the tracker is ADO). This is the exact same rule and the exact same transform table used by the `story_questions` agent — apply it consistently here.
+
+### Description structure (generic placeholders — transform before writing)
 
 ```
-### Goal
- what & why
+<heading3>Goal</heading3>
+what & why
 
-### Scope
- minimal requirements: functional, data, behaviour, integrations, constraints
+<heading3>Scope</heading3>
+minimal requirements: functional, data, behaviour, integrations, constraints
 
-### Out of scope
- explicitly NOT included
+<heading3>Out of scope</heading3>
+explicitly NOT included
 
-### Notes
- assumptions, questions, links
+<heading3>Notes</heading3>
+assumptions, questions, links
 ```
+
+### ❌ Common mistake — do not do this
+
+Writing raw Markdown (e.g. `### Goal`, `**Scope**`, `- item`) straight into a Jira description. Jira wiki markup interprets `#`/`##`/`###` as numbered-list markers, not headings — this silently corrupts the rendered ticket (nested empty numbered lists, mangled bullets). Always run content through the tracker transform table first.

--- a/instructions/intake/intake_instructions.md
+++ b/instructions/intake/intake_instructions.md
@@ -12,7 +12,7 @@ flowchart TD
         T3["Write description files"]
         T3a["Epics → outputs/stories/epic-N.md"]
         T3b["Stories → outputs/stories/story-N.md"]
-        T3c["Structure: Goal → Scope → Out of scope → Notes"]
+        T3c["Structure: Goal → Scope → Out of scope → Notes<br/>⚠️ Use generic placeholder tags (see formatting_rules.md), NEVER raw Markdown — transform via tracker markup table before writing"]
         T4["Write outputs/stories.json — valid JSON array"]
         T5["Write outputs/comment.md — tracker-formatted summary"]
         T6["Bug request → type Bug, bug-N.md, no Epics/Stories"]
@@ -37,6 +37,8 @@ flowchart TD
         R7["Stories MUST be Testable: if autotest/integration coverage isn't realistic, don't create a separate story OR explicitly state 'no integration testing required — must be skipped, no test cases required, prerequisite story' (unit tests still required)"]
         R8["For existing/already-implemented features: verify they work correctly end-to-end AND are fully test-covered — code presence alone is not completion; gaps become their own Bug/Story"]
         R9["If the project defines an authoritative reference/target specification for scope (reference platform codebase, design spec, or PRD), that reference — not what the current codebase already appears to have — is the sole source of truth for decomposition. Existing code that merely looks similar to a reference feature is NEVER evidence that feature is done — always create/keep the story for that feature so a downstream dev/verification agent independently confirms real completeness. If the project has its own planning/tracking artifacts recording per-story/per-epic status and deferred/stubbed work (e.g. a sprint-status file, a deferred-work log, per-story files), treat their recorded status as ground truth and cross-check every 'already implemented' claim against them before asserting a feature works"]
+        R10["NEVER create an Epic with zero child Stories in the same run. Every new Epic MUST be created together with at least its first actionable Stories in this same run — an Epic without Stories is not a valid output. If an Epic's full scope is too large to fully decompose in one pass, still create as many Stories as are known/actionable now, and explicitly list the remaining not-yet-decomposed slices in the Epic's own description Notes section — never leave the Epic itself as an empty placeholder"]
+        R11["Before writing any description .md file: replace every generic placeholder tag with the tracker-specific markup from the transform table for this run's tracker (e.g. `agents/instructions/tracker/jira_markup_transform.md` for Jira). Never write literal placeholder tags or raw Markdown headings/bullets straight into a tracker description — same rule as `story_questions`"]
     end
 
     INPUTS --> TASK

--- a/instructions/intake/workflow.md
+++ b/instructions/intake/workflow.md
@@ -59,6 +59,8 @@ flowchart TD
     CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
     CR3["CRITICAL: For existing/already-implemented features, verify they work correctly end-to-end AND are fully covered by tests — do not assume completion just because the code/module exists. Gaps found (broken flow, missing tests) become their own Bug/Story."]
     CR4["CRITICAL: If the project defines an authoritative reference/target specification for scope (e.g. a reference platform codebase to reach parity with, a design spec, or a PRD) that is more authoritative than the current implementation, that reference — not what the current codebase already appears to have — is the sole source of truth for decomposition. Existing code that merely looks similar to a reference feature is NEVER by itself evidence that feature is complete — always create/keep the story for that feature so a downstream dev/verification agent can independently confirm real completeness. If the project has its own planning/tracking artifacts recording per-story/per-epic implementation status and deferred/stubbed work (e.g. a sprint-status file, a deferred-work log, per-story files), treat their recorded status as ground truth and cross-check every claim of 'already implemented' against them before ever asserting a feature works — a self-run shallow code read is never sufficient grounds to skip or omit a story."]
+    CR5["CRITICAL: NEVER create an Epic with zero child Stories in the same run — an Epic without Stories is not a valid output. Every new Epic must be created together with at least its first actionable Stories in this same run. If the Epic's full scope is too large to fully decompose in one pass, still create as many Stories as are known/actionable now, and explicitly list the remaining not-yet-decomposed slices in the Epic's own description Notes section."]
+    CR6["CRITICAL: Description files (epic-N.md, story-N.md, bug-N.md) must NEVER contain literal placeholder tags or raw Markdown (### heading, **bold**, - item). Always transform generic structure placeholders into the current tracker's markup using the tracker-specific transform table (e.g. agents/instructions/tracker/jira_markup_transform.md for Jira) — the same rule used by the story_questions agent — before writing the final file."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -71,4 +73,6 @@ flowchart TD
     CR2 -.-> OUTPUT
     CR3 -.-> OUTPUT
     CR4 -.-> OUTPUT
+    CR5 -.-> OUTPUT
+    CR6 -.-> OUTPUT
 ```

--- a/intake.json
+++ b/intake.json
@@ -29,9 +29,11 @@
     ],
     "cliPromptsByTracker": {
       "jira": [
+        "./agents/instructions/tracker/jira_markup_transform.md",
         "./agents/instructions/tracker/jira_comment_format.md"
       ],
       "ado": [
+        "./agents/instructions/tracker/ado_markup_transform.md",
         "./agents/instructions/tracker/ado_comment_format.md"
       ]
     }

--- a/prompts/intake_prompt.md
+++ b/prompts/intake_prompt.md
@@ -45,6 +45,8 @@ flowchart TD
     CR2["CRITICAL: Stories MUST be Testable. If a story cannot realistically be covered by an autotest/integration test: either don't create it as a separate story, OR explicitly state in its description 'No integration testing required — must be skipped, no test cases required, this story is a prerequisite'. Unit tests are still required regardless."]
     CR3["CRITICAL: For existing/already-implemented features, verify they work correctly end-to-end AND are fully covered by tests — do not assume completion just because the code/module exists. Gaps found (broken flow, missing tests) become their own Bug/Story."]
     CR4["CRITICAL: If the project defines an authoritative reference/target specification for scope (e.g. a reference platform codebase to reach parity with, a design spec, or a PRD) that is more authoritative than the current implementation, that reference — not what the current codebase already appears to have — is the sole source of truth for decomposition. Existing code that merely looks similar to a reference feature is NEVER by itself evidence that feature is complete — always create/keep the story for that feature so a downstream dev/verification agent can independently confirm real completeness. If the project has its own planning/tracking artifacts recording per-story/per-epic implementation status and deferred/stubbed work (e.g. a sprint-status file, a deferred-work log, per-story files), treat their recorded status as ground truth and cross-check every claim of 'already implemented' against them before ever asserting a feature works — a self-run shallow code read is never sufficient grounds to skip or omit a story."]
+    CR5["CRITICAL: NEVER create an Epic with zero child Stories in the same run — an Epic without Stories is not a valid output. Every new Epic must be created together with at least its first actionable Stories in this same run. If the Epic's full scope is too large to fully decompose in one pass, still create as many Stories as are known/actionable now, and explicitly list the remaining not-yet-decomposed slices in the Epic's own description Notes section."]
+    CR6["CRITICAL: Description files (epic-N.md, story-N.md, bug-N.md) must NEVER contain literal placeholder tags or raw Markdown (### heading, **bold**, - item). Always transform generic structure placeholders into the current tracker's markup using the tracker-specific transform table (e.g. agents/instructions/tracker/jira_markup_transform.md for Jira) — the same rule used by the story_questions agent — before writing the final file."]
 
     INPUT --> STUDY
     INPUT --> ATTACH
@@ -56,4 +58,6 @@ flowchart TD
     CR2 -.-> OUTPUT
     CR3 -.-> OUTPUT
     CR4 -.-> OUTPUT
+    CR5 -.-> OUTPUT
+    CR6 -.-> OUTPUT
 ```


### PR DESCRIPTION
Fixes two generic (project-agnostic) bugs in the intake agent:

1. `intake.json` was missing `jira_markup_transform.md`/`ado_markup_transform.md` in `cliPromptsByTracker`. Story/Epic descriptions were written with raw Markdown (`### Goal`) directly, which Jira wiki markup parses as nested numbered-list markers, silently corrupting the rendered ticket. Wired the same transform table already used by `story_questions`.
2. Description templates now use generic placeholder tags (consistent with `story_questions`' `description_template.md`) with an explicit mandatory transform step.
3. Added a rule that an Epic must never be created with zero child Stories in the same intake run — at least an actionable first slice of Stories must ship together with any new Epic.