### PR TITLE
feat(setup): add Cursor Agent CLI install and cache support

### DIFF
--- a/scripts/providers/cursor.sh
+++ b/scripts/providers/cursor.sh
@@ -7,22 +7,151 @@ run_cursor() {
     return 127
   fi
 
-  local cursor_model_value
+  local cursor_model_value script_dir
   cursor_model_value="${CURSOR_MODEL:-auto}"
-  echo "Cursor Configuration:"
-  echo "  Model: ${cursor_model_value}"
-
-  local cmd
-  # Build command with defaults if no options provided
-  if [ ${#PASS_ARGS[@]} -eq 0 ]; then
-    cmd=(cursor-agent --force --print --model "${cursor_model_value}" --output-format=text "$PROMPT")
-  else
-    cmd=(cursor-agent "${PASS_ARGS[@]}" --output-format=text "$PROMPT")
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ "${CURSOR_SESSION_ENABLED:-true}" != "false" ] && [ -f "${script_dir}/../../setup/cursor-session.sh" ]; then
+    # shellcheck source=/dev/null
+    source "${script_dir}/../../setup/cursor-session.sh" env
   fi
 
+  _cursor_chats_root() {
+    printf '%s' "${HOME}/.cursor/chats"
+  }
+
+  _cursor_session_dir() {
+    local sid="$1"
+    find "$(_cursor_chats_root)" -maxdepth 2 -type d -name "${sid}" 2>/dev/null | head -1
+  }
+
+  _cursor_session_exists() {
+    local sid="$1"
+    local session_dir
+    session_dir="$(_cursor_session_dir "${sid}")"
+    [ -n "${session_dir}" ] && [ -f "${session_dir}/store.db" ]
+  }
+
+  _cursor_extract_uuid() {
+    local text="$1"
+    local uuid
+    uuid="$(printf '%s' "${text}" | grep -Eo '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' | head -1 || true)"
+    printf '%s' "${uuid}"
+  }
+
+  _cursor_normalize_session_id() {
+    local src_id="$1"
+    local dest_id="$2"
+    local src_dir dest_dir parent
+
+    if [ -z "${src_id}" ] || [ -z "${dest_id}" ] || [ "${src_id}" = "${dest_id}" ]; then
+      return 0
+    fi
+
+    src_dir="$(_cursor_session_dir "${src_id}")"
+    if [ -z "${src_dir}" ]; then
+      return 1
+    fi
+
+    parent="$(dirname "${src_dir}")"
+    dest_dir="${parent}/${dest_id}"
+    if [ "${src_dir}" != "${dest_dir}" ] && [ ! -e "${dest_dir}" ]; then
+      mv "${src_dir}" "${dest_dir}"
+      echo "✅ Normalized Cursor session id to deterministic id: ${dest_id}"
+    fi
+  }
+
+  _cursor_create_chat_id() {
+    local create_output new_id
+    create_output="$(cursor-agent create-chat 2>&1 || true)"
+    new_id="$(_cursor_extract_uuid "${create_output}")"
+    printf '%s' "${new_id}"
+  }
+
+  local cursor_has_resume_arg=false
+  local cursor_has_explicit_resume_id=false
+  local pass_arg
+  if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
+    for pass_arg in "${PASS_ARGS[@]}"; do
+      case "$pass_arg" in
+        --continue|--resume)
+          cursor_has_resume_arg=true
+          ;;
+        --resume=*)
+          cursor_has_resume_arg=true
+          cursor_has_explicit_resume_id=true
+          ;;
+      esac
+    done
+  fi
+
+  local cursor_session_id="${CURSOR_SESSION_ID:-}"
+  local cursor_session_args=()
+  local cursor_pass_args=()
+  if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
+    cursor_pass_args=("${PASS_ARGS[@]}")
+  fi
+
+  if [ "${cursor_has_resume_arg}" = "true" ] && [ "${cursor_has_explicit_resume_id}" = "false" ]; then
+    if [ -z "${cursor_session_id}" ] && [ -f "outputs/cursor_session_id.txt" ]; then
+      cursor_session_id="$(tr -d '[:space:]' < outputs/cursor_session_id.txt || true)"
+    fi
+    if [ -z "${cursor_session_id}" ]; then
+      echo "Error: Cursor resume requested but no session id is available." >&2
+      echo "Set CURSOR_SESSION_ID or run a non-resume agent first so the session id can be persisted." >&2
+      return 1
+    fi
+    echo "Resuming Cursor session: ${cursor_session_id}"
+    cursor_session_args=(--resume "${cursor_session_id}")
+    cursor_pass_args=()
+    if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
+      for pass_arg in "${PASS_ARGS[@]}"; do
+        case "$pass_arg" in
+          --continue|--resume|--resume=*) ;;
+          *) cursor_pass_args+=("$pass_arg") ;;
+        esac
+      done
+    fi
+  elif [ -n "${cursor_session_id}" ] && [ "${cursor_has_explicit_resume_id}" = "false" ]; then
+    if _cursor_session_exists "${cursor_session_id}"; then
+      echo "Resuming Cursor session: ${cursor_session_id}"
+      cursor_session_args=(--resume "${cursor_session_id}")
+    else
+      echo "Cursor session ${cursor_session_id} not found; creating chat (will normalize to deterministic id)"
+      local created_id=""
+      created_id="$(_cursor_create_chat_id)"
+      if [ -n "${created_id}" ] && [ "${created_id}" != "${cursor_session_id}" ]; then
+        _cursor_normalize_session_id "${created_id}" "${cursor_session_id}"
+      fi
+      if _cursor_session_exists "${cursor_session_id}"; then
+        cursor_session_args=(--resume "${cursor_session_id}")
+      elif [ -n "${created_id}" ]; then
+        cursor_session_args=(--resume "${created_id}")
+        cursor_session_id="${created_id}"
+      fi
+    fi
+  fi
+
+  local cursor_output_format="text"
+  if [ "${CURSOR_SESSION_ENABLED:-true}" != "false" ] && [ -n "${CURSOR_SESSION_ID:-}" ]; then
+    cursor_output_format="stream-json"
+  fi
+
+  echo "Cursor Configuration:"
+  echo "  Model: ${cursor_model_value}"
+  if [ -n "${CURSOR_SESSION_ID:-}" ]; then
+    echo "  Session: ${CURSOR_SESSION_NAME:-${CURSOR_SESSION_ID}} (${CURSOR_SESSION_GROUP:-default})"
+    echo "  Session cache path: ${CURSOR_SESSION_CACHE_PATH:-$(_cursor_chats_root)}"
+  fi
   echo "Working directory: $(pwd)"
   echo ""
-  echo "Running: ${cmd[*]}"
+
+  local cmd
+  cmd=(cursor-agent --force --print --model "${cursor_model_value}" \
+    ${cursor_session_args[@]+"${cursor_session_args[@]}"} \
+    ${cursor_pass_args[@]+"${cursor_pass_args[@]}"} \
+    --output-format="${cursor_output_format}" "$PROMPT")
+
+  echo "Running: cursor-agent --force --print --model ${cursor_model_value} ${cursor_session_args[*]:-} ${cursor_pass_args[*]:-} --output-format=${cursor_output_format} <prompt:${PROMPT_BYTES} bytes>"
   echo ""
 
   local agent_log
@@ -32,6 +161,24 @@ run_cursor() {
   local exit_code=${PIPESTATUS[0]}
   set -e
   record_codegraph_usage "$agent_log"
+
+  local new_session_id=""
+  new_session_id="$(grep -o '"session_id":"[^"]*"' "$agent_log" | head -1 | cut -d'"' -f4 || true)"
+  if [ -z "${new_session_id}" ]; then
+    new_session_id="$(_cursor_extract_uuid "$(cat "$agent_log" 2>/dev/null || true)")"
+  fi
+
+  local effective_session_id="${cursor_session_id:-${new_session_id}}"
+  if [ -n "${CURSOR_SESSION_ID:-}" ] && [ -n "${new_session_id}" ] && [ "${new_session_id}" != "${CURSOR_SESSION_ID}" ]; then
+    _cursor_normalize_session_id "${new_session_id}" "${CURSOR_SESSION_ID}"
+    effective_session_id="${CURSOR_SESSION_ID}"
+  fi
+
+  if [ -n "${effective_session_id}" ]; then
+    mkdir -p outputs
+    printf '%s\n' "${effective_session_id}" > outputs/cursor_session_id.txt
+  fi
+
   rm -f "$agent_log"
 
   echo ""

--- a/scripts/providers/cursor.sh
+++ b/scripts/providers/cursor.sh
@@ -10,9 +10,19 @@ run_cursor() {
   local cursor_model_value script_dir
   cursor_model_value="${CURSOR_MODEL:-auto}"
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [ "${CURSOR_SESSION_ENABLED:-true}" != "false" ] && [ -f "${script_dir}/../../setup/cursor-session.sh" ]; then
-    # shellcheck source=/dev/null
-    source "${script_dir}/../../setup/cursor-session.sh" env
+
+  local cursor_session_enabled=true
+  if [ "${CURSOR_SESSION_ENABLED:-true}" = "false" ]; then
+    cursor_session_enabled=false
+  fi
+
+  local teammate_session_enabled=false
+  if [ "${cursor_session_enabled}" = "true" ] && [ -n "${AI_TEAMMATE_CONFIG_FILE:-}" ]; then
+    teammate_session_enabled=true
+    if [ -f "${script_dir}/../../setup/cursor-session.sh" ]; then
+      # shellcheck source=/dev/null
+      source "${script_dir}/../../setup/cursor-session.sh" env
+    fi
   fi
 
   _cursor_chats_root() {
@@ -36,6 +46,10 @@ run_cursor() {
     local uuid
     uuid="$(printf '%s' "${text}" | grep -Eo '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' | head -1 || true)"
     printf '%s' "${uuid}"
+  }
+
+  _cursor_is_uuid() {
+    printf '%s' "$1" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
   }
 
   _cursor_normalize_session_id() {
@@ -67,20 +81,59 @@ run_cursor() {
     printf '%s' "${new_id}"
   }
 
+  _cursor_strip_resume_flags() {
+    local skip_next=false
+    local pass_arg
+
+    cursor_pass_args=()
+    if [ "${#PASS_ARGS[@]}" -eq 0 ]; then
+      return 0
+    fi
+
+    for pass_arg in "${PASS_ARGS[@]}"; do
+      if [ "${skip_next}" = "true" ]; then
+        skip_next=false
+        continue
+      fi
+      case "$pass_arg" in
+        --resume)
+          if [ "${cursor_has_explicit_resume_id}" = "true" ]; then
+            skip_next=true
+          fi
+          ;;
+        --resume=*|--continue) ;;
+        *) cursor_pass_args+=("$pass_arg") ;;
+      esac
+    done
+  }
+
   local cursor_has_resume_arg=false
   local cursor_has_explicit_resume_id=false
-  local pass_arg
+  local cursor_explicit_resume_id=""
+  local pass_arg pass_idx next_arg
   if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
-    for pass_arg in "${PASS_ARGS[@]}"; do
+    pass_idx=0
+    while [ "${pass_idx}" -lt "${#PASS_ARGS[@]}" ]; do
+      pass_arg="${PASS_ARGS[$pass_idx]}"
       case "$pass_arg" in
-        --continue|--resume)
+        --continue)
           cursor_has_resume_arg=true
+          ;;
+        --resume)
+          cursor_has_resume_arg=true
+          next_arg="${PASS_ARGS[$((pass_idx + 1))]:-}"
+          if _cursor_is_uuid "${next_arg}"; then
+            cursor_has_explicit_resume_id=true
+            cursor_explicit_resume_id="${next_arg}"
+          fi
           ;;
         --resume=*)
           cursor_has_resume_arg=true
           cursor_has_explicit_resume_id=true
+          cursor_explicit_resume_id="${pass_arg#--resume=}"
           ;;
       esac
+      pass_idx=$((pass_idx + 1))
     done
   fi
 
@@ -91,7 +144,14 @@ run_cursor() {
     cursor_pass_args=("${PASS_ARGS[@]}")
   fi
 
-  if [ "${cursor_has_resume_arg}" = "true" ] && [ "${cursor_has_explicit_resume_id}" = "false" ]; then
+  if [ "${cursor_session_enabled}" = "false" ]; then
+    :
+  elif [ "${cursor_has_explicit_resume_id}" = "true" ]; then
+    echo "Resuming Cursor session: ${cursor_explicit_resume_id}"
+    cursor_session_args=(--resume "${cursor_explicit_resume_id}")
+    cursor_session_id="${cursor_explicit_resume_id}"
+    _cursor_strip_resume_flags
+  elif [ "${cursor_has_resume_arg}" = "true" ] && [ "${teammate_session_enabled}" = "true" ]; then
     if [ -z "${cursor_session_id}" ] && [ -f "outputs/cursor_session_id.txt" ]; then
       cursor_session_id="$(tr -d '[:space:]' < outputs/cursor_session_id.txt || true)"
     fi
@@ -102,16 +162,8 @@ run_cursor() {
     fi
     echo "Resuming Cursor session: ${cursor_session_id}"
     cursor_session_args=(--resume "${cursor_session_id}")
-    cursor_pass_args=()
-    if [ "${#PASS_ARGS[@]}" -gt 0 ]; then
-      for pass_arg in "${PASS_ARGS[@]}"; do
-        case "$pass_arg" in
-          --continue|--resume|--resume=*) ;;
-          *) cursor_pass_args+=("$pass_arg") ;;
-        esac
-      done
-    fi
-  elif [ -n "${cursor_session_id}" ] && [ "${cursor_has_explicit_resume_id}" = "false" ]; then
+    _cursor_strip_resume_flags
+  elif [ -n "${cursor_session_id}" ] && [ "${teammate_session_enabled}" = "true" ]; then
     if _cursor_session_exists "${cursor_session_id}"; then
       echo "Resuming Cursor session: ${cursor_session_id}"
       cursor_session_args=(--resume "${cursor_session_id}")
@@ -132,7 +184,7 @@ run_cursor() {
   fi
 
   local cursor_output_format="text"
-  if [ "${CURSOR_SESSION_ENABLED:-true}" != "false" ] && [ -n "${CURSOR_SESSION_ID:-}" ]; then
+  if [ "${cursor_session_enabled}" = "true" ] && [ -n "${CURSOR_SESSION_ID:-}" ]; then
     cursor_output_format="stream-json"
   fi
 
@@ -162,26 +214,28 @@ run_cursor() {
   set -e
   record_codegraph_usage "$agent_log"
 
-  local new_session_id=""
-  new_session_id="$(grep -o '"session_id":"[^"]*"' "$agent_log" | head -1 | cut -d'"' -f4 || true)"
-  if [ -z "${new_session_id}" ]; then
-    new_session_id="$(_cursor_extract_uuid "$(cat "$agent_log" 2>/dev/null || true)")"
-  fi
+  if [ "${teammate_session_enabled}" = "true" ] && [ "${cursor_has_explicit_resume_id}" = "false" ]; then
+    local new_session_id=""
+    new_session_id="$(grep -o '"session_id":"[^"]*"' "$agent_log" | head -1 | cut -d'"' -f4 || true)"
+    if [ -z "${new_session_id}" ]; then
+      new_session_id="$(_cursor_extract_uuid "$(cat "$agent_log" 2>/dev/null || true)")"
+    fi
 
-  local effective_session_id="${cursor_session_id:-${new_session_id}}"
-  if [ -n "${CURSOR_SESSION_ID:-}" ] && [ -n "${new_session_id}" ] && [ "${new_session_id}" != "${CURSOR_SESSION_ID}" ]; then
-    _cursor_normalize_session_id "${new_session_id}" "${CURSOR_SESSION_ID}"
-    effective_session_id="${CURSOR_SESSION_ID}"
-  fi
+    local effective_session_id="${cursor_session_id:-${new_session_id}}"
+    if [ -n "${CURSOR_SESSION_ID:-}" ] && [ -n "${new_session_id}" ] && [ "${new_session_id}" != "${CURSOR_SESSION_ID}" ]; then
+      _cursor_normalize_session_id "${new_session_id}" "${CURSOR_SESSION_ID}"
+      effective_session_id="${CURSOR_SESSION_ID}"
+    fi
 
-  if [ -n "${effective_session_id}" ]; then
-    mkdir -p outputs
-    printf '%s\n' "${effective_session_id}" > outputs/cursor_session_id.txt
+    if [ -n "${effective_session_id}" ]; then
+      mkdir -p outputs
+      printf '%s\n' "${effective_session_id}" > outputs/cursor_session_id.txt
+    fi
   fi
 
   rm -f "$agent_log"
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="
-  return $exit_code
+  return "$exit_code"
 }

--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -97,6 +97,11 @@ _cache_kimi() {
   export_var "KIMI_CACHE_KEY"  "kimi-${version}-${OS_TAG}"
 }
 
+_cache_cursor() {
+  export_var "CURSOR_CACHE_PATH" "${HOME}/.cursor"
+  export_var "CURSOR_CACHE_KEY"  "cursor-${OS_TAG}"
+}
+
 _cache_kimi_session() {
   # shellcheck source=/dev/null
   source "${SCRIPT_DIR}/kimi-session.sh" env
@@ -171,7 +176,7 @@ _dispatch_tool() {
     playwright) _cache_playwright "${version}" ;;
     codemie)  _cache_codemie  "${version}" ;;
     kimi)     _cache_kimi     "${version}" ;;
-    cursor)   echo "ℹ️  cursor-agent is not cacheable (part of Cursor IDE)" ;;
+    cursor)   _cache_cursor ;;
     gradle)   _cache_gradle ;;
     konan)    _cache_konan ;;
     android)  _cache_android  "${version}" ;;
@@ -190,7 +195,7 @@ _print_info() {
   printf "│ %-11s │ %-32s │ %-46s │\n" "maestro"  "~/.maestro"     "maestro-latest-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "copilot"  "~/.npm-global"  "npm-global-copilot-latest-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "codemie"  "~/.local/bin"   "codemie-latest-linux-x86_64"
-  printf "│ %-11s │ %-32s │ %-46s │\n" "cursor"   "(not cacheable)" "-"
+  printf "│ %-11s │ %-32s │ %-46s │\n" "cursor"   "~/.cursor"        "cursor-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "codegraph" "~/.npm-global + .codegraph/" "npm-global-codegraph-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "playwright" "~/.cache/ms-playwright" "playwright-browsers-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "gradle"    "~/.gradle/wrapper + caches" "gradle-wrapper-<hash> / gradle-caches-<hash>"
@@ -213,7 +218,7 @@ _print_info() {
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-ALL_TOOLS="java node dmtools maestro copilot copilot-session kimi-session codemie codegraph playwright kimi"  # cursor has no cache
+ALL_TOOLS="java node dmtools maestro copilot copilot-session kimi-session codemie cursor codegraph playwright kimi"
 
 MODE="${1:-info}"
 shift || true

--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -107,6 +107,11 @@ _cache_kimi_session() {
   source "${SCRIPT_DIR}/kimi-session.sh" env
 }
 
+_cache_cursor_session() {
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/cursor-session.sh" env
+}
+
 _cache_gradle() {
   # Gradle wrapper distribution (~/.gradle/wrapper) and dependency cache (~/.gradle/caches).
   # Keys hash the files most likely to change the cache content:
@@ -172,6 +177,7 @@ _dispatch_tool() {
     copilot)  _cache_copilot  "${version}" ;;
     copilot-session) _cache_copilot_session ;;
     kimi-session) _cache_kimi_session ;;
+    cursor-session) _cache_cursor_session ;;
     codegraph) _cache_codegraph "${version}" ;;
     playwright) _cache_playwright "${version}" ;;
     codemie)  _cache_codemie  "${version}" ;;
@@ -196,6 +202,7 @@ _print_info() {
   printf "│ %-11s │ %-32s │ %-46s │\n" "copilot"  "~/.npm-global"  "npm-global-copilot-latest-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "codemie"  "~/.local/bin"   "codemie-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "cursor"   "~/.cursor"        "cursor-linux-x86_64"
+  printf "│ %-11s │ %-32s │ %-46s │\n" "cursor-session" "~/.cursor/chats" "cursor-session-<repo>-<key>-<group>-v1-<run>"
   printf "│ %-11s │ %-32s │ %-46s │\n" "codegraph" "~/.npm-global + .codegraph/" "npm-global-codegraph-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "playwright" "~/.cache/ms-playwright" "playwright-browsers-latest-linux-x86_64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "gradle"    "~/.gradle/wrapper + caches" "gradle-wrapper-<hash> / gradle-caches-<hash>"
@@ -218,7 +225,7 @@ _print_info() {
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-ALL_TOOLS="java node dmtools maestro copilot copilot-session kimi-session codemie cursor codegraph playwright kimi"
+ALL_TOOLS="java node dmtools maestro copilot copilot-session kimi-session cursor-session codemie cursor codegraph playwright kimi"
 
 MODE="${1:-info}"
 shift || true

--- a/setup/cursor-session.sh
+++ b/setup/cursor-session.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Configure a stable, cacheable Cursor CLI session for AI Teammate runs.
+#
+# Usage:
+#   cursor-session.sh env
+#   cursor-session.sh info
+#
+# Inputs:
+#   AI_TEAMMATE_CONFIG_FILE       e.g. agents/story_development.json
+#   AI_TEAMMATE_CONCURRENCY_KEY   workflow concurrency key (usually ticket key)
+#   AI_TEAMMATE_DISPLAY_KEY       user-visible ticket key, preferred when set
+#   GITHUB_WORKSPACE              workspace root
+#
+# Outputs:
+#   CURSOR_SESSION_ID               stable UUID derived from repo/key/group
+#   CURSOR_SESSION_NAME             stable human-readable session name
+#   CURSOR_SESSION_GROUP            logical group (dev-write, dev-review, ...)
+#   CURSOR_SESSION_CACHE_PATH       path for CI cache restore/save (~/.cursor/chats)
+#   CURSOR_SESSION_CACHE_KEY        immutable cache key for this run
+#   CURSOR_SESSION_CACHE_RESTORE_KEY prefix for previous runs of the same stream
+#
+# CI restore order (when caching both cursor and cursor-session):
+#   1. cursor         — CLI binary/config (~/.cursor, excluding chats)
+#   2. cursor-session — chat history (~/.cursor/chats)
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_common.sh"
+
+_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+_uuid_from_seed() {
+  local hash="$(_sha256 "$1")"
+  # Build a deterministic UUID-looking value. Cursor only requires a UUID;
+  # the seed keeps the same ticket/group on the same session across CI runs.
+  printf '%s-%s-5%s-a%s-%s' \
+    "${hash:0:8}" \
+    "${hash:8:4}" \
+    "${hash:13:3}" \
+    "${hash:17:3}" \
+    "${hash:20:12}"
+}
+
+_config_slug() {
+  local config="${AI_TEAMMATE_CONFIG_FILE:-${CONFIG_FILE:-}}"
+  config="${config##*/}"
+  config="${config%.json}"
+  _slug "${config:-unknown}"
+}
+
+_session_group_for_config() {
+  local config="$1"
+  case "${config}" in
+    story_development|bug_development|pr_rework)
+      echo "dev-write"
+      ;;
+    pr_review)
+      echo "dev-review"
+      ;;
+    test_case_automation|pr_test_automation_rework)
+      echo "test-write"
+      ;;
+    pr_test_automation_review)
+      echo "test-review"
+      ;;
+    *)
+      echo "${config}"
+      ;;
+  esac
+}
+
+configure_cursor_session() {
+  local workspace="${GITHUB_WORKSPACE:-${PWD}}"
+  local repo="${GITHUB_REPOSITORY:-$(basename "${workspace}")}"
+  local config="$(_config_slug)"
+  local group="$(_session_group_for_config "${config}")"
+  local key="${AI_TEAMMATE_DISPLAY_KEY:-${DISPLAY_KEY:-}}"
+
+  if [ -z "${key}" ]; then
+    key="${AI_TEAMMATE_CONCURRENCY_KEY:-${CONCURRENCY_KEY:-}}"
+  fi
+  if [ -z "${key}" ]; then
+    key="$(git -C "${workspace}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)"
+  fi
+
+  local repo_slug="$(_slug "${repo}")"
+  local key_slug="$(_slug "${key}")"
+  local group_slug="$(_slug "${group}")"
+  local session_seed="${repo_slug}:${key_slug}:${group_slug}"
+  local session_id="$(_uuid_from_seed "${session_seed}")"
+  local session_name="${repo_slug}-${key_slug}-${group_slug}"
+  local cache_prefix="cursor-session-${repo_slug}-${key_slug}-${group_slug}-"
+  local cache_version="${CURSOR_SESSION_CACHE_VERSION:-v1}"
+  local cache_run_id="${GITHUB_RUN_ID:-local}"
+
+  export_var "CURSOR_SESSION_ID" "${session_id}"
+  export_var "CURSOR_SESSION_NAME" "${session_name}"
+  export_var "CURSOR_SESSION_GROUP" "${group_slug}"
+  export_var "CURSOR_SESSION_CACHE_PATH" "${HOME}/.cursor/chats"
+  export_var "CURSOR_SESSION_CACHE_RESTORE_KEY" "${cache_prefix}${cache_version}-"
+  export_var "CURSOR_SESSION_CACHE_KEY" "${cache_prefix}${cache_version}-${cache_run_id}"
+}
+
+MODE="${1:-env}"
+case "${MODE}" in
+  env|restore|save|info)
+    configure_cursor_session
+    echo "🖱  Cursor session: group=${CURSOR_SESSION_GROUP} name=${CURSOR_SESSION_NAME}"
+    echo "📦 Cursor session cache: key=${CURSOR_SESSION_CACHE_KEY} path=${CURSOR_SESSION_CACHE_PATH}"
+    ;;
+  *)
+    echo "Usage: cursor-session.sh env|restore|save|info" >&2
+    exit 1
+    ;;
+esac

--- a/setup/cursor.sh
+++ b/setup/cursor.sh
@@ -1,30 +1,66 @@
 #!/usr/bin/env bash
-# Check / validate cursor-agent availability.
-# cursor-agent is part of the Cursor IDE and cannot be installed via script.
+# Install Cursor Agent CLI.
+# Requires CURSOR_API_KEY at runtime on CI (auth is not handled here).
 #
 # Usage:
-#   cursor.sh        # check and report status
+#   cursor.sh
 #
-# To use cursor as AI_AGENT_PROVIDER on CI, switch to 'copilot' or 'codemie' instead.
+# Cache path: ~/.cursor
+# Binary: agent or cursor-agent in ~/.local/bin / ~/.cursor/bin
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_common.sh"
 
-echo "🖱  cursor-agent"
+CURSOR_HOME="${HOME}/.cursor"
+CURSOR_LOCAL_BIN="${HOME}/.local/bin"
+CURSOR_BIN_DIR="${CURSOR_HOME}/bin"
 
-if is_installed cursor-agent; then
-  echo "✅ cursor-agent available: $(cursor-agent --version 2>/dev/null || echo "present")"
-else
-  echo "⚠️  cursor-agent not found."
-  echo ""
-  echo "   cursor-agent ships with the Cursor IDE (https://www.cursor.com) and"
-  echo "   cannot be installed via a script. It is intended for local development."
-  echo ""
-  echo "   On CI, use AI_AGENT_PROVIDER=copilot or AI_AGENT_PROVIDER=codemie instead."
-  echo ""
-  CI="$(detect_ci)"
-  if [ "${CI}" != "local" ]; then
-    echo "   ℹ️  Detected CI platform: ${CI} — cursor-agent will not work here."
+echo "🖱  Cursor Agent CLI"
+
+_ensure_cursor_agent_symlink() {
+  if command -v agent >/dev/null 2>&1 && ! command -v cursor-agent >/dev/null 2>&1; then
+    mkdir -p "${CURSOR_LOCAL_BIN}"
+    ln -sf "$(command -v agent)" "${CURSOR_LOCAL_BIN}/cursor-agent"
   fi
+}
+
+# ── Register bin dirs (before install check, like copilot.sh) ────────────────
+mkdir -p "${CURSOR_LOCAL_BIN}"
+register_path "${CURSOR_LOCAL_BIN}"
+register_path "${CURSOR_BIN_DIR}"
+
+# ── Already installed? ────────────────────────────────────────────────────────
+if is_installed cursor-agent; then
+  echo "✅ cursor-agent already installed: $(cursor-agent --version 2>/dev/null || echo 'present')"
+  exit 0
+fi
+if is_installed agent; then
+  _ensure_cursor_agent_symlink
+  echo "✅ agent already on PATH: $(agent --version 2>/dev/null || echo 'present')"
+  exit 0
+fi
+if [ -x "${CURSOR_BIN_DIR}/agent" ] || [ -x "${CURSOR_LOCAL_BIN}/agent" ]; then
+  _ensure_cursor_agent_symlink
+  echo "✅ Cursor Agent CLI already installed (cached)"
+  exit 0
+fi
+
+# ── Prerequisite ─────────────────────────────────────────────────────────────
+if ! is_installed curl; then
+  echo "❌ curl not found. Install curl first (apt-get install -y curl on CI)." >&2
+  exit 1
+fi
+
+# ── Install ───────────────────────────────────────────────────────────────────
+echo "📥 Installing Cursor Agent CLI..."
+curl https://cursor.com/install -fsS | bash
+
+_ensure_cursor_agent_symlink
+
+if is_installed cursor-agent || is_installed agent; then
+  echo "✅ Cursor Agent CLI $(cursor-agent --version 2>/dev/null || agent --version 2>/dev/null || echo 'installed')"
+else
+  echo "❌ cursor-agent not found after install" >&2
+  exit 1
 fi

--- a/setup/cursor.sh
+++ b/setup/cursor.sh
@@ -25,6 +25,20 @@ _ensure_cursor_agent_symlink() {
   fi
 }
 
+# ── Configure stable Cursor session for AI Teammate runs ────────────────────
+_configure_session() {
+  # When running inside AI Teammate, derive a stable session id per
+  # repo:ticket:agent_group and cache ~/.cursor/chats so the session can be
+  # resumed across CI runs.
+  if [ -z "${AI_TEAMMATE_CONFIG_FILE:-}" ]; then
+    return 0
+  fi
+  if [ -f "${SCRIPT_DIR}/cursor-session.sh" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/cursor-session.sh" env
+  fi
+}
+
 # ── Register bin dirs (before install check, like copilot.sh) ────────────────
 mkdir -p "${CURSOR_LOCAL_BIN}"
 register_path "${CURSOR_LOCAL_BIN}"
@@ -33,16 +47,19 @@ register_path "${CURSOR_BIN_DIR}"
 # ── Already installed? ────────────────────────────────────────────────────────
 if is_installed cursor-agent; then
   echo "✅ cursor-agent already installed: $(cursor-agent --version 2>/dev/null || echo 'present')"
+  _configure_session
   exit 0
 fi
 if is_installed agent; then
   _ensure_cursor_agent_symlink
   echo "✅ agent already on PATH: $(agent --version 2>/dev/null || echo 'present')"
+  _configure_session
   exit 0
 fi
 if [ -x "${CURSOR_BIN_DIR}/agent" ] || [ -x "${CURSOR_LOCAL_BIN}/agent" ]; then
   _ensure_cursor_agent_symlink
   echo "✅ Cursor Agent CLI already installed (cached)"
+  _configure_session
   exit 0
 fi
 
@@ -60,6 +77,7 @@ _ensure_cursor_agent_symlink
 
 if is_installed cursor-agent || is_installed agent; then
   echo "✅ Cursor Agent CLI $(cursor-agent --version 2>/dev/null || agent --version 2>/dev/null || echo 'installed')"
+  _configure_session
 else
   echo "❌ cursor-agent not found after install" >&2
   exit 1

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
   echo "  maestro   — Maestro mobile testing.  Default version: latest"
   echo "  copilot   — @github/copilot npm CLI. Default version: latest  (needs node)"
   echo "  codemie   — codemie-claude CLI.      Default version: latest"
-  echo "  cursor    — cursor-agent (check only; cannot be auto-installed)"
+  echo "  cursor    — Cursor Agent CLI (via https://cursor.com/install)"
   echo "  codegraph — CodeGraph CLI (npm).     Default version: latest"
   echo "  playwright — Playwright + Chromium.  Default version: latest"
   echo "  kimi      — Kimi Code CLI.           Default version: latest"


### PR DESCRIPTION
## Summary

- Install Cursor Agent CLI in CI via `setup/cursor.sh` (`https://cursor.com/install`)
- Register `~/.cursor` cache path in `setup/cache.sh`
- Update `setup/install.sh` help text for the cursor tool
- Add `setup/cursor-session.sh` for stable per-repo/ticket/agent-group session IDs in AI Teammate runs
- Cache `~/.cursor/chats` via `setup/cache.sh` `cursor-session` tool
- Extend `scripts/providers/cursor.sh` with session create/resume, `outputs/cursor_session_id.txt` persistence, and deterministic session id normalization

## Follow-up

- `scripts/providers/cursor.sh`: hardened resume edge cases (two-token `--resume <uuid>`, teammate session gating via `AI_TEAMMATE_CONFIG_FILE`, `CURSOR_SESSION_ENABLED=false`); verified with Git Bash `bash -n`.

## Test plan

- [ ] Run `setup/install.sh cursor` on a clean CI runner and confirm `cursor-agent` is available
- [ ] Run `setup/cache.sh cursor` and confirm `~/.cursor` cache key is registered
- [ ] Run `setup/cache.sh cursor-session` and confirm chat store is restored across runs
- [ ] Verify a resume agent run uses persisted session id when `outputs/cursor_session_id.txt` exists