### PR TITLE
Fix SM idempotency-label cleanup for story_development / bug_development

### DIFF
--- a/bug_development.json
+++ b/bug_development.json
@@ -16,7 +16,7 @@
     "preCliJSAction": "agents/js/preCliDevelopmentSetup.js",
     "postJSAction": "agents/js/developBugAndCreatePR.js",
     "customParams": {
-      "removeLabel": "sm_bug_development_triggered"
+      "removeLabel": "sm_bug_dev_triggered"
     },
     "inputJql": "key = PROJ-74",
     "cliPrompts": [

--- a/story_development.json
+++ b/story_development.json
@@ -20,6 +20,9 @@
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliDevelopmentSetup.js",
     "postJSAction": "agents/js/developTicketAndCreatePR.js",
+    "customParams": {
+      "removeLabel": "sm_story_dev_triggered"
+    },
     "inputJql": "key in (JD-82)",
     "cliPrompts": [
       "Senior Developer Engineer",


### PR DESCRIPTION
## Problem
SOHO-132 and SOHO-133 (in EPAM-DarkFactory/SH_ANDR_WIP) got permanently stuck: after a `story_development` failure, `sm`'s guard label `sm_story_dev_triggered` was never removed, so the "Ready Stories → trigger story_development" rule silently skipped them forever on every subsequent `sm` run.

## Root cause
- `story_development.json` had **no `customParams.removeLabel`** at all, so `developTicketAndCreatePR.js`'s `resetDevelopmentForRetry()` (called on every failure path) had nothing to remove.
- `bug_development.json` **did** declare a `removeLabel`, but its value (`sm_bug_development_triggered`) didn't match the actual guard label added by the SM rule (`sm_bug_dev_triggered` per `.dmtools/config.js`), so it could never match/remove it either — same bug class, just latent since no Bug ticket had failed+retried yet.

## Fix
Mirror the already-working pattern from `pr_review.json`/`pr_rework.json`:
- `story_development.json`: add `customParams.removeLabel: "sm_story_dev_triggered"`.
- `bug_development.json`: fix `removeLabel` to `"sm_bug_dev_triggered"`.

## Testing
`dmtools run js/unit-tests/run_all.json` → 667/667 passing (no regressions; existing generic tests already cover the `removeLabel`/`ruleTargetSelfManagesLabel` mechanism, this PR only corrects config values).