### PR TITLE
fix(agents): skip rework push and rework auto-trigger when no PR exists

### DIFF
--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -878,13 +878,28 @@ function action(params) {
                     label: LABELS.PR_APPROVED
                 });
                 console.log('✅ Added pr_approved label to Jira ticket — SM will retry merge');
-            } else {
-                // Has issues → move to In Rework for focused fixes
+            } else if (prNumber && repoInfo) {
+                // Has issues, and there is an actual PR to rework → move to In Rework for focused fixes
                 jira_move_to_status({
                     key: ticketKey,
                     statusName: statuses.IN_REWORK
                 });
                 console.log('✅ Ticket moved to In Rework');
+            } else {
+                // Has issues, but no PR was ever matched to this ticket — moving to In Rework
+                // would start a rework cycle with nothing to rework. Leave the status alone
+                // and surface this explicitly instead of silently transitioning the ticket.
+                try {
+                    jira_post_comment({
+                        key: ticketKey,
+                        comment: 'h3. ⚠️ PR Review Could Not Be Attached\n\n' +
+                            'The review analysis completed, but no open Pull Request could be matched to this ticket. ' +
+                            'The ticket status was left unchanged (not moved to In Rework) since there is no PR to rework.'
+                    });
+                } catch (commentError) {
+                    console.warn('Could not post PR-review-could-not-be-attached comment:', commentError);
+                }
+                console.warn('⚠️ No PR found for', ticketKey, '— leaving ticket status unchanged');
             }
         } catch (statusError) {
             console.warn('Could not update ticket status/label:', statusError);
@@ -937,9 +952,11 @@ function action(params) {
             console.warn('Failed to assign ticket:', error);
         }
 
-        // Step 12: Auto-start pr_rework when changes were requested (opt-in via customParams)
+        // Step 12: Auto-start pr_rework when changes were requested (opt-in via customParams).
+        // Only when there's an actual PR to rework — with no PR found, there's nothing for a
+        // rework cycle to act on, so don't mark for SM rework or trigger SM.
         var reworkStarted = false;
-        if (!isApproved) {
+        if (!isApproved && prNumber && repoInfo) {
             const autoStartRework = customParams && customParams.autoStartRework;
             const reworkConfigFile = customParams && customParams.autoStartReworkConfigFile;
             if (autoStartRework && reworkConfigFile) {

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -422,6 +422,55 @@ function isInterruptedReworkResponse(response) {
         text.indexOf('"path": "interrupted"') !== -1;
 }
 
+/**
+ * Reads input/<ticketKey>/rework_setup_failed.md, written by preCliReworkSetup's
+ * failSetup() when it could not find/checkout a PR for the ticket (e.g. "no PR
+ * found for ticket"). Returns the file content, or null if the file does not
+ * exist (the normal, working-PR path).
+ */
+function readReworkSetupFailure(ticketKey) {
+    try {
+        var content = file_read({ path: 'input/' + ticketKey + '/rework_setup_failed.md' });
+        return (content && content.trim()) ? content : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Rework setup already failed (most commonly: no PR found for the ticket) before
+ * the CLI agent even ran. There is no branch/PR to push changes to, and retrying
+ * the CLI cannot conjure one up — in the observed incident, retrying instead led
+ * the CLI agent to fabricate a fake pr_info.md just to satisfy the "refuse to
+ * commit on base branch" guard. Skip commitAndPush() and the resumeAgent retry
+ * entirely, and just make sure Jira reflects what happened.
+ */
+function handleReworkSetupAlreadyFailed(ticketKey, customParams, failureContent) {
+    console.warn('⚠️ Rework setup already failed (no PR found) for', ticketKey, '— skipping commit/push and CLI retry.');
+    try {
+        var comment = 'h3. ❌ Rework Push Skipped — Setup Already Failed\n\n' +
+            'Rework setup did not find (or could not check out) a Pull Request for this ticket, ' +
+            'so there is no branch to push changes to. Retrying the CLI agent cannot fix a missing PR, ' +
+            'so the push step was skipped rather than retried.\n\n';
+        if (failureContent) {
+            comment += '{code}' + failureContent.trim() + '{code}';
+        } else {
+            comment += 'See {code}input/' + ticketKey + '/rework_setup_failed.md{code} for details.';
+        }
+        jira_post_comment({ key: ticketKey, comment: comment });
+        console.log('✅ Posted rework-setup-already-failed comment to Jira:', ticketKey);
+    } catch (e) {
+        console.warn('Failed to post rework-setup-already-failed Jira comment:', e.message || e);
+    }
+    removeConfiguredLabels(ticketKey, customParams || {});
+    return {
+        success: true,
+        path: 'rework-setup-already-failed',
+        ticketKey: ticketKey,
+        error: 'Rework setup already failed (no PR found for ticket); push step skipped.'
+    };
+}
+
 function handleInterruptedRework(ticketKey, branchName, customParams, statuses) {
     console.warn('Rework CLI was interrupted before writing required outputs; leaving PR conversations open and resetting ticket for retry.');
     try {
@@ -495,6 +544,14 @@ function action(params) {
             console.warn('⚠️ Non-blocking gate failures (push/replies continue):\n' + warningLines.join('\n'));
         }
         const fixSummaryWithWarnings = fixSummary + nonBlockingGateWarningBlock;
+
+        // If rework setup already failed (e.g. no PR found for this ticket), there is
+        // nothing to commit/push to and no amount of CLI retrying can fix a missing PR.
+        // Bail out here, before touching git at all.
+        var reworkSetupFailure = readReworkSetupFailure(ticketKey);
+        if (reworkSetupFailure !== null) {
+            return handleReworkSetupAlreadyFailed(ticketKey, _customParams, reworkSetupFailure);
+        }
 
         // Commit and push
         let branchName;
@@ -723,5 +780,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, resolveCustomParams, isInterruptedReworkResponse, postThreadReplies, commitAndPush };
+    module.exports = { action, resolveCustomParams, isInterruptedReworkResponse, postThreadReplies, commitAndPush, readReworkSetupFailure };
 }

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -258,5 +258,161 @@ suite('postPRReviewComments', function() {
             assert.notEqual(calls[0].text, 'outputs/pr_review_comments/comment1_analytics_confirm.md');
         });
     });
+
+    // ── action(): !isApproved + no-PR guard (issue #311) ──────────────────────
+    // postPRReviewComments must not move the Jira ticket to In Rework, nor
+    // auto-trigger a pr_rework cycle (markForSmStoryRework/triggerSmIfIdle), when
+    // the review recommendation isn't a clean approval but no open PR could ever
+    // be matched to the ticket. Only the GitHub-comment-posting step (Step 4) was
+    // previously guarded with `if (prNumber && repoInfo)`; the Jira status
+    // transition (Step 7) and the SM/rework auto-trigger (Step 12) were not.
+    suite('action — !isApproved + no-PR guard (#311)', function() {
+
+        function loadPostPRReviewCommentsForAction(opts) {
+            opts = opts || {};
+            var jiraAddLabelCalls = [];
+            var jiraMoveToStatusCalls = [];
+            var jiraPostCommentCalls = [];
+            var triggerSmIfIdleCalls = [];
+
+            var scm = {
+                listPrs: function() { return opts.openPrs || []; },
+                getRemoteRepoInfo: function() { return opts.repoInfo !== undefined ? opts.repoInfo : null; },
+                addLabel: function() {},
+                fetchDiscussions: function() { return { rawThreads: { threads: [] } }; }
+            };
+
+            var outputFiles = {
+                readOutputFileDetailed: function() {
+                    return { content: JSON.stringify(opts.reviewData), path: 'outputs/pr_review.json' };
+                },
+                readOutputFile: function() { return null; }
+            };
+
+            var defaultMocks = {
+                file_read: function(args) {
+                    var p = args && (args.path || args);
+                    if (p && p.indexOf('pr_info.md') !== -1) {
+                        return opts.prInfoContent || null;
+                    }
+                    return null;
+                },
+                jira_add_label: function(args) { jiraAddLabelCalls.push(args); },
+                jira_move_to_status: function(args) { jiraMoveToStatusCalls.push(args); },
+                jira_post_comment: function(args) { jiraPostCommentCalls.push(args); },
+                jira_remove_label: function() {},
+                jira_assign_ticket_to: function() {}
+            };
+
+            var mod = loadModule(
+                'js/postPRReviewComments.js',
+                makeRequire({
+                    './config.js': configModule,
+                    './common/scm.js': { createScm: function() { return scm; } },
+                    './common/autoStart.js': {
+                        triggerConfiguredWorkflowForTicket: function() { return false; },
+                        triggerSmIfIdle: function(args) { triggerSmIfIdleCalls.push(args); }
+                    },
+                    './configLoader.js': {
+                        loadProjectConfig: function() { return opts.config || {}; },
+                        resolveInstructions: function() { return { jobParamPatch: {} }; }
+                    },
+                    './common/outputFiles.js': outputFiles,
+                    './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+                }),
+                defaultMocks
+            );
+
+            return {
+                mod: mod,
+                jiraAddLabelCalls: jiraAddLabelCalls,
+                jiraMoveToStatusCalls: jiraMoveToStatusCalls,
+                jiraPostCommentCalls: jiraPostCommentCalls,
+                triggerSmIfIdleCalls: triggerSmIfIdleCalls
+            };
+        }
+
+        test('no PR found: does NOT move to In Rework, does NOT mark/trigger SM rework, posts "could not attach" comment instead', function() {
+            var loaded = loadPostPRReviewCommentsForAction({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                repoInfo: null,
+                openPrs: []
+            });
+
+            var result = loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1'
+            });
+
+            assert.equal(result.success, true);
+            assert.equal(result.githubCommentsPosted, false);
+
+            assert.equal(
+                loaded.jiraMoveToStatusCalls.length, 0,
+                'must NOT move the ticket to In Rework when no PR was found'
+            );
+            assert.equal(
+                loaded.jiraAddLabelCalls.filter(function(c) { return c.label === 'sm_story_rework_triggered'; }).length, 0,
+                'must NOT mark for SM story rework when no PR was found'
+            );
+            assert.equal(
+                loaded.triggerSmIfIdleCalls.length, 0,
+                'must NOT trigger SM when no PR was found (nothing to rework)'
+            );
+
+            assert.ok(
+                loaded.jiraPostCommentCalls.some(function(c) {
+                    return c.comment.indexOf('PR Review Could Not Be Attached') !== -1;
+                }),
+                'should post the new "could not attach" comment explaining the ticket was left unchanged'
+            );
+        });
+
+        test('regression: !isApproved WITH a PR found still moves to In Rework and triggers SM rework as before', function() {
+            var loaded = loadPostPRReviewCommentsForAction({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                repoInfo: { owner: 'IstiN', repo: 'dmtools-agents' },
+                prInfoContent: '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n'
+            });
+
+            var result = loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1'
+            });
+
+            assert.equal(result.success, true);
+            assert.equal(result.githubCommentsPosted, true);
+
+            assert.ok(
+                loaded.jiraMoveToStatusCalls.some(function(c) { return c.statusName === 'In Rework'; }),
+                'should still move the ticket to In Rework when a PR was found'
+            );
+            assert.equal(
+                loaded.jiraAddLabelCalls.filter(function(c) { return c.label === 'sm_story_rework_triggered'; }).length, 1,
+                'should still mark for SM story rework when a PR was found'
+            );
+            assert.equal(
+                loaded.triggerSmIfIdleCalls.length, 1,
+                'should still trigger SM when a PR was found'
+            );
+            assert.equal(
+                loaded.jiraPostCommentCalls.some(function(c) {
+                    return c.comment.indexOf('PR Review Could Not Be Attached') !== -1;
+                }),
+                false,
+                'must not post the "could not attach" comment when a PR was found'
+            );
+        });
+    });
 });
 

--- a/js/unit-tests/test_pushReworkChanges.js
+++ b/js/unit-tests/test_pushReworkChanges.js
@@ -307,3 +307,159 @@ suite('pushReworkChanges.commitAndPush — base-branch safety invariant', functi
         }, 'must refuse to commit/push without a known expected branch');
     });
 });
+
+// ── action(): rework_setup_failed.md guard (issue #310) ──────────────────────
+// preCliReworkSetup.js writes input/<ticketKey>/rework_setup_failed.md (via
+// failSetup()) when it could not find/checkout a PR for the ticket, e.g. "no PR
+// found for ticket". pushReworkChanges must detect that marker BEFORE calling
+// commitAndPush()/resumeAgent() — retrying the CLI cannot fix a missing PR, and
+// in the observed incident retrying instead led the CLI agent to fabricate a
+// fake pr_info.md just to slip past the "refuse to commit on base branch" guard.
+
+function loadPushReworkChangesForAction(mocks) {
+    var jiraPostCommentCalls = [];
+    var jiraMoveToStatusCalls = [];
+    var resumeAgentCalls = [];
+    var cliCommands = [];
+
+    var scm = {
+        listPrs: function() { return []; },
+        getRemoteRepoInfo: function() { return { owner: 'IstiN', repo: 'dmtools-agents' }; }
+    };
+
+    var defaultMocks = {
+        cli_execute_command: function(args) {
+            cliCommands.push(args.command);
+            if (args.command === 'git branch --show-current') return 'bug/PROJ-123\n';
+            if (args.command.indexOf('git ls-remote --heads origin') === 0) {
+                return 'abc123\trefs/heads/bug/PROJ-123\n';
+            }
+            return '';
+        },
+        file_read: function(args) {
+            var p = args && (args.path || args);
+            if (p && p.indexOf('rework_setup_failed.md') !== -1) {
+                throw new Error('File does not exist');
+            }
+            if (p && p.indexOf('pr_info.md') !== -1) {
+                return '**Branch**: `bug/PROJ-123` → `develop`';
+            }
+            return null;
+        },
+        jira_post_comment: function(args) { jiraPostCommentCalls.push(args); },
+        jira_move_to_status: function(args) { jiraMoveToStatusCalls.push(args); },
+        jira_remove_label: function() {},
+        jira_assign_ticket_to: function() {}
+    };
+
+    var mod = loadModule(
+        'js/pushReworkChanges.js',
+        makeRequire({
+            './configLoader.js': {
+                loadProjectConfig: function() { return baseConfig(); },
+                resolveInstructions: function() { return { jobParamPatch: {} }; },
+                formatTemplate: function(template, vars) {
+                    return template.replace(/\{(\w+)\}/g, function(m, key) {
+                        return (vars && vars[key] !== undefined) ? vars[key] : m;
+                    });
+                }
+            },
+            './common/scm.js': { createScm: function() { return scm; } },
+            './common/submodules.js': { pushManagedSubmodules: function() {} },
+            './common/pullRequest.js': {
+                readStagedDiffStat: function() { return 'M file.txt\n'; },
+                syncBranchWithBase: function() { return { success: true, updated: false }; }
+            },
+            './common/feedbackLoop.js': {
+                runQualityGates: function() { return { success: true }; },
+                runPolicyGates: function() { return { success: true }; },
+                runPostPublishGates: function() { return { success: true }; },
+                resumeAgent: function(args) { resumeAgentCalls.push(args); return { attempted: false }; }
+            },
+            './common/autoStart.js': {
+                triggerSmIfIdle: function() {},
+                triggerConfiguredWorkflowForTicket: function() { return false; }
+            },
+            './common/outputFiles.js': { readOutputFile: function() { return null; } },
+            './config.js': configModule,
+            './cacheToReleases.js': { action: function() {} },
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+        }),
+        Object.assign({}, defaultMocks, mocks || {})
+    );
+
+    return {
+        mod: mod,
+        jiraPostCommentCalls: jiraPostCommentCalls,
+        jiraMoveToStatusCalls: jiraMoveToStatusCalls,
+        resumeAgentCalls: resumeAgentCalls,
+        cliCommands: cliCommands
+    };
+}
+
+suite('pushReworkChanges.action — rework_setup_failed.md guard (#310)', function() {
+
+    test('skips commitAndPush and resumeAgent, posts a Jira comment, when rework_setup_failed.md exists', function() {
+        var loaded = loadPushReworkChangesForAction({
+            file_read: function(args) {
+                var p = args && (args.path || args);
+                if (p && p.indexOf('rework_setup_failed.md') !== -1) {
+                    return '# Rework Setup Failed\n\nNo Pull Request found for ticket PROJ-123. Cannot start rework without an existing PR.\n';
+                }
+                return null;
+            }
+        });
+
+        var result = loaded.mod.action({
+            ticket: { key: 'PROJ-123', fields: { labels: [] } },
+            response: 'Some fix summary that would have been pushed.'
+        });
+
+        assert.equal(result.success, true, 'should be a handled outcome, not a hard failure');
+        assert.equal(result.path, 'rework-setup-already-failed');
+
+        assert.equal(
+            loaded.cliCommands.filter(function(c) { return c.indexOf('git commit') !== -1; }).length, 0,
+            'must never commit when rework setup already failed'
+        );
+        assert.equal(
+            loaded.cliCommands.filter(function(c) { return c.indexOf('git push') !== -1; }).length, 0,
+            'must never push when rework setup already failed'
+        );
+        assert.equal(loaded.resumeAgentCalls.length, 0, 'must NOT trigger a CLI retry — a missing PR cannot be fixed by retrying');
+
+        assert.equal(loaded.jiraPostCommentCalls.length, 1, 'exactly one Jira comment explaining the skip');
+        assert.contains(loaded.jiraPostCommentCalls[0].comment, 'Rework Push Skipped');
+        assert.contains(loaded.jiraPostCommentCalls[0].comment, 'No Pull Request found for ticket PROJ-123');
+
+        assert.equal(loaded.jiraMoveToStatusCalls.length, 0, 'must not reach the normal "move to In Review" step');
+    });
+
+    test('regression: normal commit/push flow is unchanged when rework_setup_failed.md does NOT exist', function() {
+        var loaded = loadPushReworkChangesForAction({});
+
+        var result = loaded.mod.action({
+            ticket: { key: 'PROJ-123', fields: { labels: [] } },
+            response: 'Some fix summary that should be pushed normally.'
+        });
+
+        assert.equal(result.success, true);
+        assert.notEqual(result.path, 'rework-setup-already-failed');
+        assert.equal(result.branchName, 'bug/PROJ-123');
+
+        assert.ok(
+            loaded.cliCommands.filter(function(c) { return c.indexOf('git commit') !== -1; }).length >= 1,
+            'should still commit staged changes'
+        );
+        assert.ok(
+            loaded.cliCommands.filter(function(c) { return c.indexOf('git push -u origin bug/PROJ-123') !== -1; }).length >= 1,
+            'should still push to the PR branch'
+        );
+        assert.equal(loaded.resumeAgentCalls.length, 0);
+
+        assert.ok(
+            loaded.jiraMoveToStatusCalls.some(function(c) { return c.statusName === 'In Review'; }),
+            'should still move the ticket to In Review as before'
+        );
+    });
+});


### PR DESCRIPTION
Fixes #310 and #311. See issue #309 for the related engine-side root cause (out of scope for this PR).