### PR TITLE
Fix run-agent.sh resume self-invocations rejecting --continue + --resume

### DIFF
--- a/js/aiTeammateTokenUsageReporter.js
+++ b/js/aiTeammateTokenUsageReporter.js
@@ -83,7 +83,11 @@ function extractTokenUsage(logs) {
             resumeDetected = true;
             feedbackLoopCount += 1;
             resumeStages.push((resumeMatch[1] || 'resume') + ' ' + resumeMatch[2] + '/' + resumeMatch[3]);
-        } else if (line.indexOf('--resume') !== -1 || line.indexOf('--continue --resume') !== -1) {
+        } else if (line.indexOf('--resume') !== -1 || line.indexOf('run-agent.sh --continue') !== -1) {
+            // 'run-agent.sh --continue' (without '--resume') is the recovery command shape
+            // used since --continue and --resume were found to be mutually exclusive in the
+            // Copilot CLI; kept alongside the older '--continue --resume' shape (still
+            // matched via the '--resume' check above) so historical logs still parse.
             resumeDetected = true;
         }
         if (/Copilot rate limit detected; retrying/i.test(line)) {

--- a/js/common/feedbackLoop.js
+++ b/js/common/feedbackLoop.js
@@ -128,7 +128,13 @@ function resumeAgent(options) {
     var promptPath = 'outputs/feedback/' + key + '.md';
     writeFile(promptPath, prompt);
 
-    var resumeArgs = config.resumeArgs || '--continue --resume';
+    // Copilot CLI's `--continue` already means "resume the most recent session in this
+    // directory" (no value needed); its own `-r, --resume[=value]` flag is a second,
+    // mutually exclusive way to resume (by explicit id or an interactive picker when bare).
+    // Passing both together is rejected outright: "error: option '-r, --resume[=value]'
+    // cannot be used with option '--continue'" — which made every feedback-loop retry fail
+    // deterministically before the agent ever got a chance to act on the new prompt.
+    var resumeArgs = config.resumeArgs || '--continue';
     var command = 'bash agents/scripts/run-agent.sh ' + resumeArgs + ' ' + promptPath;
     console.log('Feedback loop: resuming agent for ' + (options.stage || 'failure') + ' attempt ' + attempt + '/' + maxAttempts);
     runCommand(command);

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -504,7 +504,7 @@ function resetDevelopmentForRetry(ticketKey, statuses, customParams, metadata, s
 }
 
 function resumeDevelopmentAgent(params, ticketKey, customParams, stage, errorMessage) {
-    // feedbackLoop.resumeAgent() itself shells out (mkdir/bash/run-agent.sh --continue --resume).
+    // feedbackLoop.resumeAgent() itself shells out (mkdir/bash/run-agent.sh --continue).
     // If that self-invocation is ever blocked (e.g. a misconfigured CLI_ALLOWED_COMMANDS
     // whitelist) or fails for any other unexpected reason, it can throw instead of returning
     // { attempted: false }. Every call site below treats a falsy return as "could not resume"

--- a/js/postMobileTestAutomationResults.js
+++ b/js/postMobileTestAutomationResults.js
@@ -6,7 +6,7 @@
  * labels and updates the feature PR, and posts results to Jira.
  *
  * Steps:
- * 1. If mandatory output files are missing, attempt one resume run via run-agent.sh --continue --resume
+ * 1. If mandatory output files are missing, attempt one resume run via run-agent.sh --continue
  * 2. Read outputs/test_automation_result.json
  * 3. Commit + push test files in the automation repo (src/tests/)
  * 4. Create or find PR in the test automation repository
@@ -66,7 +66,7 @@ function createScmCompat(config, owner, repo) {
 
 /**
  * If mandatory output files are missing and a resume has not already been attempted,
- * run `run-agent.sh --continue --resume` with a targeted recovery prompt so the agent
+ * run `run-agent.sh --continue` with a targeted recovery prompt so the agent
  * writes outputs/test_automation_result.json, outputs/response.md, outputs/pr_body.md,
  * and outputs/pr_feature_update.md without rewriting the already-committed flows.
  *
@@ -132,7 +132,11 @@ function attemptResumeIfOutputsMissing(ticketKey, workingDir) {
 
     try {
         var resumeResult = cli_execute_command({
-            command: 'bash agents/scripts/run-agent.sh --continue --resume ' + promptFile
+            // `--continue` alone resumes the most recent session in this directory;
+            // pairing it with `--resume` is rejected by the Copilot CLI as mutually
+            // exclusive ("cannot be used with option '--continue'"), which made this
+            // recovery run fail deterministically before ever reaching the agent.
+            command: 'bash agents/scripts/run-agent.sh --continue ' + promptFile
         });
         console.log('Resume run output:', (resumeResult || '').substring(0, 500));
         return true;

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -201,7 +201,11 @@ function attemptResumeIfReviewOutputsMissing(ticketKey) {
 
     try {
         var resumeResult = cli_execute_command({
-            command: 'bash agents/scripts/run-agent.sh --continue --resume ' + promptFile
+            // `--continue` alone resumes the most recent session in this directory;
+            // pairing it with `--resume` is rejected by the Copilot CLI as mutually
+            // exclusive ("cannot be used with option '--continue'"), which made this
+            // recovery run fail deterministically before ever reaching the agent.
+            command: 'bash agents/scripts/run-agent.sh --continue ' + promptFile
         });
         console.log('Review output resume run output:', (resumeResult || '').substring(0, 500));
         return true;

--- a/js/postStoryTestAutomationResults.js
+++ b/js/postStoryTestAutomationResults.js
@@ -187,7 +187,10 @@ function attemptResumeIfOutputsIncomplete(storyKey, result, linkedTestCases, wor
         return { attempted: false, reason: 'write-failed', missingKeys: missingKeys };
     }
 
-    var command = 'bash agents/scripts/run-agent.sh --continue --resume ' + promptPath;
+    // `--continue` alone resumes the most recent session in this directory; pairing it
+    // with `--resume` is rejected by the Copilot CLI as mutually exclusive, which made
+    // this recovery run fail deterministically before ever reaching the agent.
+    var command = 'bash agents/scripts/run-agent.sh --continue ' + promptPath;
     console.log('Story test output incomplete — resuming agent for missing TCs (attempt ' + attempt + '/' + maxAttempts + '):', missingKeys.join(', '));
     try {
         var output = runInRepo(command, workingDir);

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -21,7 +21,7 @@ var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 /**
  * Wraps feedbackLoop.resumeAgent() so an unexpected failure inside it (e.g. its own
- * mkdir/bash/run-agent.sh --continue --resume self-invocation being blocked by a
+ * mkdir/bash/run-agent.sh --continue self-invocation being blocked by a
  * misconfigured CLI_ALLOWED_COMMANDS whitelist) can never throw out of a call site.
  * Every caller treats { attempted: false } as "could not resume" and falls through to
  * posting an honest error comment / resetting the ticket — an uncaught throw here would

--- a/js/unit-tests/test_developTicketAndCreatePR.js
+++ b/js/unit-tests/test_developTicketAndCreatePR.js
@@ -94,7 +94,7 @@ suite('developTicketAndCreatePR > failure recovery', function() {
             },
             {
                 // Simulate the real-world bug: the feedback loop's own self-invocation
-                // (mkdir/bash/run-agent.sh --continue --resume) gets blocked by a
+                // (mkdir/bash/run-agent.sh --continue) gets blocked by a
                 // misconfigured CLI_ALLOWED_COMMANDS whitelist and throws instead of
                 // returning { attempted: false }.
                 resumeAgent: function() { throw new Error('Security violation: Command not whitelisted: bash'); }

--- a/js/unit-tests/test_feedbackLoop.js
+++ b/js/unit-tests/test_feedbackLoop.js
@@ -76,7 +76,7 @@ suite('feedbackLoop helper', function() {
         assert.contains(loaded.files['outputs/feedback/TS-1_git_operations.md'], 'git failed');
         assert.deepEqual(loaded.commands, [
             'mkdir -p outputs/feedback',
-            'bash agents/scripts/run-agent.sh --continue --resume outputs/feedback/TS-1_git_operations.md'
+            'bash agents/scripts/run-agent.sh --continue outputs/feedback/TS-1_git_operations.md'
         ]);
     });
 
@@ -110,7 +110,7 @@ suite('feedbackLoop helper', function() {
         assert.deepEqual(loaded.commands, [
             'flutter test --coverage',
             'mkdir -p outputs/feedback',
-            'bash agents/scripts/run-agent.sh --continue --resume outputs/feedback/TS-2_quality_gate_flutter-test.md',
+            'bash agents/scripts/run-agent.sh --continue outputs/feedback/TS-2_quality_gate_flutter-test.md',
             'flutter test --coverage'
         ]);
     });
@@ -216,7 +216,7 @@ suite('feedbackLoop helper', function() {
         assert.equal(loaded.commands[1].command, 'mkdir -p outputs/feedback');
         assert.equal(
             loaded.commands[2].command,
-            'bash agents/scripts/run-agent.sh --continue --resume outputs/feedback/TS-5_post_publish_gate_accessibility-lint.md'
+            'bash agents/scripts/run-agent.sh --continue outputs/feedback/TS-5_post_publish_gate_accessibility-lint.md'
         );
         assert.contains(
             loaded.files['outputs/feedback/TS-5_post_publish_gate_accessibility-lint.md'],

--- a/js/unit-tests/test_pushReworkChanges.js
+++ b/js/unit-tests/test_pushReworkChanges.js
@@ -465,7 +465,7 @@ suite('pushReworkChanges.action — rework_setup_failed.md guard (#310)', functi
 });
 
 // ── action(): resumeAgent exception safety ───────────────────────────────────
-// feedbackLoop.resumeAgent() shells out (mkdir/bash/run-agent.sh --continue --resume) and
+// feedbackLoop.resumeAgent() shells out (mkdir/bash/run-agent.sh --continue) and
 // can itself throw (e.g. blocked by a misconfigured CLI_ALLOWED_COMMANDS whitelist). Every
 // call site wraps it via tryResumeAgent() so that failure is treated the same as
 // { attempted: false } instead of propagating and skipping the honest error-comment fallback.

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -61,7 +61,8 @@ Example:
 Notes:
   - Provide the prompt as a single argument
   - Extra arguments before the prompt are passed through to the agent (cursor and codemie)
-  - Useful for resume: $(basename "$0") --continue --resume "fix the push error"
+  - Useful for resume: $(basename "$0") --continue "fix the push error"
+    (do NOT combine with --resume: Copilot CLI rejects --continue + --resume together)
   - For codemie: requires CODEMIE_API_KEY and CODEMIE_BASE_URL environment variables
   - For copilot: requires COPILOT_GITHUB_TOKEN or GITHUB_TOKEN environment variable
   - For cursor: optional CURSOR_MODEL env var (default: auto)


### PR DESCRIPTION
## Problem
Copilot CLI rejects combining --continue (resume most recent session, no value) with -r/--resume[=value] (resume by explicit id, or an interactive picker if bare) — mutually exclusive:

```
error: option '-r, --resume[=value]' cannot be used with option '--continue'
```

Every feedback-loop / self-heal retry constructed exactly this broken combination: `run-agent.sh --continue --resume <feedback-file>`:
- js/common/feedbackLoop.js's resumeAgent() default resumeArgs
- js/postPRReviewComments.js
- js/postStoryTestAutomationResults.js
- js/postMobileTestAutomationResults.js

This made every policy-gate / quality-gate self-heal retry fail deterministically before the agent ever saw the new prompt — confirmed live on a real pr_rework run (SOHO-131) where the same doomed command was retried repeatedly and never had a chance to succeed.

## Fix
--continue alone already resumes the most recent session in the current working directory, so drop --resume from all of the above call sites, and from run-agent.sh's own usage example (the likely source of the copy-pasted pattern). Also updated aiTeammateTokenUsageReporter.js's resume-detection log heuristic to additionally recognize the new `run-agent.sh --continue` shape (previously matched via `--resume`).

## Testing
- `bash -n scripts/run-agent.sh` — syntax OK
- Full local suite: `dmtools run js/unit-tests/run_all.json` -> 665/665 passed
