### PR TITLE
Fix smAgent re-adding trigger label after self-clearing local runs

### DIFF
--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -429,6 +429,25 @@ function addRuleLabels(ticketKey, rule) {
     });
 }
 
+// True when the rule's own target config (e.g. pr_review.json, pr_rework.json,
+// bug_development.json) already removes this exact addLabel itself via
+// customParams.removeLabel/removeLabels — i.e. the job manages the label's full
+// lifecycle (add is implied by dispatch, remove happens on its own completion) and
+// smAgent must not re-add it afterward. See processRule()'s localTeammate handling.
+function ruleTargetSelfManagesLabel(rule) {
+    var addLabels = normalizeLabels(rule.addLabel, rule.addLabels);
+    if (!addLabels.length || !rule.configFile) return false;
+    try {
+        var raw = file_read({ path: rule.configFile });
+        var targetConfig = JSON.parse(raw);
+        var customParams = (targetConfig.params && targetConfig.params.customParams) || {};
+        var removeLabels = normalizeLabels(customParams.removeLabel, customParams.removeLabels);
+        return addLabels.some(function(label) { return removeLabels.indexOf(label) !== -1; });
+    } catch (e) {
+        return false;
+    }
+}
+
 function removeRuleLabel(ticketKey, label) {
     if (!ticketKey || !label) return;
     try {
@@ -645,6 +664,14 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         return { processedKeys: [], skippedKeys: [] };
     }
 
+    // Computed once per rule (not per ticket) — see ruleTargetSelfManagesLabel() and its
+    // use in the localTeammate branch below.
+    var ruleSelfManagesLabel = rule.localTeammate && ruleTargetSelfManagesLabel(rule);
+    if (ruleSelfManagesLabel) {
+        console.log('  ℹ️  Target job self-manages "' + (rule.addLabel || rule.addLabels) +
+            '" — smAgent will not re-add it after a local run');
+    }
+
     var ruleLimit = (typeof rule.limit === 'number' && rule.limit > 0) ? Math.floor(rule.limit) : null;
     var effectiveLimit = ruleLimit;
     if (workflowBudget && !rule.localTeammate) {
@@ -707,11 +734,19 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
             moveStatus(key, rule.targetStatus);
         }
 
+        // localTeammate runs the *entire* job (checkout, AI CLI, postJSAction) synchronously
+        // before returning here — unlike the async workflow_dispatch path, there is no in-flight
+        // gap left to guard once it returns. Jobs whose own customParams already
+        // remove/removeLabels this exact addLabel (pr_review, pr_rework, bug_development, ...)
+        // are trusted to manage it themselves — e.g. clearing it on completion so the next
+        // review<->rework cycle can re-trigger. Re-adding it here afterward would immediately
+        // stomp on that cleanup and permanently stick the ticket, since local rules have no
+        // stale-label recovery. Only add it when the target job does *not* already self-manage it.
         var triggered = rule.localTeammate
             ? runTeammateLocally(key, rule, effectiveConfig)
             : triggerWorkflow(effectiveRepoInfo, key, rule, effectiveConfig, workflowBudget);
 
-        if (triggered) addRuleLabels(key, rule);
+        if (triggered && !ruleSelfManagesLabel) addRuleLabels(key, rule);
 
         if (triggered) {
             processedKeys.push(key);

--- a/js/unit-tests/test_smAgent.js
+++ b/js/unit-tests/test_smAgent.js
@@ -759,6 +759,79 @@ suite('smAgent: localTeammate execution mode', function() {
         assert.equal(sm.capturedLabels.length, 0, 'no label added when the local run fails');
     });
 
+    // Regression test for a real production bug: pr_review.json/pr_rework.json's own
+    // postJSAction removes its addLabel (sm_story_review_triggered / sm_story_rework_triggered)
+    // as part of completing, to let a ticket cycle between In Review <-> In Rework. Since
+    // runTeammateLocally() runs that entire job synchronously, re-adding the label afterward
+    // would immediately undo that cleanup and permanently stick the ticket (no stale-label
+    // recovery exists for local rules) — this is exactly what happened to SOHO-131.
+    test('does not re-add the label after a local run when the target job self-manages it', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };',
+                'agents/pr_review.json': JSON.stringify({
+                    params: { customParams: { removeLabel: 'sm_story_review_triggered' } }
+                })
+            },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/pr_review.json',
+                localTeammate: true,
+                addLabel: 'sm_story_review_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 0,
+            'smAgent must not re-add a label the target job manages/removes itself');
+    });
+
+    test('does not re-add any addLabels when the target job self-manages one of them via removeLabels', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };',
+                'agents/pr_rework.json': JSON.stringify({
+                    params: { customParams: { removeLabels: ['sm_story_rework_triggered', 'sm_story_review_triggered'] } }
+                })
+            },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/pr_rework.json',
+                localTeammate: true,
+                addLabel: 'sm_story_rework_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 0,
+            'smAgent must not re-add sm_story_rework_triggered either, since pr_rework.json manages it');
+    });
+
+    test('still adds the label for a non-self-managing local rule (unaffected by the self-managing check)', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };',
+                'agents/story_solution.json': JSON.stringify({ params: { customParams: {} } })
+            },
+            tickets: [{ key: 'P-1', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = {jiraProject}", {
+                configFile: 'agents/story_solution.json',
+                localTeammate: true,
+                addLabel: 'sm_story_solution_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 1, 'label is still added when the target job does not self-manage it');
+        assert.equal(sm.capturedLabels[0].label, 'sm_story_solution_triggered');
+    });
+
     test('respects skipIfLabel without checking GitHub Actions run state', function() {
         var sm = makeSmAgent({
             fileMap: { '../.dmtools/config.js': 'module.exports = { jira: { project: "P" }, repository: { owner: "o", repo: "r" } };' },
@@ -1096,6 +1169,32 @@ suite('smAgent: skipIfLabel', function() {
         assert.equal(sm.capturedLabels.length, 2);
         assert.equal(sm.capturedLabels[0].label, 'primary_label');
         assert.equal(sm.capturedLabels[1].label, 'secondary_label');
+    });
+
+    // The self-managing skip only applies to localTeammate (synchronous) rules — for the
+    // async workflow_dispatch path the label really is the only in-flight guard (the actual
+    // job runs later on a GitHub Actions runner and clears it on completion), so it must
+    // still be added right after a successful dispatch even if the target config also
+    // happens to declare a matching removeLabel.
+    test('still adds the label after an async dispatch even if the target config declares a matching removeLabel', function() {
+        var sm = makeSmAgent({
+            fileMap: {
+                'agents/pr_review.json': JSON.stringify({
+                    params: { customParams: { removeLabel: 'sm_story_review_triggered' } }
+                })
+            },
+            tickets: [{ key: 'T-21', fields: { labels: [] } }]
+        });
+
+        sm.action(baseParams('o', 'r', [
+            makeRule("project = X", {
+                configFile: 'agents/pr_review.json',
+                addLabel: 'sm_story_review_triggered'
+            })
+        ]));
+
+        assert.equal(sm.capturedLabels.length, 1,
+            'async dispatch must still add its idempotency label regardless of the self-managing check');
     });
 
 });


### PR DESCRIPTION
## Bug

`runTeammateLocally()` runs the entire job (checkout, AI CLI, postJSAction) synchronously in-process. `processRule()` then unconditionally called `addRuleLabels()` right after, which **re-added** the rule's `addLabel` even when the target job's own `postJSAction` had just *removed* that exact label as part of completing (e.g. `pr_review.json`/`pr_rework.json` clearing `sm_story_review_triggered`/`sm_story_rework_triggered` to allow a ticket to keep cycling between In Review <-> In Rework).

Since local rules have no stale-label recovery (that mechanism only exists for the async GitHub Actions dispatch path), this permanently stuck any ticket that went through a local `pr_review`/`pr_rework` run. Observed live on SOHO-131: it ended up with **both** `sm_story_review_triggered` and `sm_story_rework_triggered` labels simultaneously, which made both the "trigger pr_review" and "trigger pr_rework" rules skip it forever.

## Fix

Added `ruleTargetSelfManagesLabel(rule)` — reads the rule's target `configFile` and checks whether `customParams.removeLabel`/`removeLabels` already includes the rule's own `addLabel`/`addLabels`. When true (job self-manages the label's lifecycle) and the rule runs via `localTeammate`, `processRule()` skips the redundant re-add, trusting the job's own cleanup. The async `workflow_dispatch` path is untouched — there, the label is the only in-flight guard until the real job finishes later on a GitHub Actions runner.

## Testing
- Added 4 new unit tests in `test_smAgent.js` covering: self-managing label skip (single `removeLabel` and `removeLabels`), non-self-managing rules unaffected, and async dispatch unaffected.
- `js/unit-tests/run_smAgent.json`: 74/74 passed (was 70/70).
- `js/unit-tests/run_all.json` (full suite): 665/665 passed.
