### PR TITLE
feat(git): pluggable branchCreateFnPath/branchSyncFnPath hooks for two-branch mode

### DIFF
--- a/js/checkoutBranch.js
+++ b/js/checkoutBranch.js
@@ -4,6 +4,13 @@
  * Branch name format: ai/<TICKET-KEY>
  * If the branch already exists (locally or remotely), it is checked out directly.
  * postAction (developTicketAndCreatePR) then just commits and pushes the current branch.
+ *
+ * Two-branch mode (config.git.featureBranch.enabled): when the "feature" branch doesn't
+ * exist yet remotely, customParams.branchCreateFnPath can point to a JS file (module.exports
+ * = function(ctx)) that creates it by some project-specific mechanism instead of a plain
+ * `git push -u origin` — e.g. a repo whose branch-protection rules block direct pushes for
+ * that branch pattern and require going through an external CI job. See loadHookFn() in
+ * configLoader.js for the loading contract. When not configured, behavior is unchanged.
  */
 
 const { GIT_CONFIG } = require('./config.js');
@@ -31,6 +38,7 @@ function cleanCommandOutput(output) {
 function action(params) {
     try {
         var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var customParams = (params.jobParams && params.jobParams.customParams) || params.customParams || {};
         var ticketKey = params.ticket.key;
         var branchName = configLoader.resolveBranchName(config, params.ticket, 'development');
 
@@ -66,11 +74,30 @@ function action(params) {
                 featureRemote = cleanCommandOutput(cli_execute_command({ command: 'git ls-remote --heads origin ' + featureBranchName }) || '');
             } catch (e) {}
             if (!featureLocal.trim() && !featureRemote.trim()) {
-                console.log('Two-branch mode: creating feature branch from', config.git.baseBranch + ':', featureBranchName);
-                cli_execute_command({ command: 'git checkout ' + config.git.baseBranch });
-                cli_execute_command({ command: 'git pull origin ' + config.git.baseBranch });
-                cli_execute_command({ command: 'git checkout -b ' + featureBranchName });
-                cli_execute_command({ command: 'git push -u origin ' + featureBranchName });
+                var branchCreateFn = customParams.branchCreateFnPath
+                    ? configLoader.loadHookFn(customParams.branchCreateFnPath, 'branchCreateFnPath')
+                    : null;
+                if (branchCreateFn) {
+                    console.log('Two-branch mode: delegating feature branch creation to', customParams.branchCreateFnPath, '→', featureBranchName);
+                    branchCreateFn({
+                        branchName: featureBranchName,
+                        baseBranch: config.git.baseBranch,
+                        workingDir: config.workingDir,
+                        ticket: params.ticket,
+                        config: config
+                    });
+                    // The hook is responsible for making featureBranchName exist on origin
+                    // (e.g. via an external CI job) — fetch it and check it out like any
+                    // other pre-existing remote branch.
+                    cli_execute_command({ command: prHelper.buildOriginFetchCommand() });
+                    cli_execute_command({ command: 'git checkout -b ' + featureBranchName + ' origin/' + featureBranchName });
+                } else {
+                    console.log('Two-branch mode: creating feature branch from', config.git.baseBranch + ':', featureBranchName);
+                    cli_execute_command({ command: 'git checkout ' + config.git.baseBranch });
+                    cli_execute_command({ command: 'git pull origin ' + config.git.baseBranch });
+                    cli_execute_command({ command: 'git checkout -b ' + featureBranchName });
+                    cli_execute_command({ command: 'git push -u origin ' + featureBranchName });
+                }
             } else if (featureRemote.trim() && !featureLocal.trim()) {
                 cli_execute_command({ command: 'git checkout -b ' + featureBranchName + ' origin/' + featureBranchName });
             } else {
@@ -122,4 +149,11 @@ function action(params) {
         console.error('Error in checkoutBranch:', error);
         // Non-fatal: log but do not block CLI execution
     }
+}
+
+// Guarded export — dmtools invokes the top-level `action` global directly as a
+// preCliJSAction, but exposing it via module.exports also lets unit tests load this file
+// in isolation (see js/unit-tests/test_checkoutBranch.js).
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
 }

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -256,6 +256,28 @@ function loadConfigFile(path) {
 }
 
 /**
+ * Loads a project-supplied "hook" JS file (same GraalJS-safe loader as branchNamingFnPath)
+ * whose module.exports must be a function. Used for extension points such as
+ * customParams.branchCreateFnPath / branchSyncFnPath, where a project can plug in custom
+ * branch-creation/sync logic (e.g. delegating to an external CI job) without that logic
+ * living in this generic repo. Returns null (with a console.warn) if the path isn't set,
+ * the file can't be loaded, or it doesn't export a function.
+ *
+ * @param {string} path     - customParams.<x>FnPath value
+ * @param {string} hookName - label used in warning messages, e.g. "branchCreateFnPath"
+ * @returns {Function|null}
+ */
+function loadHookFn(path, hookName) {
+    if (!path) return null;
+    var fn = loadConfigFile(path);
+    if (typeof fn !== 'function') {
+        console.warn('configLoader: ' + hookName + ' "' + path + '" did not export a function — ignoring');
+        return null;
+    }
+    return fn;
+}
+
+/**
  * Load project configuration with discovery and merging.
  *
  * Discovery order:
@@ -620,5 +642,7 @@ module.exports = {
     resolvePRTargetBranch: resolvePRTargetBranch,
     resolveConfluenceUrls: resolveConfluenceUrls,
     resolveInstructions: resolveInstructions,
+    loadConfigFile: loadConfigFile,
+    loadHookFn: loadHookFn,
     createScm: _scmModule ? _scmModule.createScm : function() { throw new Error('scm.js not available in this environment'); }
 };

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -15,6 +15,45 @@ const fetchParentContextToInput = require('./fetchParentContextToInput.js');
 var restoreFromReleases = require('./restoreFromReleases.js');
 var setupCommands = require('./common/setupCommands.js');
 
+/**
+ * Optionally syncs the PR's base branch with its own upstream (config.git.baseBranch)
+ * before merge-conflict detection runs. Relevant in two-branch mode, where the PR's base is
+ * a long-lived branch (e.g. "release/rc_*") that can drift stale relative to
+ * config.git.baseBranch over time. Delegates to a project-specific hook
+ * (customParams.branchSyncFnPath) because syncing may require bypassing branch-protection
+ * rules that block direct pushes to that branch — same rationale as
+ * customParams.branchCreateFnPath in checkoutBranch.js.
+ *
+ * No-op when branchSyncFnPath isn't configured, or when the PR's base already IS
+ * config.git.baseBranch (nothing to sync). Failures are logged and swallowed — the sync is
+ * a best-effort freshness step, not a hard prerequisite for the rest of the rework flow.
+ *
+ * @param {string} baseBranch    - the PR's base branch (prDetails.base.ref)
+ * @param {Object} customParams  - agent customParams (may contain branchSyncFnPath)
+ * @param {Object} config        - resolved project config (config.git.baseBranch, workingDir)
+ */
+function syncBaseBranchIfConfigured(baseBranch, customParams, config) {
+    if (!customParams.branchSyncFnPath || !baseBranch || baseBranch === config.git.baseBranch) {
+        return;
+    }
+    var branchSyncFn = configLoader.loadHookFn(customParams.branchSyncFnPath, 'branchSyncFnPath');
+    if (!branchSyncFn) {
+        return;
+    }
+    try {
+        console.log('Syncing base branch', baseBranch, 'via', customParams.branchSyncFnPath);
+        branchSyncFn({
+            branchName: baseBranch,
+            targetBranch: config.git.baseBranch,
+            workingDir: config.workingDir,
+            config: config
+        });
+        cli_execute_command({ command: gh.buildOriginFetchCommand() });
+    } catch (e) {
+        console.warn('branchSyncFnPath failed (non-fatal):', e && e.toString ? e.toString() : String(e));
+    }
+}
+
 function failSetup(ticketKey, inputFolder, message) {
     try {
         file_write({
@@ -98,6 +137,10 @@ function action(params) {
 
         // Step 5: Diff + discussions (human-readable + raw with IDs)
         const baseBranch = prDetails.base ? prDetails.base.ref : config.git.baseBranch;
+
+        // Step 4.4: Optionally sync the PR's base branch with its own upstream — see
+        // syncBaseBranchIfConfigured() docblock for the rationale.
+        syncBaseBranchIfConfigured(baseBranch, customParams, config);
 
         // Step 4.5: Merge base branch and detect conflicts
         // Always merges origin/{baseBranch} so the branch stays up to date.
@@ -187,5 +230,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action };
+    module.exports = { action, syncBaseBranchIfConfigured };
 }

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -64,7 +64,9 @@
         "js/unit-tests/test_cacheToReleases.js",
         "js/unit-tests/test_restoreFromReleases.js",
         "js/unit-tests/test_resolveRepoFromTicket.js",
-        "js/unit-tests/test_preCliDevelopmentSetupDynamicRepo.js"
+        "js/unit-tests/test_preCliDevelopmentSetupDynamicRepo.js",
+        "js/unit-tests/test_checkoutBranch.js",
+        "js/unit-tests/test_preCliReworkSetup.js"
       ]
     }
   }

--- a/js/unit-tests/run_checkoutBranch.json
+++ b/js/unit-tests/run_checkoutBranch.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_checkoutBranch.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/run_preCliReworkSetup.json
+++ b/js/unit-tests/run_preCliReworkSetup.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_preCliReworkSetup.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_checkoutBranch.js
+++ b/js/unit-tests/test_checkoutBranch.js
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for js/checkoutBranch.js
+ *
+ * Focuses on the two-branch mode "feature" branch creation step and its
+ * customParams.branchCreateFnPath extension point — the rest of the file's
+ * plain-branch checkout logic is exercised indirectly through these tests.
+ *
+ * Uses: loadModule(), makeRequire(), assert, test(), suite()
+ */
+
+function makeConfig(overrides) {
+    var base = {
+        git: {
+            baseBranch: 'master',
+            authorName: 'AI Teammate',
+            authorEmail: 'ai@example.com',
+            featureBranch: { enabled: true }
+        },
+        workingDir: null
+    };
+    if (overrides && overrides.git) {
+        base.git = Object.assign({}, base.git, overrides.git);
+        overrides = Object.assign({}, overrides);
+        delete overrides.git;
+    }
+    return Object.assign({}, base, overrides || {});
+}
+
+/**
+ * Builds a configLoader stub with full control over loadProjectConfig/resolveBranchName/
+ * loadHookFn, so tests don't depend on the real configLoader.js or real file_read.
+ */
+function makeConfigLoaderStub(config, branchNameByRole, hookFn, hookLoadCalls) {
+    return {
+        loadProjectConfig: function() { return config; },
+        resolveBranchName: function(cfg, ticket, role) { return branchNameByRole[role]; },
+        loadHookFn: function(path, hookName) {
+            hookLoadCalls.push({ path: path, hookName: hookName });
+            return hookFn || null;
+        }
+    };
+}
+
+var DEFAULT_PR_HELPER_STUB = {
+    buildOriginFetchCommand: function(refSpec) {
+        return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+    }
+};
+
+function loadCheckoutBranch(configLoaderStub, mocks) {
+    return loadModule(
+        'js/checkoutBranch.js',
+        makeRequire({
+            './config.js': { GIT_CONFIG: {} },
+            './configLoader.js': configLoaderStub,
+            './common/pullRequest.js': DEFAULT_PR_HELPER_STUB
+        }),
+        mocks || {}
+    );
+}
+
+/** Builds a cli_execute_command mock that records every call and returns '' unless a
+ *  response is registered for that exact command in `responses`. */
+function makeCliMock(calls, responses) {
+    return function(opts) {
+        var command = opts && opts.command;
+        calls.push(command);
+        if (responses && Object.prototype.hasOwnProperty.call(responses, command)) {
+            return responses[command];
+        }
+        return '';
+    };
+}
+
+var TICKET = { key: 'PROJ-1' };
+
+suite('checkoutBranch — two-branch mode feature branch creation', function() {
+
+    test('falls back to git checkout+push when branchCreateFnPath is not configured', function() {
+        var calls = [];
+        var hookLoadCalls = [];
+        var config = makeConfig();
+        var configLoaderStub = makeConfigLoaderStub(
+            config,
+            { development: 'ai/PROJ-1', feature: 'release/rc_mobile_proj-1' },
+            null,
+            hookLoadCalls
+        );
+        var mod = loadCheckoutBranch(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, {})
+        });
+
+        mod.action({ ticket: TICKET, jobParams: { customParams: {} } });
+
+        assert.equal(hookLoadCalls.length, 0, 'loadHookFn should not be called when branchCreateFnPath is unset');
+        assert.ok(calls.indexOf('git checkout -b release/rc_mobile_proj-1') !== -1, 'creates the feature branch locally');
+        assert.ok(calls.indexOf('git push -u origin release/rc_mobile_proj-1') !== -1, 'pushes the new feature branch directly');
+    });
+
+    test('delegates feature branch creation to branchCreateFnPath and checks out via origin tracking', function() {
+        var calls = [];
+        var hookLoadCalls = [];
+        var hookCallArgs = null;
+        var hookFn = function(ctx) { hookCallArgs = ctx; };
+        var config = makeConfig();
+        var configLoaderStub = makeConfigLoaderStub(
+            config,
+            { development: 'ai/PROJ-1', feature: 'release/rc_mobile_proj-1' },
+            hookFn,
+            hookLoadCalls
+        );
+        // Dev branch already exists locally so the rest of the flow is a no-op simple checkout.
+        var responses = {};
+        responses['git branch --list "ai/PROJ-1"'] = 'ai/PROJ-1';
+        var mod = loadCheckoutBranch(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, responses)
+        });
+
+        mod.action({ ticket: TICKET, jobParams: { customParams: { branchCreateFnPath: '.dmtools/branchNaming/sf_rc_jenkins.js' } } });
+
+        assert.equal(hookLoadCalls.length, 1);
+        assert.equal(hookLoadCalls[0].path, '.dmtools/branchNaming/sf_rc_jenkins.js');
+        assert.equal(hookLoadCalls[0].hookName, 'branchCreateFnPath');
+
+        assert.ok(hookCallArgs, 'branchCreateFn should have been invoked');
+        assert.equal(hookCallArgs.branchName, 'release/rc_mobile_proj-1');
+        assert.equal(hookCallArgs.baseBranch, 'master');
+        assert.equal(hookCallArgs.ticket, TICKET);
+        assert.equal(hookCallArgs.config, config);
+
+        assert.ok(calls.indexOf('git -c fetch.recurseSubmodules=no fetch origin') !== -1, 'fetches origin after the hook runs');
+        assert.ok(calls.indexOf('git checkout -b release/rc_mobile_proj-1 origin/release/rc_mobile_proj-1') !== -1,
+            'checks out the branch created by the hook via origin tracking');
+        assert.equal(calls.indexOf('git push -u origin release/rc_mobile_proj-1'), -1,
+            'must not attempt a direct push when delegating to branchCreateFnPath');
+        assert.equal(calls.indexOf('git checkout -b release/rc_mobile_proj-1'), -1,
+            'must not create a bare local branch when delegating to branchCreateFnPath');
+    });
+
+    test('does not touch the feature branch step when the feature branch already exists', function() {
+        var calls = [];
+        var hookLoadCalls = [];
+        var config = makeConfig();
+        var configLoaderStub = makeConfigLoaderStub(
+            config,
+            { development: 'ai/PROJ-1', feature: 'release/rc_mobile_proj-1' },
+            null,
+            hookLoadCalls
+        );
+        var responses = {};
+        responses['git branch --list "release/rc_mobile_proj-1"'] = 'release/rc_mobile_proj-1';
+        responses['git branch --list "ai/PROJ-1"'] = 'ai/PROJ-1';
+        var mod = loadCheckoutBranch(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, responses)
+        });
+
+        mod.action({ ticket: TICKET, jobParams: { customParams: { branchCreateFnPath: '.dmtools/branchNaming/sf_rc_jenkins.js' } } });
+
+        assert.equal(hookLoadCalls.length, 0, 'branchCreateFnPath is only consulted when the feature branch does not exist yet');
+        assert.equal(calls.indexOf('git push -u origin release/rc_mobile_proj-1'), -1);
+    });
+
+    test('two-branch mode is skipped entirely when config.git.featureBranch.enabled is false', function() {
+        var calls = [];
+        var hookLoadCalls = [];
+        var config = makeConfig({ git: { featureBranch: { enabled: false } } });
+        var configLoaderStub = makeConfigLoaderStub(
+            config,
+            { development: 'ai/PROJ-1' },
+            null,
+            hookLoadCalls
+        );
+        var responses = {};
+        responses['git branch --list "ai/PROJ-1"'] = 'ai/PROJ-1';
+        var mod = loadCheckoutBranch(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, responses)
+        });
+
+        mod.action({ ticket: TICKET, jobParams: { customParams: {} } });
+
+        assert.equal(hookLoadCalls.length, 0);
+        for (var i = 0; i < calls.length; i++) {
+            assert.ok(calls[i].indexOf('release/rc_') === -1, 'no feature-branch commands should run: ' + calls[i]);
+        }
+    });
+
+});

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -776,3 +776,49 @@ suite('configLoader: jira.questions', function() {
     });
 
 });
+
+// ── loadHookFn ─────────────────────────────────────────────────────────────
+
+function makeIsolatedConfigLoaderForHooks(fileMap) {
+    var fr = function(opts) {
+        var p = opts && (opts.path || opts);
+        if (fileMap && fileMap[p] !== undefined) return fileMap[p];
+        // Block all config discovery to prevent loading a real parent .dmtools/config.js
+        if (p && p.indexOf('.dmtools/config') !== -1) return null;
+        return null;
+    };
+    return loadModule('js/configLoader.js', makeRequire({ './config.js': configModule }), { file_read: fr });
+}
+
+suite('configLoader.loadHookFn', function() {
+
+    test('returns null without reading anything when path is falsy', function() {
+        var cl = makeIsolatedConfigLoaderForHooks({});
+        assert.equal(cl.loadHookFn(null, 'branchCreateFnPath'), null);
+        assert.equal(cl.loadHookFn('', 'branchCreateFnPath'), null);
+    });
+
+    test('returns null when the file does not exist', function() {
+        var cl = makeIsolatedConfigLoaderForHooks({});
+        var result = cl.loadHookFn('.dmtools/branchNaming/missing.js', 'branchCreateFnPath');
+        assert.equal(result, null);
+    });
+
+    test('returns null when the file does not export a function', function() {
+        var cl = makeIsolatedConfigLoaderForHooks({
+            '.dmtools/branchNaming/not_a_fn.js': 'module.exports = { foo: 1 };'
+        });
+        var result = cl.loadHookFn('.dmtools/branchNaming/not_a_fn.js', 'branchCreateFnPath');
+        assert.equal(result, null);
+    });
+
+    test('returns the exported function and it is callable', function() {
+        var cl = makeIsolatedConfigLoaderForHooks({
+            '.dmtools/branchNaming/create.js': 'module.exports = function(ctx) { return "created:" + ctx.branchName; };'
+        });
+        var fn = cl.loadHookFn('.dmtools/branchNaming/create.js', 'branchCreateFnPath');
+        assert.equal(typeof fn, 'function');
+        assert.equal(fn({ branchName: 'release/rc_mobile_proj-1' }), 'created:release/rc_mobile_proj-1');
+    });
+
+});

--- a/js/unit-tests/test_preCliReworkSetup.js
+++ b/js/unit-tests/test_preCliReworkSetup.js
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for js/preCliReworkSetup.js
+ *
+ * Scope: syncBaseBranchIfConfigured() — the customParams.branchSyncFnPath extension point
+ * used to keep a two-branch-mode PR base (e.g. "release/rc_*") from drifting stale relative
+ * to config.git.baseBranch before merge-conflict detection runs. The rest of action()'s flow
+ * (PR lookup, branch checkout, discussions/diff writing, Jira comment) is unit-tested
+ * elsewhere/indirectly and isn't re-verified here.
+ *
+ * Uses: loadModule(), makeRequire(), assert, test(), suite()
+ */
+
+var NOOP_MODULE = {};
+
+function makeGhStub(fetchCalls) {
+    return {
+        buildOriginFetchCommand: function() {
+            return 'git -c fetch.recurseSubmodules=no fetch origin';
+        },
+        // Unused by syncBaseBranchIfConfigured but required by the module's top-level require().
+        _isScm: function() { return false; },
+        findPRForTicket: function() {},
+        getPRDetails: function() {},
+        fetchDiscussionsAndRawData: function() {},
+        detectFailedChecks: function() {},
+        cleanCommandOutput: function(s) { return s; }
+    };
+}
+
+function loadPreCliReworkSetup(configLoaderStub, mocks) {
+    return loadModule(
+        'js/preCliReworkSetup.js',
+        makeRequire({
+            './configLoader.js': configLoaderStub,
+            './common/githubHelpers.js': mocks.__ghStub,
+            './common/gitOps.js': NOOP_MODULE,
+            './fetchQuestionsToInput.js': NOOP_MODULE,
+            './fetchParentContextToInput.js': NOOP_MODULE,
+            './restoreFromReleases.js': NOOP_MODULE,
+            './common/setupCommands.js': NOOP_MODULE
+        }),
+        mocks || {}
+    );
+}
+
+function makeConfig(overrides) {
+    var base = { git: { baseBranch: 'master' }, workingDir: 'dependencies/proj' };
+    return Object.assign({}, base, overrides || {});
+}
+
+function makeConfigLoaderStub(hookFn, hookLoadCalls) {
+    return {
+        loadHookFn: function(path, hookName) {
+            hookLoadCalls.push({ path: path, hookName: hookName });
+            return hookFn || null;
+        }
+    };
+}
+
+suite('preCliReworkSetup.syncBaseBranchIfConfigured', function() {
+
+    test('is a no-op when branchSyncFnPath is not configured', function() {
+        var hookLoadCalls = [];
+        var cliCalls = [];
+        var ghStub = makeGhStub();
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(null, hookLoadCalls), {
+            __ghStub: ghStub,
+            cli_execute_command: function(opts) { cliCalls.push(opts.command); return ''; }
+        });
+
+        mod.syncBaseBranchIfConfigured('release/rc_mobile_proj-1', {}, makeConfig());
+
+        assert.equal(hookLoadCalls.length, 0);
+        assert.equal(cliCalls.length, 0);
+    });
+
+    test('is a no-op when the PR base already equals config.git.baseBranch', function() {
+        var hookLoadCalls = [];
+        var cliCalls = [];
+        var ghStub = makeGhStub();
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(null, hookLoadCalls), {
+            __ghStub: ghStub,
+            cli_execute_command: function(opts) { cliCalls.push(opts.command); return ''; }
+        });
+
+        mod.syncBaseBranchIfConfigured('master', { branchSyncFnPath: '.dmtools/branchNaming/sf_rc_jenkins.js' }, makeConfig());
+
+        assert.equal(hookLoadCalls.length, 0, 'should not even look up the hook when there is nothing to sync');
+        assert.equal(cliCalls.length, 0);
+    });
+
+    test('is a no-op when baseBranch is falsy', function() {
+        var hookLoadCalls = [];
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(null, hookLoadCalls), {
+            __ghStub: makeGhStub(),
+            cli_execute_command: function() { return ''; }
+        });
+
+        mod.syncBaseBranchIfConfigured(null, { branchSyncFnPath: 'x.js' }, makeConfig());
+
+        assert.equal(hookLoadCalls.length, 0);
+    });
+
+    test('invokes the configured hook with the right context and fetches origin afterwards', function() {
+        var hookLoadCalls = [];
+        var hookCallArgs = null;
+        var cliCalls = [];
+        var hookFn = function(ctx) { hookCallArgs = ctx; };
+        var config = makeConfig();
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(hookFn, hookLoadCalls), {
+            __ghStub: makeGhStub(),
+            cli_execute_command: function(opts) { cliCalls.push(opts.command); return ''; }
+        });
+
+        mod.syncBaseBranchIfConfigured('release/rc_mobile_proj-1', { branchSyncFnPath: '.dmtools/branchNaming/sf_rc_jenkins.js' }, config);
+
+        assert.equal(hookLoadCalls.length, 1);
+        assert.equal(hookLoadCalls[0].path, '.dmtools/branchNaming/sf_rc_jenkins.js');
+        assert.equal(hookLoadCalls[0].hookName, 'branchSyncFnPath');
+
+        assert.ok(hookCallArgs, 'branchSyncFn should have been invoked');
+        assert.equal(hookCallArgs.branchName, 'release/rc_mobile_proj-1');
+        assert.equal(hookCallArgs.targetBranch, 'master');
+        assert.equal(hookCallArgs.workingDir, 'dependencies/proj');
+        assert.equal(hookCallArgs.config, config);
+
+        assert.ok(cliCalls.indexOf('git -c fetch.recurseSubmodules=no fetch origin') !== -1,
+            'fetches origin after the hook runs so the local repo sees the synced branch');
+    });
+
+    test('swallows errors thrown by the hook and does not fetch afterwards', function() {
+        var hookLoadCalls = [];
+        var cliCalls = [];
+        var hookFn = function() { throw new Error('Jenkins job failed'); };
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(hookFn, hookLoadCalls), {
+            __ghStub: makeGhStub(),
+            cli_execute_command: function(opts) { cliCalls.push(opts.command); return ''; }
+        });
+
+        // Should not throw.
+        mod.syncBaseBranchIfConfigured('release/rc_mobile_proj-1', { branchSyncFnPath: 'x.js' }, makeConfig());
+
+        assert.equal(cliCalls.length, 0, 'should not fetch origin when the hook itself failed');
+    });
+
+    test('is a no-op when the hook path does not export a function', function() {
+        var hookLoadCalls = [];
+        var cliCalls = [];
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(null, hookLoadCalls), {
+            __ghStub: makeGhStub(),
+            cli_execute_command: function(opts) { cliCalls.push(opts.command); return ''; }
+        });
+
+        mod.syncBaseBranchIfConfigured('release/rc_mobile_proj-1', { branchSyncFnPath: 'x.js' }, makeConfig());
+
+        assert.equal(hookLoadCalls.length, 1, 'loadHookFn is still consulted');
+        assert.equal(cliCalls.length, 0, 'nothing runs when loadHookFn returns null');
+    });
+
+});


### PR DESCRIPTION
Some repos protect long-lived branches (e.g. a `release/rc_*` pattern used as a two-branch-mode PR base) with rules that reject a direct `git push`, even with a normal PAT/token — only a privileged external CI job is allowed to create/update them. `checkoutBranch.js`'s two-branch mode previously always did `git checkout -b ... && git push -u origin ...` for a brand new feature branch, which would simply fail on such repos.

- `configLoader.js`: add `loadHookFn(path, hookName)` — a thin wrapper around the existing `loadConfigFile()` GraalJS-safe loader (already used for `branchNamingFnPath`) that also validates the export is a function and warns otherwise. Exported `loadConfigFile`/`loadHookFn` for reuse.
- `checkoutBranch.js`: when the feature branch doesn't exist yet and `customParams.branchCreateFnPath` is configured, delegate branch creation to that function instead of the direct push, then fetch + checkout the branch via origin tracking (the hook is responsible for making it exist remotely, however it needs to). Falls back to today's behavior when not configured — no change for any other consumer.
- `preCliReworkSetup.js`: extracted `syncBaseBranchIfConfigured()`, called before merge-conflict detection. When `customParams.branchSyncFnPath` is configured and the PR's base branch differs from `config.git.baseBranch` (i.e. a two-branch-mode base like `release/rc_*`), delegates syncing that base branch with `config.git.baseBranch` to the hook, then fetches origin. No-op otherwise.

Both hooks are opt-in via `customParams` and receive a plain `ctx` object (`branchName`/`targetBranch`/`baseBranch`, `workingDir`, `ticket`, `config`) — **no project-specific logic lives here**; the actual sync/create mechanism (e.g. triggering a Jenkins job) is supplied entirely by the consuming project via `customParams.branchCreateFnPath`/`branchSyncFnPath`.

Added 14 unit tests (4 for `checkoutBranch.js`, 6 for `syncBaseBranchIfConfigured`, 4 for `configLoader.loadHookFn`) plus a guarded `module.exports` on `checkoutBranch.js` so it can be loaded standalone by tests. All 657 tests in `run_all.json` pass, no regressions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>