### PR TITLE
feat: persist full CLI-agent transcripts instead of deleting them

### DIFF
--- a/scripts/providers/_common.sh
+++ b/scripts/providers/_common.sh
@@ -1,6 +1,40 @@
 #!/bin/bash
 # Common helpers shared by all run-agent provider subscripts.
 
+# Directory where the full, untruncated CLI-agent provider transcript (Claude
+# Code / Copilot / Cursor / Kimi / Codemie stdout+stderr) is persisted.
+#
+# Every provider used to `tee` its raw output to a `mktemp` file, grep it once
+# for codegraph usage / session-id extraction, then `rm -f` it — so the actual
+# conversation the agent had was never recoverable after the job finished,
+# even though `record_codegraph_usage` had already looked at it. That is the
+# single biggest source of "blind" CI runs: unlike nested `dmtools run`
+# subprocess output (capped/persisted on the Java side via
+# CommandLineUtils/DMTOOLS_CLI_LOG_DIR), the top-level agent's own transcript
+# was never written anywhere durable at all.
+#
+# Uses the SAME .dmtools-logs/cli root as DMTOOLS_CLI_LOG_DIR on the Java side
+# (see CommandLineUtils.java / PropertyReader.getCliFullOutputLogDir) so a
+# single CI artifact glob (.dmtools-logs/**) picks up both nested `dmtools run`
+# transcripts and the top-level provider CLI transcript.
+agent_full_log_dir() {
+  echo "${DMTOOLS_CLI_LOG_DIR:-.dmtools-logs/cli}/agent"
+}
+
+# Allocates a fresh, unique path under agent_full_log_dir() for a provider to
+# tee its full stdout+stderr to. $1: provider/attempt label (e.g. "copilot",
+# "copilot-attempt2", "claude-code"). The caller is responsible for `tee`-ing
+# into this path and MUST NOT delete it afterwards (unlike the old mktemp
+# pattern) — that's the whole point: it needs to survive for the CI job to
+# archive as an artifact.
+new_agent_log_file() {
+  local label="${1:-agent}"
+  local dir
+  dir="$(agent_full_log_dir)"
+  mkdir -p "$dir"
+  echo "${dir}/${label}-$(date -u +%Y%m%dT%H%M%SZ)-$$-${RANDOM}.log"
+}
+
 # Record a *_usage.json file path to outputs/token_usage_files.json so that
 # post-action JavaScript can discover usage summaries without relying on fs.
 record_usage_file() {

--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -45,7 +45,7 @@ run_claude_code() {
 
   local claude_code_exit_code=0
   local claude_code_log
-  claude_code_log="$(mktemp)"
+  claude_code_log="$(new_agent_log_file "claude-code")"
   # Session resume: if .claude-session-id exists from a previous run, continue that session.
   local claude_resume_args=()
   if [ -f ".claude-session-id" ]; then
@@ -95,7 +95,8 @@ run_claude_code() {
     echo "${saved_session_id}" > .claude-session-id
     echo "💾 Claude session saved: ${saved_session_id}"
   fi
-  rm -f "${claude_code_log}"
+
+  echo "Full transcript saved to: ${claude_code_log}"
 
   echo ""
   echo "=== Agent completed with exit code: $claude_code_exit_code ==="

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -47,13 +47,13 @@ run_codemie() {
   echo ""
 
   local agent_log
-  agent_log="$(mktemp)"
+  agent_log="$(new_agent_log_file "codemie")"
   set +e
   "${cmd[@]}" 2>&1 | tee "$agent_log"
   local exit_code=${PIPESTATUS[0]}
   set -e
   record_codegraph_usage "$agent_log"
-  rm -f "$agent_log"
+  echo "Full transcript saved to: ${agent_log}"
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="

--- a/scripts/providers/copilot.sh
+++ b/scripts/providers/copilot.sh
@@ -167,10 +167,16 @@ run_copilot() {
   local retry_delay="${COPILOT_RATE_LIMIT_RETRY_DELAY_SECONDS:-90}"
   local attempt=1
   local exit_code=1
+  # Every attempt (including model-fallback and rate-limit retries) gets its
+  # own persisted transcript file — unlike the old mktemp+rm pattern, none of
+  # these are deleted, so a full history of what Copilot actually did/said
+  # across retries is recoverable after the job finishes.
+  local copilot_log_files=()
 
   while [ "$attempt" -le "$max_attempts" ]; do
     local copilot_log
-    copilot_log="$(mktemp)"
+    copilot_log="$(new_agent_log_file "copilot-attempt${attempt}")"
+    copilot_log_files+=("$copilot_log")
     set +e
     run_copilot_once "$copilot_log" "$copilot_model_value"
     exit_code=$?
@@ -182,7 +188,6 @@ run_copilot() {
 
     if [ "$exit_code" -eq 0 ]; then
       record_codegraph_usage "$copilot_log"
-      rm -f "$copilot_log"
       break
     fi
 
@@ -190,8 +195,8 @@ run_copilot() {
       echo ""
       echo "Copilot model ${copilot_model_value} is unavailable; retrying with ${copilot_default_model}"
       record_codegraph_usage "$copilot_log"
-      rm -f "$copilot_log"
-      copilot_log="$(mktemp)"
+      copilot_log="$(new_agent_log_file "copilot-attempt${attempt}-fallback")"
+      copilot_log_files+=("$copilot_log")
       set +e
       run_copilot_once "$copilot_log" "$copilot_default_model"
       exit_code=$?
@@ -199,7 +204,6 @@ run_copilot() {
       copilot_model_value="$copilot_default_model"
       if [ "$exit_code" -eq 0 ]; then
         record_codegraph_usage "$copilot_log"
-        rm -f "$copilot_log"
         break
       fi
     fi
@@ -208,16 +212,18 @@ run_copilot() {
       echo ""
       echo "Copilot rate limit detected; retrying in ${retry_delay}s (attempt $((attempt + 1))/${max_attempts})"
       record_codegraph_usage "$copilot_log"
-      rm -f "$copilot_log"
       sleep "$retry_delay"
       attempt=$((attempt + 1))
       continue
     fi
 
     record_codegraph_usage "$copilot_log"
-    rm -f "$copilot_log"
     break
   done
+
+  echo ""
+  echo "Full transcript(s) saved to:"
+  printf '  %s\n' "${copilot_log_files[@]}"
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="

--- a/scripts/providers/cursor.sh
+++ b/scripts/providers/cursor.sh
@@ -207,7 +207,7 @@ run_cursor() {
   echo ""
 
   local agent_log
-  agent_log="$(mktemp)"
+  agent_log="$(new_agent_log_file "cursor")"
   set +e
   "${cmd[@]}" 2>&1 | tee "$agent_log"
   local exit_code=${PIPESTATUS[0]}
@@ -233,7 +233,7 @@ run_cursor() {
     fi
   fi
 
-  rm -f "$agent_log"
+  echo "Full transcript saved to: ${agent_log}"
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="

--- a/scripts/providers/kimi.sh
+++ b/scripts/providers/kimi.sh
@@ -197,7 +197,7 @@ PY
   # Stdin mode causes kimi to enter interactive TUI which hangs/does nothing in CI.
   # For local interactive use, stdin is fine but -p is still preferred for reliability.
   local kimi_log
-  kimi_log="$(mktemp)"
+  kimi_log="$(new_agent_log_file "kimi")"
   echo "Running: kimi ${kimi_model_args[*]:-} ${kimi_session_args[*]:-} ${kimi_pass_args[*]:-} -p <prompt:${PROMPT_BYTES} bytes>"
   echo ""
   set +e
@@ -244,7 +244,7 @@ PY
 
   print_kimi_usage_summary_and_write_json "${effective_session_id}"
 
-  rm -f "$kimi_log"
+  echo "Full transcript saved to: ${kimi_log}"
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="


### PR DESCRIPTION
## Problem

Every provider in `scripts/providers/*.sh` (claude, codemie, copilot, cursor, kimi) `tee`s its full stdout+stderr to a `mktemp` file, greps it once (`record_codegraph_usage`, session-id extraction), then `rm -f`s it. The actual conversation the top-level CLI agent had is never recoverable after the job finishes — even on failed runs, which is exactly when you'd want to inspect it.

Discovered while investigating a "blind CI" incident (GENSGENP-53009 / gens-igt !7860): even after fixing the nested `dmtools run` subprocess output truncation on the dmtools-core side (companion PR epam/dm.ai#439), the *top-level* provider transcript was still being thrown away regardless.

## Fix

- New `agent_full_log_dir()` / `new_agent_log_file()` helpers in `providers/_common.sh`. Files land under `.dmtools-logs/cli/agent/<label>-<timestamp>-<pid>-<random>.log` — the same `.dmtools-logs/cli` root dmtools-core's `DMTOOLS_CLI_LOG_DIR` uses, so a single CI artifact glob (`.dmtools-logs/**`) picks up both nested `dmtools run` transcripts and the top-level provider transcript.
- Every provider now allocates its transcript via `new_agent_log_file` instead of `mktemp`, and no longer deletes it.
- `copilot.sh`'s retry loop (model-fallback, rate-limit retries) now labels each attempt (`copilot-attempt1`, `copilot-attempt2`, `copilot-attempt1-fallback`, ...) so every retry's full transcript is individually recoverable, not just the last one.

## Testing

- `bash -n` on all modified scripts — OK.
- `shellcheck -S warning` on all modified scripts — clean, no warnings.
- Manually smoke-tested `new_agent_log_file`/`agent_full_log_dir` (unique paths per call, directory auto-created).

No JS unit tests touched — this PR is bash-only (`scripts/`), unrelated to the JS agent config layer.