### PR TITLE
Fix auto-start workflow dispatch defaulting to main instead of repo default branch

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -171,7 +171,10 @@ function triggerConfiguredWorkflowForTicket(options) {
     var config = options.config || {};
     var configFile = options.configFile;
     var workflowFile = options.workflowFile || 'ai-teammate.yml';
-    var ref = options.ref || 'main';
+    // Default to the target repo's actual default branch (config.git.baseBranch, e.g. 'master')
+    // rather than assuming 'main' — dispatching a workflow_dispatch against a non-existent ref
+    // fails with "No ref found for: <ref>" (HTTP 422) and silently breaks auto-chaining.
+    var ref = options.ref || (config.git && config.git.baseBranch) || 'main';
     var label = options.label || configFile || workflowFile;
     if (!ticketKey || !configFile) {
         console.warn('autoStart: missing ticketKey or configFile — skipping');
@@ -278,7 +281,8 @@ function triggerSmIfIdle(options) {
     }
 
     try {
-        scm.triggerWorkflow(aiOwner, aiRepo, smWorkflowFile, '{}', 'main');
+        var ref = (config.git && config.git.baseBranch) || 'main';
+        scm.triggerWorkflow(aiOwner, aiRepo, smWorkflowFile, '{}', ref);
         console.log('✅ SM fallback: system idle — triggered ' + smWorkflowFile);
         return true;
     } catch (e) {

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -114,6 +114,28 @@ suite('autoStart helper', function() {
         assert.equal(decoded.params.fromSharedBuilder, true, 'encoded_config should be built by shared builder');
     });
 
+    test('dispatches against config.git.baseBranch instead of assuming main', function() {
+        var triggeredPayload = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredPayload = { ref: ref };
+            }
+        });
+
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'trackstate' }, git: { baseBranch: 'master' } },
+            customParams: {},
+            configFile: 'agents/pr_test_automation_rework.json'
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggeredPayload.ref, 'master', 'should dispatch against the repo default branch, not a hardcoded main');
+    });
+
     test('skips trigger when global active workflow cap is reached', function() {
         var triggered = false;
         var autoStart = loadAutoStartHelper({
@@ -203,6 +225,26 @@ suite('triggerSmIfIdle', function() {
         assert.equal(triggeredWorkflow.owner, 'IstiN');
         assert.equal(triggeredWorkflow.repo, 'trackstate');
         assert.equal(triggeredWorkflow.ref, 'main');
+    });
+
+    test('dispatches SM fallback against config.git.baseBranch instead of assuming main', function() {
+        var triggeredWorkflow = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredWorkflow = { ref: ref };
+            }
+        });
+
+        var result = autoStart.triggerSmIfIdle({
+            config: { repository: { owner: 'IstiN', repo: 'trackstate' }, git: { baseBranch: 'master' } },
+            customParams: { smFallback: true }
+        });
+
+        assert.equal(result, true, 'should trigger SM when idle');
+        assert.equal(triggeredWorkflow.ref, 'master', 'should dispatch against the repo default branch, not a hardcoded main');
     });
 
     test('triggers SM when only 1 run active (the current finishing one)', function() {


### PR DESCRIPTION
## Problem
`triggerConfiguredWorkflowForTicket` and `triggerSmIfIdle` in `js/common/autoStart.js` hardcoded `ref='main'` when dispatching `ai-teammate.yml`/`sm.yml` via GitHub's `workflow_dispatch` API.

Confirmed live on `EPAM-DarkFactory/SH_ANDR_WIP` (default branch `master`): every `autoStartReview`/`autoStartRework`/SM-idle-fallback attempt failed with:
```
{"message":"No ref found for: main","status":"422"}
```
This silently breaks auto-chaining (pr_review -> pr_rework -> pr_review, and the SM idle fallback), forcing tickets to wait for the next SM cron cycle instead of being picked up immediately.

## Fix
Default `ref` to `config.git.baseBranch` when configured, falling back to `'main'` only when not set - matching the pattern already used elsewhere in this codebase for git ref resolution (e.g. `preCliReworkSetup.syncBaseBranchIfConfigured`).

## Tests
Added 2 new tests asserting the dispatch `ref` follows `config.git.baseBranch` when set. Full suite: 667/667 passing (was 665, +2 new).
