### PR TITLE
Whitelist gradlew for story_development/pr_rework quality gates

### DIFF
--- a/pr_rework.json
+++ b/pr_rework.json
@@ -14,7 +14,7 @@
     "skipAIProcessing": true,
     "alwaysPostComments": true,
     "envVariables": {
-      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh"
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh,gradlew"
     },
     "timerJSAction": "agents/js/timerAutoCommitAndSave.js",
     "timerIntervalSeconds": 300,

--- a/story_development.json
+++ b/story_development.json
@@ -13,7 +13,7 @@
     "skipAIProcessing": true,
     "alwaysPostComments": true,
     "envVariables": {
-      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh"
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh,gradlew"
     },
     "timerJSAction": "agents/js/timerAutoCommitAndSave.js",
     "timerIntervalSeconds": 300,


### PR DESCRIPTION
## Problem
Android/Gradle projects' `.dmtools/config.js` `qualityGates` (detekt/lint/unit-test) run `./gradlew ...` directly via `feedbackLoop.runQualityGates()` -> `cli_execute_command()`. `CliCommandExecutor`'s whitelist is base-whitelist + `CLI_ALLOWED_COMMANDS`, and `gradlew` was never included in `story_development.json`/`pr_rework.json`'s `CLI_ALLOWED_COMMANDS`, so every quality gate invocation was rejected with `SecurityException: Command not allowed`.

Observed live on `EPAM-DarkFactory/SH_ANDR_WIP`: SOHO-131's `story_development` `quality_gate_detekt` step failed immediately on the whitelist check, exhausted retry attempts, and correctly reset the ticket for retry (no false success this time) -- but the gate can never pass until `gradlew` is whitelisted.

## Fix
Add `gradlew` to `CLI_ALLOWED_COMMANDS` in both `story_development.json` and `pr_rework.json` (identical quality-gate mechanism via `pushReworkChanges.js`). `CliCommandExecutor.isCommandWhitelisted()` matches on the executable's basename after stripping `./`, so `./gradlew detekt -PBUILD_ENV=staging` etc. will now be permitted regardless of arguments.

## Verification
- Both JSON files remain valid JSON.
- Full `js/unit-tests/run_all.json` suite passes: 657/657.
