### PR TITLE
fix(scm): GitHub getCommitCheckRuns falls back to legacy commit statuses

### DIFF
--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -110,6 +110,69 @@ function _runGitDiff(baseRef, headRef, workingDir) {
     return '';
 }
 
+/**
+ * Normalize a legacy GitHub commit-status entry (the classic pre-Checks-API
+ * `/commits/{sha}/statuses` endpoint, still used by external CI systems such as Jenkins
+ * that report build results via the Status API instead of GitHub Check Runs) into the same
+ * shape detectFailedChecks() expects from github_get_commit_check_runs: { name, conclusion, details_url }.
+ */
+function _normalizeGithubCommitStatus(status) {
+    var s = String((status && status.state) || '').toLowerCase();
+    var conclusion = (s === 'failure' || s === 'error') ? 'failure'
+        : (s === 'success') ? 'success'
+        : s; // pending passes through and is filtered out by detectFailedChecks
+    return {
+        name: (status && status.context) || 'unknown',
+        conclusion: conclusion,
+        details_url: (status && status.target_url) || null
+    };
+}
+
+/**
+ * Fetch legacy commit statuses for a GitHub commit. No dedicated MCP tool exists for the
+ * classic Status API, so this shells out via `gh api` (same established pattern as
+ * updateBranch() below) and keeps only the most recent report per context — GitHub returns
+ * statuses newest-first, so the first occurrence per context wins.
+ */
+function _getLegacyGithubCommitStatuses(workspace, repository, sha) {
+    try {
+        var raw = cli_execute_command({
+            command: 'gh api repos/' + workspace + '/' + repository + '/commits/' + sha + '/statuses --paginate'
+        }) || '';
+        var cleaned = _cleanCommandOutput(raw);
+        if (!cleaned) return [];
+        var statuses = JSON.parse(cleaned);
+        if (!Array.isArray(statuses)) return [];
+        var seenContexts = {};
+        var latest = [];
+        for (var i = 0; i < statuses.length; i++) {
+            var ctx = statuses[i].context || 'unknown';
+            if (seenContexts[ctx]) continue;
+            seenContexts[ctx] = true;
+            latest.push(statuses[i]);
+        }
+        return latest;
+    } catch (e) {
+        console.warn('SCM GitHub: failed to fetch legacy commit statuses for', sha, ':', e.message || e);
+        return [];
+    }
+}
+
+/**
+ * Unwrap the raw github_get_commit_check_runs() response into a plain array, tolerating the
+ * various envelopes DMTools builds have used ({"result": ...}, {"check_runs": [...]}, a raw
+ * array, or a single object).
+ */
+function _unwrapGithubCheckRuns(raw) {
+    var parsed = _parseJson(raw);
+    if (parsed && typeof parsed.result !== 'undefined') {
+        parsed = _parseJson(parsed.result);
+    }
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && Array.isArray(parsed.check_runs)) return parsed.check_runs;
+    return parsed ? [parsed] : [];
+}
+
 function _createGithubProvider(workspace, repository) {
     return {
         listPrs: function(state) {
@@ -213,7 +276,30 @@ function _createGithubProvider(workspace, repository) {
             return raw || '';
         },
         getCommitCheckRuns: function(sha) {
-            return github_get_commit_check_runs({ workspace: workspace, repository: repository, commitSha: sha });
+            if (!sha) return null;
+            var checkRuns = [];
+            try {
+                var raw = github_get_commit_check_runs({ workspace: workspace, repository: repository, commitSha: sha });
+                checkRuns = _unwrapGithubCheckRuns(raw);
+            } catch (e) {
+                console.warn('SCM GitHub: failed to fetch check runs for', sha, ':', e.message || e);
+            }
+
+            // Some repos are wired to an external CI (e.g. Jenkins) that reports build
+            // results via the classic commit-status API instead of GitHub Check Runs, so
+            // checkRuns above can legitimately be empty even when CI actually ran and
+            // failed. Merge in legacy statuses (by name) so detectFailedChecks() still sees them.
+            var legacyStatuses = _getLegacyGithubCommitStatuses(workspace, repository, sha)
+                .map(_normalizeGithubCommitStatus);
+            if (!legacyStatuses.length) {
+                return checkRuns;
+            }
+            var existingNames = {};
+            checkRuns.forEach(function(c) { existingNames[c.name] = true; });
+            legacyStatuses.forEach(function(s) {
+                if (!existingNames[s.name]) checkRuns.push(s);
+            });
+            return checkRuns;
         },
         getJobLogs: function(jobId) {
             return github_get_job_logs({ workspace: workspace, repository: repository, jobId: String(jobId) });
@@ -946,5 +1032,8 @@ module.exports = {
     _createGithubProvider: _createGithubProvider,
     _createGitLabProvider: _createGitLabProvider,
     _createAdoProvider: _createAdoProvider,
-    _normalizeGitLabCommitStatus: _normalizeGitLabCommitStatus
+    _normalizeGitLabCommitStatus: _normalizeGitLabCommitStatus,
+    _normalizeGithubCommitStatus: _normalizeGithubCommitStatus,
+    _getLegacyGithubCommitStatuses: _getLegacyGithubCommitStatuses,
+    _unwrapGithubCheckRuns: _unwrapGithubCheckRuns
 };

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -630,6 +630,127 @@ suite('scm GitHub provider getPrDiff fallback', function() {
         assert.ok(diff.indexOf('diff --git') === 0, 'should return raw diff, not JSON envelope');
     });
 });
+
+suite('scm GitHub provider getCommitCheckRuns', function() {
+
+    test('returns native check runs as-is when the Checks API already reports them', function() {
+        var checkRunArgs = null;
+        var cliCalls = [];
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function(args) {
+                checkRunArgs = args;
+                return { check_runs: [{ name: 'build', conclusion: 'failure' }] };
+            },
+            cli_execute_command: function(args) { cliCalls.push(args.command); return '[]'; }
+        });
+
+        var provider = scmModule._createGithubProvider('IstiN', 'trackstate');
+        var runs = provider.getCommitCheckRuns('abc123');
+
+        assert.equal(checkRunArgs.workspace, 'IstiN');
+        assert.equal(checkRunArgs.repository, 'trackstate');
+        assert.equal(checkRunArgs.commitSha, 'abc123');
+        assert.equal(runs.length, 1);
+        assert.equal(runs[0].name, 'build');
+        assert.equal(runs[0].conclusion, 'failure');
+    });
+
+    test('merges legacy commit statuses (e.g. an external Jenkins) when the Checks API has none', function() {
+        var cliCommand = null;
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { return { check_runs: [] }; },
+            cli_execute_command: function(args) {
+                cliCommand = args.command;
+                return JSON.stringify([
+                    { context: 'continuous-integration/jenkins/pr-merge', state: 'error', target_url: 'https://jenkins.example.com/job/x/job/PR-1/5/display/redirect' },
+                    { context: 'continuous-integration/jenkins/pr-merge', state: 'pending', target_url: 'https://jenkins.example.com/job/x/job/PR-1/5/display/redirect' },
+                    { context: 'other-check', state: 'success', target_url: 'https://ci.example.com/1' }
+                ]);
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        var runs = provider.getCommitCheckRuns('deadbeef');
+
+        assert.ok(cliCommand.indexOf('repos/acme/widgets/commits/deadbeef/statuses') !== -1, 'should call gh api for the right repo/sha');
+        assert.equal(runs.length, 2, 'should dedupe to the most recent status per context');
+        assert.equal(runs[0].name, 'continuous-integration/jenkins/pr-merge');
+        assert.equal(runs[0].conclusion, 'failure', 'most recent report (error) wins over the older pending one');
+        assert.equal(runs[0].details_url, 'https://jenkins.example.com/job/x/job/PR-1/5/display/redirect');
+        assert.equal(runs[1].name, 'other-check');
+        assert.equal(runs[1].conclusion, 'success');
+    });
+
+    test('does not duplicate a check that is already reported by the Checks API', function() {
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { return { check_runs: [{ name: 'shared-check', conclusion: 'success' }] }; },
+            cli_execute_command: function() {
+                return JSON.stringify([{ context: 'shared-check', state: 'failure', target_url: 'https://x/1' }]);
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        var runs = provider.getCommitCheckRuns('deadbeef');
+
+        assert.equal(runs.length, 1, 'Checks API entry should win, not be duplicated by the legacy status');
+        assert.equal(runs[0].conclusion, 'success');
+    });
+
+    test('returns only check runs when there are no legacy statuses', function() {
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { return { check_runs: [{ name: 'build', conclusion: 'success' }] }; },
+            cli_execute_command: function() { return '[]'; }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        var runs = provider.getCommitCheckRuns('deadbeef');
+
+        assert.equal(runs.length, 1);
+        assert.equal(runs[0].name, 'build');
+    });
+
+    test('does not throw when the legacy status CLI call fails', function() {
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { return { check_runs: [{ name: 'build', conclusion: 'failure' }] }; },
+            cli_execute_command: function() { throw new Error('gh not authenticated'); }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        var runs = provider.getCommitCheckRuns('deadbeef');
+
+        assert.equal(runs.length, 1, 'should still return the native check runs it already had');
+        assert.equal(runs[0].name, 'build');
+    });
+
+    test('does not throw when the Checks API call fails, and still surfaces legacy statuses', function() {
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { throw new Error('boom'); },
+            cli_execute_command: function() {
+                return JSON.stringify([{ context: 'continuous-integration/jenkins/pr-merge', state: 'error', target_url: 'https://x/1' }]);
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        var runs = provider.getCommitCheckRuns('deadbeef');
+
+        assert.equal(runs.length, 1);
+        assert.equal(runs[0].name, 'continuous-integration/jenkins/pr-merge');
+        assert.equal(runs[0].conclusion, 'failure');
+    });
+
+    test('returns null without calling any tool when sha is missing', function() {
+        var calls = [];
+        var scmModule = loadScm({
+            github_get_commit_check_runs: function() { calls.push('checks'); return { check_runs: [] }; },
+            cli_execute_command: function() { calls.push('cli'); return '[]'; }
+        });
+
+        var provider = scmModule._createGithubProvider('acme', 'widgets');
+        assert.equal(provider.getCommitCheckRuns(null), null);
+        assert.equal(calls.length, 0);
+    });
+});
+
 suite('scm GitLab provider getPrDiff fallback', function() {
 
     test('prefers gitlab_get_mr_diff_text when available', function() {


### PR DESCRIPTION
Some repos are wired to an external CI (e.g. Jenkins posting via the classic commit-status API instead of the newer GitHub Check Runs API) whose build results only ever show up at `/commits/{sha}/statuses`, not in `github_get_commit_check_runs()`. `detectFailedChecks()` (used by `pr_rework`/`pr_review`) only queried the Checks API, so on such repos it silently saw zero checks and never surfaced a real CI failure or fetched its Jenkins log.

- `_createGithubProvider().getCommitCheckRuns()` now merges native check runs with legacy commit statuses (fetched via `gh api .../commits/{sha}/statuses`, since no dedicated MCP tool exists for the classic Status API), deduping by context name and keeping the most recent report per context.
- Added `_normalizeGithubCommitStatus`/`_getLegacyGithubCommitStatuses`/`_unwrapGithubCheckRuns` helpers, mirroring the existing GitLab `_normalizeGitLabCommitStatus` pattern already in this file.
- Added 7 unit tests: native-only, legacy-only merge, dedup when both sources report the same check, sha-missing guard, and non-throwing behavior when either source fails.

All 43 tests in `js/unit-tests/run_githubHelpers.json` pass, plus the full 643-test suite (`run_all.json`).

No project-specific content — generic SCM abstraction fix, verified live against a real GitHub PR with a Jenkins-reported failed commit status.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>