### PR TITLE
feat: generic hooks for target branch resolution from fixVersion

### DIFF
--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -57,6 +57,7 @@ var DEFAULTS = {
 
     git: {
         baseBranch: DEFAULT_CONFIG.GIT_CONFIG.DEFAULT_BASE_BRANCH,
+        snapshotBranch: '',     // optional branch for BA/SA/discovery codegraph snapshots
         authorName: DEFAULT_CONFIG.GIT_CONFIG.AUTHOR_NAME,
         authorEmail: DEFAULT_CONFIG.GIT_CONFIG.AUTHOR_EMAIL,
         branchPrefix: {
@@ -369,6 +370,49 @@ function loadProjectConfig(params) {
     // This lets project-specific naming functions read explicit, non-generic
     // settings without hardcoding them in the shared agents repo.
     config.customParams = customParams;
+
+    // Apply baseBranchResolverFnPath from config.git — project-specific function
+    // that can override config.git.baseBranch based on the ticket (e.g. mapping from
+    // a Jira fixVersion to a release branch). The resolver receives
+    // (ticket, candidateBaseBranch, config) and must return a branch name;
+    // returning a falsy value keeps the candidate branch.
+    var baseBranchResolverPath = config.git && config.git.baseBranchResolverFnPath;
+    if (baseBranchResolverPath && params && params.ticket) {
+        var baseBranchResolver = loadHookFn(baseBranchResolverPath, 'baseBranchResolverFnPath');
+        if (baseBranchResolver) {
+            var candidateBaseBranch = config.git.baseBranch;
+            try {
+                var resolvedBaseBranch = baseBranchResolver(params.ticket, candidateBaseBranch, config);
+                if (resolvedBaseBranch) {
+                    config.git.baseBranch = resolvedBaseBranch;
+                    console.log('configLoader: Resolved baseBranch via ' + baseBranchResolverPath + ' → ' + resolvedBaseBranch);
+                }
+            } catch (e) {
+                console.warn('configLoader: baseBranchResolver failed, keeping candidate baseBranch:', e.message || e);
+            }
+        }
+    }
+
+    // Apply snapshotBranchResolverFnPath from config.git — project-specific function
+    // that selects the branch used for BA/SA/discovery codegraph snapshots.
+    // Differs from baseBranchResolver in that it may fall back to the latest
+    // existing release branch rather than the repository's default base branch.
+    var snapshotBranchResolverPath = config.git && config.git.snapshotBranchResolverFnPath;
+    if (snapshotBranchResolverPath && params && params.ticket) {
+        var snapshotBranchResolver = loadHookFn(snapshotBranchResolverPath, 'snapshotBranchResolverFnPath');
+        if (snapshotBranchResolver) {
+            var candidateSnapshotBranch = config.git.snapshotBranch || config.git.baseBranch;
+            try {
+                var resolvedSnapshotBranch = snapshotBranchResolver(params.ticket, candidateSnapshotBranch, config);
+                if (resolvedSnapshotBranch) {
+                    config.git.snapshotBranch = resolvedSnapshotBranch;
+                    console.log('configLoader: Resolved snapshotBranch via ' + snapshotBranchResolverPath + ' → ' + resolvedSnapshotBranch);
+                }
+            } catch (e) {
+                console.warn('configLoader: snapshotBranchResolver failed, keeping candidate snapshotBranch:', e.message || e);
+            }
+        }
+    }
 
     // Apply branchNamingFnPath from customParams — loads a JS file whose module.exports
     // is a function(ticket, branchRole, config) → string.  Takes priority over config.git.branchNamingFn.

--- a/js/preCliSnapshotSetup.js
+++ b/js/preCliSnapshotSetup.js
@@ -1,0 +1,160 @@
+/**
+ * Pre-CLI snapshot setup — optional codegraph branch alignment for non-dev agents.
+ *
+ * Use case: BA / SA / discovery / questions agents need a codegraph snapshot that
+ * matches the branch the implementation will eventually target. While dev agents
+ * already align the branch in preCliDevelopmentSetup, other agents run against the
+ * static checkout created by setup/checkout.sh (usually the repo default branch).
+ *
+ * Behavior:
+ *   1. Optionally chains the agent's original preCliJSAction (configured via
+ *      customParams.chainedPreCliJSAction) so existing setup is preserved.
+ *   2. Resolves config.git.snapshotBranch through configLoader, which may invoke a
+ *      project-specific snapshotBranchResolverFnPath (e.g. based on fixVersion).
+ *   3. If a snapshotBranch different from the current HEAD is resolved, checks it
+ *      out in targetRepository.workingDir and syncs codegraph.
+ *
+ * The action is fully backward-compatible: if no snapshotBranchResolverFnPath is
+ * configured, or if targetRepository.workingDir is missing, it returns success
+ * immediately without touching git state.
+ */
+
+var configLoader = require('./configLoader.js');
+
+function cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function(line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function runCommand(command, workingDir) {
+    var args = { command: command };
+    if (workingDir) args.workingDirectory = workingDir;
+    return cli_execute_command(args);
+}
+
+function lastNonEmptyLine(output) {
+    var lines = cleanCommandOutput(output || '').split(/\r?\n/)
+        .map(function(line) { return line.trim(); })
+        .filter(function(line) { return line; });
+    return lines[lines.length - 1] || '';
+}
+
+function currentBranch(workingDir) {
+    try {
+        return lastNonEmptyLine(runCommand('git rev-parse --abbrev-ref HEAD', workingDir));
+    } catch (e) {
+        return '';
+    }
+}
+
+function checkoutSnapshotBranch(workingDir, branchName) {
+    if (!workingDir || !branchName) return false;
+
+    var current = currentBranch(workingDir);
+    if (current === branchName) {
+        try {
+            runCommand('git pull origin ' + branchName + ' --ff-only', workingDir);
+            console.log('preCliSnapshotSetup: already on ' + branchName + ', pulled latest');
+            return true;
+        } catch (e) {
+            console.warn('preCliSnapshotSetup: pull failed:', e.message || e);
+            return true; // still on right branch
+        }
+    }
+
+    try {
+        runCommand('git fetch origin ' + branchName, workingDir);
+    } catch (e) {
+        console.warn('preCliSnapshotSetup: could not fetch origin/' + branchName + ':', e.message || e);
+    }
+
+    try {
+        runCommand('git checkout ' + branchName, workingDir);
+    } catch (e) {
+        console.log('preCliSnapshotSetup: local branch missing — creating from origin/' + branchName);
+        runCommand('git checkout -B ' + branchName + ' origin/' + branchName, workingDir);
+    }
+
+    try {
+        runCommand('git pull origin ' + branchName + ' --ff-only', workingDir);
+    } catch (e) {
+        console.warn('preCliSnapshotSetup: could not fast-forward ' + branchName + ':', e.message || e);
+    }
+
+    console.log('preCliSnapshotSetup: checked out snapshot branch ' + branchName + ' in ' + workingDir);
+    return true;
+}
+
+function syncCodegraph(workspace) {
+    try {
+        runCommand('codegraph sync "' + workspace + '"', workspace);
+        console.log('preCliSnapshotSetup: codegraph sync completed');
+        return true;
+    } catch (e) {
+        console.warn('preCliSnapshotSetup: codegraph sync failed:', e.message || e);
+        return false;
+    }
+}
+
+function action(params) {
+    try {
+        var actualParams = params.ticket ? params : (params.jobParams || params);
+        var customParams = actualParams.customParams || {};
+
+        // 1. Preserve existing preCliJSAction behavior by chaining.
+        var chained = customParams.chainedPreCliJSAction;
+        if (chained) {
+            try {
+                // Paths in agent JSONs are relative to agents/js/.
+                var chainedModule = require('./' + chained);
+                if (chainedModule && typeof chainedModule.action === 'function') {
+                    console.log('preCliSnapshotSetup: chaining ' + chained);
+                    var chainedResult = chainedModule.action(params);
+                    if (chainedResult === false) {
+                        console.warn('preCliSnapshotSetup: chained action returned false — aborting');
+                        return false;
+                    }
+                }
+            } catch (chainError) {
+                console.warn('preCliSnapshotSetup: chained action failed (non-fatal):', chainError.message || chainError);
+            }
+        }
+
+        // 2. Resolve config. snapshotBranch is filled by snapshotBranchResolverFnPath if configured.
+        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var snapshotBranch = config.git && config.git.snapshotBranch;
+        if (!snapshotBranch) {
+            console.log('preCliSnapshotSetup: no snapshotBranch configured — nothing to do');
+            return true;
+        }
+
+        var targetRepo = config.customParams && config.customParams.targetRepository;
+        var workingDir = targetRepo && targetRepo.workingDir;
+        if (!workingDir) {
+            console.log('preCliSnapshotSetup: no targetRepository.workingDir — skipping checkout');
+            return true;
+        }
+
+        // 3. Align the dependency checkout with the snapshot branch.
+        checkoutSnapshotBranch(workingDir, snapshotBranch);
+
+        // 4. Refresh codegraph index so BA/SA/discovery agents see the aligned snapshot.
+        var workspace = config.workingDir || '.';
+        syncCodegraph(workspace);
+
+        return true;
+    } catch (error) {
+        console.error('preCliSnapshotSetup: unexpected error:', error);
+        // Never block the agent because of a snapshot setup failure.
+        return true;
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action: action };
+}

--- a/js/unit-tests/run_configLoader.json
+++ b/js/unit-tests/run_configLoader.json
@@ -4,7 +4,8 @@
     "jsPath": "js/unit-tests/testRunner.js",
     "jobParams": {
       "testFiles": [
-        "js/unit-tests/test_configLoader.js"
+        "js/unit-tests/test_configLoader.js",
+        "js/unit-tests/test_preCliSnapshotSetup.js"
       ]
     }
   }

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -324,6 +324,104 @@ suite('configLoader.loadProjectConfig', function() {
         assert.equal(config.workingDir, 'other-repo');
     });
 
+    test('applies baseBranchResolverFnPath using ticket fixVersion', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { baseBranchResolverFnPath: "./.dmtools/resolver.js", baseBranchByFixVersionPattern: "develop/{version}" } };',
+            './.dmtools/resolver.js':
+                'module.exports = function(ticket, candidateBaseBranch, config) { ' +
+                '  var targetRepo = config.customParams && config.customParams.targetRepository; ' +
+                '  if (!targetRepo || targetRepo.repo !== "example-repo") return candidateBaseBranch; ' +
+                '  var pattern = config.git && config.git.baseBranchByFixVersionPattern || "develop/{version}"; ' +
+                '  var versions = ticket && ticket.fields && ticket.fields.fixVersions; ' +
+                '  if (versions && versions.length > 0) { ' +
+                '    var v = versions[0]; var name = v && v.name ? v.name : v; ' +
+                '    if (name) return pattern.replace("{version}", name); ' +
+                '  } ' +
+                '  return candidateBaseBranch; ' +
+                '};'
+        });
+        var config = cl.loadProjectConfig({
+            ticket: { key: 'PROJ-1', fields: { fixVersions: [{ name: '3.9.0' }] } },
+            customParams: {
+                targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'master' }
+            }
+        });
+        assert.equal(config.git.baseBranch, 'develop/3.9.0');
+    });
+
+    test('baseBranchResolverFnPath falls back to candidate baseBranch when no fixVersion', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { baseBranchResolverFnPath: "./.dmtools/resolver.js" } };',
+            './.dmtools/resolver.js':
+                'module.exports = function(ticket, candidateBaseBranch) { ' +
+                '  var versions = ticket && ticket.fields && ticket.fields.fixVersions; ' +
+                '  if (versions && versions.length > 0) return "develop/" + versions[0].name; ' +
+                '  return candidateBaseBranch; ' +
+                '};'
+        });
+        var config = cl.loadProjectConfig({
+            ticket: { key: 'PROJ-1', fields: {} },
+            customParams: {
+                targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'master' }
+            }
+        });
+        assert.equal(config.git.baseBranch, 'master');
+    });
+
+    test('baseBranchResolverFnPath ignored when no ticket provided', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { baseBranchResolverFnPath: "./.dmtools/resolver.js" } };',
+            './.dmtools/resolver.js':
+                'module.exports = function(ticket, candidateBaseBranch) { return "develop/forced"; };'
+        });
+        var config = cl.loadProjectConfig({
+            customParams: {
+                targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'master' }
+            }
+        });
+        assert.equal(config.git.baseBranch, 'master');
+    });
+
+    test('snapshotBranchResolverFnPath resolves snapshotBranch from ticket', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { snapshotBranchResolverFnPath: "./.dmtools/snapshot-resolver.js" } };',
+            './.dmtools/snapshot-resolver.js':
+                'module.exports = function(ticket, candidateBranch) { ' +
+                '  var versions = ticket && ticket.fields && ticket.fields.fixVersions; ' +
+                '  if (versions && versions.length > 0) return "develop/" + versions[0].name; ' +
+                '  return candidateBranch; ' +
+                '};'
+        });
+        var config = cl.loadProjectConfig({
+            ticket: { key: 'PROJ-1', fields: { fixVersions: [{ name: '3.9.0' }] } },
+            customParams: {
+                targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'master' }
+            }
+        });
+        assert.equal(config.git.snapshotBranch, 'develop/3.9.0');
+        assert.equal(config.git.baseBranch, 'master', 'baseBranch unchanged');
+    });
+
+    test('snapshotBranchResolverFnPath falls back to candidate branch', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { snapshotBranchResolverFnPath: "./.dmtools/snapshot-resolver.js" } };',
+            './.dmtools/snapshot-resolver.js':
+                'module.exports = function(ticket, candidateBranch) { return candidateBranch; };'
+        });
+        var config = cl.loadProjectConfig({
+            ticket: { key: 'PROJ-1', fields: {} },
+            customParams: {
+                targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'master' }
+            }
+        });
+        assert.equal(config.git.snapshotBranch, 'master');
+    });
+
     test('partial config — only overridden fields change', function() {
         var cl = makeLoader({
             '../.dmtools/config.js':

--- a/js/unit-tests/test_preCliSnapshotSetup.js
+++ b/js/unit-tests/test_preCliSnapshotSetup.js
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for js/preCliSnapshotSetup.js
+ *
+ * Uses: loadModule(), makeRequire(), assert, test(), suite()
+ */
+
+var NOOP_CONFIG_JS = { GIT_CONFIG: {}, STATUSES: {}, resolveStatuses: function() { return {}; } };
+
+function loadPreCliSnapshotSetup(configLoaderStub, mocks) {
+    return loadModule(
+        'js/preCliSnapshotSetup.js',
+        makeRequire({
+            './configLoader.js': configLoaderStub || makeConfigLoaderStub(),
+            './config.js': NOOP_CONFIG_JS
+        }),
+        mocks || {}
+    );
+}
+
+function makeConfigLoaderStub(snapshotBranch) {
+    return {
+        loadProjectConfig: function() {
+            return {
+                git: {
+                    baseBranch: 'master',
+                    snapshotBranch: snapshotBranch || ''
+                },
+                customParams: {
+                    targetRepository: {
+                        owner: 'acme-corp',
+                        repo: 'example-repo',
+                        baseBranch: 'master',
+                        workingDir: './dependencies/example-repo'
+                    }
+                },
+                workingDir: '.'
+            };
+        }
+    };
+}
+
+function makeCliMock(calls, responses) {
+    return function(opts) {
+        var command = opts && opts.command;
+        calls.push(command);
+        if (responses && Object.prototype.hasOwnProperty.call(responses, command)) {
+            return responses[command];
+        }
+        return '';
+    };
+}
+
+function makeChainedAction(calls) {
+    return {
+        action: function(params) {
+            calls.push('chained-action');
+            return true;
+        }
+    };
+}
+
+var TICKET = { key: 'PROJ-1', fields: { fixVersions: [{ name: '3.9.0' }] } };
+
+suite('preCliSnapshotSetup', function() {
+
+    test('is no-op when snapshotBranch is not resolved', function() {
+        var calls = [];
+        var mod = loadPreCliSnapshotSetup(makeConfigLoaderStub(''), {
+            cli_execute_command: makeCliMock(calls, {})
+        });
+        var result = mod.action({
+            ticket: TICKET,
+            customParams: {}
+        });
+        assert.equal(result, true);
+        assert.equal(calls.length, 0, 'no git commands when snapshotBranch empty');
+    });
+
+    test('chains existing preCliJSAction before checkout', function() {
+        var calls = [];
+        var chainedCalls = [];
+        var mod = loadModule(
+            'js/preCliSnapshotSetup.js',
+            makeRequire({
+                './configLoader.js': makeConfigLoaderStub('develop/3.9.0'),
+                './config.js': NOOP_CONFIG_JS,
+                './fetchQuestionsToInput.js': makeChainedAction(chainedCalls)
+            }),
+            { cli_execute_command: makeCliMock(calls, {}) }
+        );
+        var result = mod.action({
+            ticket: TICKET,
+            customParams: {
+                chainedPreCliJSAction: 'fetchQuestionsToInput.js'
+            }
+        });
+        assert.equal(result, true);
+        assert.deepEqual(chainedCalls, ['chained-action']);
+        assert.ok(calls.some(function(c) { return c.indexOf('git checkout develop/3.9.0') !== -1; }), 'checkout command present');
+    });
+
+    test('checks out snapshot branch and syncs codegraph', function() {
+        var calls = [];
+        var mod = loadPreCliSnapshotSetup(makeConfigLoaderStub('develop/3.9.0'), {
+            cli_execute_command: makeCliMock(calls, {
+                'git rev-parse --abbrev-ref HEAD': 'master'
+            })
+        });
+        var result = mod.action({
+            ticket: TICKET,
+            customParams: {}
+        });
+        assert.equal(result, true);
+        assert.ok(calls.some(function(c) { return c.indexOf('git fetch origin develop/3.9.0') !== -1; }));
+        assert.ok(calls.some(function(c) { return c.indexOf('git checkout develop/3.9.0') !== -1; }));
+        assert.ok(calls.some(function(c) { return c.indexOf('codegraph sync "."') !== -1; }));
+    });
+
+    test('skips checkout when already on snapshot branch', function() {
+        var calls = [];
+        var mod = loadPreCliSnapshotSetup(makeConfigLoaderStub('develop/3.9.0'), {
+            cli_execute_command: makeCliMock(calls, {
+                'git rev-parse --abbrev-ref HEAD': 'develop/3.9.0'
+            })
+        });
+        var result = mod.action({
+            ticket: TICKET,
+            customParams: {}
+        });
+        assert.equal(result, true);
+        assert.ok(!calls.some(function(c) { return c.indexOf('git checkout') !== -1; }), 'no checkout when already on branch');
+        assert.ok(calls.some(function(c) { return c.indexOf('git pull origin develop/3.9.0 --ff-only') !== -1; }));
+        assert.ok(calls.some(function(c) { return c.indexOf('codegraph sync') !== -1; }));
+    });
+
+    test('returns true even if git commands fail', function() {
+        var calls = [];
+        var mod = loadPreCliSnapshotSetup(makeConfigLoaderStub('develop/3.9.0'), {
+            cli_execute_command: function(opts) {
+                calls.push(opts.command);
+                if (opts.command.indexOf('git fetch') !== -1) {
+                    throw new Error('fetch failed');
+                }
+                return '';
+            }
+        });
+        var result = mod.action({
+            ticket: TICKET,
+            customParams: {}
+        });
+        assert.equal(result, true);
+    });
+
+});


### PR DESCRIPTION
- Add git.snapshotBranch default and snapshotBranchResolverFnPath hook.
- Add baseBranchResolverFnPath hook for dev-agent target branches.
- Add preCliSnapshotSetup.js to chain original pre-cli action, checkout snapshot branch and sync CodeGraph.
- Cover resolver and snapshot setup hooks with unit tests.

Backward-compatible: when no resolver is configured the existing baseBranch/snapshotBranch behaviour is unchanged.