### PR TITLE
Fix stale outputs/response.md leaking across ticket runs in run-teammate-local.sh

### DIFF
--- a/scripts/run-teammate-local.sh
+++ b/scripts/run-teammate-local.sh
@@ -224,6 +224,23 @@ if [ -n "${INSTALL_TOOLS}" ]; then
   bash "${SCRIPT_DIR}/../setup/install.sh" ${INSTALL_TOOLS}
 fi
 
+# ── Clear stale scratch artifacts from any previous ticket's run ────────────
+# This checkout is reused across tickets (no worktrees — see module docstring),
+# and the CLI agent + js/*.js actions read/write outputs/ (response.md,
+# diagram.md, questions.json, *_usage.json) and input/ at fixed, ticket-agnostic
+# paths (js/common/outputFiles.js checks outputs/<name> before outputs/<ticket>/
+# <name>). If this ticket's CLI run fails to (re)write a fresh outputs/response.md
+# — e.g. it crashes, times out, or is otherwise interrupted — postJSAction hooks
+# such as developTicketAndCreatePR.js's "no git changes" branch and
+# writeSolutionAndDiagrams.js treat ANY non-empty outputs/response.md as proof
+# the agent "completed successfully", so a leftover file from a PREVIOUS ticket
+# gets silently posted onto THIS ticket's Jira fields/comments — wrong content
+# reported as a false success. Removing outputs/ and input/ before every ticket
+# guarantees a failed/interrupted run leaves them empty (correctly triggering the
+# "interrupted, retry" path) instead of stale (incorrectly triggering "success").
+echo "🧹 Clearing outputs/ and input/ scratch dirs from any previous ticket run..."
+rm -rf outputs input
+
 # ── Run the agent via dmtools (same entrypoint ai-teammate.yml uses) ────────
 mkdir -p .dmtools
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"


### PR DESCRIPTION
## Problem
`run-teammate-local.sh` reuses a single checkout across every ticket (no worktrees, by design). It never cleared the `outputs/` and `input/` scratch directories used by the CLI agent and `js/*.js` post-actions for prompt/response file exchange. `js/common/outputFiles.js`'s `readOutputFile()` checks the unscoped `outputs/response.md` path *before* the ticket-scoped `outputs/<ticket>/response.md` path.

## Confirmed in production
SOHO-135's `story_development` run wrote `outputs/response.md` describing its real EventBookingSummaryScreen work. That file was never cleaned up afterward. When `story_acceptance_criteria`, `story_solution`, and `story_development` later ran for two unrelated sibling tickets (SOHO-131, SOHO-133) and their CLI runs produced no git diff, `developTicketAndCreatePR.js`'s "no git changes" branch and `writeSolutionAndDiagrams.js` both treated the stale non-empty `response.md` as proof the agent "completed successfully", copying SOHO-135's analysis verbatim into SOHO-131/SOHO-133's Acceptance Criteria, Solution fields, and a "No Code Changes Needed" Jira comment — a false success driven by leftover state, not a real result.

## Fix
Remove `outputs/` and `input/` at the start of every ticket run, right before invoking dmtools. An interrupted/failed CLI run now correctly leaves them empty (triggering the existing "interrupted, retry" handling in `developTicketAndCreatePR.js`) instead of stale (triggering a false "success" with wrong content).

## Verification
- `bash -n scripts/run-teammate-local.sh` — syntax OK
- Isolated manual test confirming `rm -rf outputs input` clears prior scratch content as expected
- No existing test infra covers this bash script directly (only `js/unit-tests/test_smAgent.js` asserts smAgent.js invokes it, unaffected by this change)

## Related
A second, engine-level contributing bug also exists in `epam/dm.ai`'s `Teammate.java`: when `requireCliOutputFile=true" and the CLI fails, the engine correctly detects `skipFieldUpdate=true" and posts an error comment, but `postJSAction" still runs unconditionally beforehand — letting hooks like `closeQuestionTicket.js` blindly mark a ticket Done despite the failure. Filing separately upstream.