### PR TITLE
Split intake description template into its own file, mirroring story_questions

### DIFF
--- a/instructions/intake/description_template.md
+++ b/instructions/intake/description_template.md
@@ -1,0 +1,31 @@
+Each description file (`outputs/stories/epic-N.md`, `story-N.md`, `bug-N.md`, referenced from `outputs/stories.json` as `description`) must follow this template. If a tracker-specific template is provided in the instructions, use that instead.
+
+The block below is a **structural template / example only**. The tags such as `<heading3>` and `<bullet>` are placeholders that show the required shape of the document.
+
+**CRITICAL: Never write the final description using these literal metatags.** Use the tracker-specific transformation table (for example `agents/instructions/tracker/jira_markup_transform.md` when the tracker is Jira) to convert every placeholder into the correct tracker markup.
+
+Structure:
+```
+<heading3>Goal</heading3>
+what & why
+
+<heading3>Scope</heading3>
+minimal requirements: functional, data, behaviour, integrations, constraints
+
+<heading3>Out of scope</heading3>
+explicitly NOT included
+
+<heading3>Notes</heading3>
+assumptions, questions, links
+```
+
+Rules:
+- Start directly with content — no header/title line, do NOT repeat the summary.
+- Do NOT include Acceptance Criteria.
+- Avoid filler; be specific.
+- Replace every placeholder tag with the equivalent markup defined in the tracker-specific transformation table.
+- Do NOT leave literal XML-style tags such as `<heading3>` or `<bullet>` in the final description.
+
+### ❌ Common mistake — do not do this
+
+Writing raw Markdown (e.g. `### Goal`, `**Scope**`, `- item`) straight into a Jira description. Jira wiki markup interprets `#`/`##`/`###` as numbered-list markers, not headings — this silently corrupts the rendered ticket (nested empty numbered lists, mangled bullets). Always run content through the tracker transform table first — the same rule and the same transform table used by the `story_questions` agent.

--- a/instructions/intake/formatting_rules.md
+++ b/instructions/intake/formatting_rules.md
@@ -31,32 +31,4 @@
 
 ## Description files: `outputs/stories/story-N.md`, `epic-N.md`, `bug-N.md`
 
-- Start directly with content — no header line.
-- Do NOT include Acceptance Criteria.
-- Avoid filler; be specific.
-
-### ⚠️ MANDATORY: tracker-specific markup transform
-
-The structure below is a **generic placeholder template only** — the tags such as `<heading3>` and `<bullet>` are NOT literal output. Never write these literal tags (or raw Markdown like `### Goal`, `**bold**`, `- item`) directly into a description file.
-
-Before writing the final `.md` file, transform every placeholder using the tracker-specific transformation table supplied for this run (e.g. `agents/instructions/tracker/jira_markup_transform.md` when the tracker is Jira, `agents/instructions/tracker/ado_markup_transform.md` when the tracker is ADO). This is the exact same rule and the exact same transform table used by the `story_questions` agent — apply it consistently here.
-
-### Description structure (generic placeholders — transform before writing)
-
-```
-<heading3>Goal</heading3>
-what & why
-
-<heading3>Scope</heading3>
-minimal requirements: functional, data, behaviour, integrations, constraints
-
-<heading3>Out of scope</heading3>
-explicitly NOT included
-
-<heading3>Notes</heading3>
-assumptions, questions, links
-```
-
-### ❌ Common mistake — do not do this
-
-Writing raw Markdown (e.g. `### Goal`, `**Scope**`, `- item`) straight into a Jira description. Jira wiki markup interprets `#`/`##`/`###` as numbered-list markers, not headings — this silently corrupts the rendered ticket (nested empty numbered lists, mangled bullets). Always run content through the tracker transform table first.
+See `description_template.md` for the required generic structure and the mandatory tracker-markup transform step.

--- a/intake.json
+++ b/intake.json
@@ -22,6 +22,7 @@
       "./agents/instructions/common/agent_task_preamble.md",
       "./agents/instructions/intake/workflow.md",
       "./agents/instructions/intake/formatting_rules.md",
+      "./agents/instructions/intake/description_template.md",
       "./agents/instructions/intake/json_validation.md",
       "./agents/instructions/common/no_development.md",
       "./agents/instructions/common/error_handling.md",


### PR DESCRIPTION
Aligns intake's architecture with story_questions: formatting_rules.md (JSON/output field rules) and description_template.md (generic tracker-agnostic body template) are now separate base cliPrompts files, both consumed alongside the tracker-specific markup transform wired via cliPromptsByTracker — same structure as story_questions.json.