### PR TITLE
fix(prompts): clarify persistent-shell cwd rules in bash_tools.md

### DIFF
--- a/prompts/bash_tools.md
+++ b/prompts/bash_tools.md
@@ -29,6 +29,9 @@ flowchart TD
         C3["Forgetting to cd back before writing outputs/* silently writes to dependencies/&lt;repo&gt;/outputs/* instead of the job's own outputs/ — the write itself succeeds, so nothing looks wrong, but the file is lost"]
         C4["Before ANY Write/Edit to outputs/ (response.md, pr_review.json, pr_review_comments/*.md, etc.): run pwd first and confirm you are at the job root, not inside dependencies/"]
         C5["If unsure or already deep in a dependency checkout: cd to the ABSOLUTE job root path shown in the very first tool result of this session before writing outputs/*"]
+        C6["Do NOT defensively re-cd into a directory you are already in — running cd dependencies/&lt;repo&gt; a second time while already inside it fails with No such file or directory (it looks for a nested dependencies/&lt;repo&gt;/dependencies/&lt;repo&gt;). Run pwd first if unsure; only cd once per direction change"]
+        C7["For one-off commands inside a dependency checkout, prefer git -C dependencies/&lt;repo&gt; &lt;command&gt; over cd dependencies/&lt;repo&gt; then command — the -C form targets that directory without depending on or changing the shell cwd, so there is no cd bookkeeping to get wrong"]
+        C8["Git global flags like --no-pager go BEFORE the subcommand: git --no-pager diff ... is correct, git diff ... --no-pager errors out (git treats the trailing flag as a positional argument)"]
     end
 
     USE --> SAFETY


### PR DESCRIPTION
## Summary

CLI agents that load `agents/prompts/bash_tools.md` (`pr_review`, `pr_rework`, `story_development`, `bug_development`) sometimes treat each Bash tool call as a fresh shell at the monorepo root. They defensively re-prepend `cd dependencies/<repo> && ...` even when the persistent shell is already inside that directory from a previous call, which then fails with `No such file or directory` (it looks for a nested `dependencies/<repo>/dependencies/<repo>`).

This extends the existing "Working directory discipline (persistent shell!)" section with three clarifications:

- Do not re-`cd` into a directory the shell is already in — `cd` once per direction change, run `pwd` first if unsure.
- Prefer `git -C dependencies/<repo> <command>` for one-off commands in a dependency checkout — it does not depend on or mutate the shell cwd.
- Git global flags like `--no-pager` must precede the subcommand (`git --no-pager diff ...`), not follow it (`git diff ... --no-pager` errors out).

Markdown/prompt-content-only change; no code or tests affected.

## Evidence

Observed live in a `pr_review` job reviewing a PR inside a submodule dependency checkout. Two failed Bash tool calls before the agent self-recovered:

- `cd dependencies/<repo> && git diff ... | wc -l` → `cd: No such file or directory` (shell was already inside the submodule from a prior `cd`).
- `git diff origin/main...HEAD --no-pager > ...` → exit 129 (`--no-pager` placed after the subcommand instead of before it).

## Test plan

- [ ] N/A — prompt/guidance content only; no runtime behavior changes.