### PR TITLE
fix(pr_review): declare CLI_ALLOWED_COMMANDS so resume gate can shell out

### DIFF
--- a/pr_review.json
+++ b/pr_review.json
@@ -13,6 +13,9 @@
     "cleanupInputFolder": false,
     "skipAIProcessing": true,
     "alwaysPostComments": true,
+    "envVariables": {
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh"
+    },
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preparePRForReview.js",
     "postJSAction": "agents/js/postPRReviewComments.js",


### PR DESCRIPTION
## Summary

The PR-review missing-output resume gate in `agents/js/postPRReviewComments.js` shells out via `cli_execute_command`:

```js
cli_execute_command({ command: 'bash agents/scripts/run-agent.sh --continue --resume ' + promptFile })
```

But `agents/pr_review.json` never declared `envVariables.CLI_ALLOWED_COMMANDS`, so only the base whitelist applied (`git, gh, dmtools, npm, yarn, docker, kubectl, terraform, ansible, aws, gcloud, az`). `bash` was therefore rejected with a security violation, the resume never actually ran, and the mandatory `outputs/pr_review.json` stayed missing — defeating the recovery mechanism it depends on.

## Change

Add the same `envVariables` block already used by the sibling `agents/pr_rework.json`:

```json
"envVariables": {
  "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh"
}
```

This is project-agnostic and benefits any consumer of this submodule (the resume gate is generic, not PostNL-specific).

Fixes #325

## Test plan

- [ ] Trigger a PR review where the first pass omits `outputs/pr_review.json`
- [ ] Confirm the resume gate's `bash agents/scripts/run-agent.sh ...` is no longer blocked by a security violation
- [ ] Confirm `outputs/pr_review.json` is produced after resume
