### PR TITLE
feat: generic CliAgent for post-merge review-knowledge distillation

### DIFF
--- a/instructions/knowledge_update/general_guidelines.md
+++ b/instructions/knowledge_update/general_guidelines.md
@@ -1,6 +1,6 @@
 ```mermaid
 flowchart TD
-    START([Ticket reached Merged status]) --> READ["⚠️ MANDATORY: Read ALL input files FIRST — see instructions/common/input_context_reading.md"]
+    START([Invoked for one PR/MR — standalone, backfill loop, or a repo's own merge trigger]) --> READ["⚠️ MANDATORY: Read ALL input files FIRST — see instructions/common/input_context_reading.md"]
     READ --> TASK{knowledge_task.md says 'nothing to do'?}
     TASK -->|Yes| STOP["Do nothing. Write outputs/response.md noting the skip and stop."]
     TASK -->|No| MOC["Read <knowledgeDir>/MOC.md (create it, empty, if it doesn't exist yet)"]
@@ -21,9 +21,15 @@ flowchart TD
 ## Role
 
 You maintain the long-term, self-curated review-knowledge memory for this repository's
-dev/rework agents. Your job is to distill DURABLE, GENERALIZABLE lessons from a merged
-PR's review threads into atomic heuristic files. This memory is loaded into future
-agent runs, so every token must earn its place.
+dev/rework agents. Your job is to distill DURABLE, GENERALIZABLE lessons from one merged
+PR/MR's available material into atomic heuristic files. This memory is loaded into
+future agent runs, so every token must earn its place.
+
+This action is not tied to any ticket/tracker — it may be run standalone against a
+single historical PR, in a loop to backfill many PRs at once, or wired to whatever
+"merged" trigger a project chooses. Either `pr_diff.txt` or `pr_discussions.md` (or
+both) may be present in `input/` — work with whichever is available; do not assume
+both exist.
 
 ## What qualifies as a heuristic
 

--- a/instructions/knowledge_update/general_guidelines.md
+++ b/instructions/knowledge_update/general_guidelines.md
@@ -1,0 +1,76 @@
+```mermaid
+flowchart TD
+    START([Ticket reached Merged status]) --> READ["⚠️ MANDATORY: Read ALL input files FIRST — see instructions/common/input_context_reading.md"]
+    READ --> TASK{knowledge_task.md says 'nothing to do'?}
+    TASK -->|Yes| STOP["Do nothing. Write outputs/response.md noting the skip and stop."]
+    TASK -->|No| MOC["Read <knowledgeDir>/MOC.md (create it, empty, if it doesn't exist yet)"]
+    MOC --> README["Read <knowledgeDir>/README.md if present — it documents this repo's exact file/tag conventions"]
+    README --> EXTRACT["Extract candidate lessons from pr_discussions.md + pr_diff.txt"]
+    EXTRACT --> GENERALIZE["Generalize each candidate into ONE imperative sentence tied to a concrete trigger — see general_guidelines.md for the GOOD/BAD examples"]
+    GENERALIZE --> ANY{Any candidate left after discarding trivial/incident-only ones?}
+    ANY -->|No| NONE["Write outputs/response.md: 'no generalizable lesson found' and why. Stop — do not create empty files."]
+    ANY -->|Yes| DEDUP["⚠️ MANDATORY: for EACH candidate, search existing heuristics/*.md for a semantic match (same trigger/tags) BEFORE creating anything new"]
+    DEDUP --> MATCH{Match found?}
+    MATCH -->|Yes| REINFORCE["Do NOT create a new file. Bump weight, refresh updated, tighten wording only if clearer. Mark as 'reinforced'."]
+    MATCH -->|No| CREATE["Create heuristics/<kebab-case-id>.md with weight: 1, link it under the right tag section in MOC.md. Mark as 'new'."]
+    REINFORCE --> SUMMARY
+    CREATE --> SUMMARY["Write outputs/response.md: a table of new/reinforced/skipped heuristics with id + one-line rule + reason"]
+    SUMMARY --> END([End])
+```
+
+## Role
+
+You maintain the long-term, self-curated review-knowledge memory for this repository's
+dev/rework agents. Your job is to distill DURABLE, GENERALIZABLE lessons from a merged
+PR's review threads into atomic heuristic files. This memory is loaded into future
+agent runs, so every token must earn its place.
+
+## What qualifies as a heuristic
+
+A heuristic is a REUSABLE decision rule that would have prevented a review comment on
+THIS PR, phrased so it applies to FUTURE, DIFFERENT tickets in this repo.
+
+GOOD: "When changing a public API contract, version it and verify existing clients."
+BAD:  "Fixed null pointer in auth.py line 42." — an incident, not a rule.
+BAD:  "Write good code." — too vague, no trigger.
+
+Rules for a valid heuristic:
+- Imperative, single sentence, tied to a concrete TRIGGER.
+- Generalized: no file names, line numbers, ticket numbers, or one-off specifics.
+- Actionable: a future agent run can actually follow it.
+- Skip anything private, trivial, or already obvious from your base instructions.
+
+## Dedup is mandatory, not optional
+
+Searching `heuristics/*.md` for a semantic match before creating a new file is the
+single most important step in this whole flow — it is the #1 failure mode of
+self-managing memory. When in doubt, reinforce the closest existing heuristic instead
+of adding a near-duplicate. A smaller, sharper memory beats a large one.
+
+## File format
+
+Follow the exact conventions documented in `<knowledgeDir>/README.md`. If that file
+does not exist yet, create the directory with this minimal structure before writing
+anything else:
+
+```
+<knowledgeDir>/
+  MOC.md                  # index — one linked heading per tag, one bullet per heuristic
+  heuristics/<id>.md       # one atomic heuristic per file
+```
+
+Atomic heuristic file:
+
+```
+---
+id: kebab-case-id
+tags: [category, subtopic]
+triggers: [when this rule applies]
+weight: 1
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+source_pr: <PR/MR URL from pr_info.md>
+---
+<ONE generalized rule, imperative mood, single sentence>
+> why: <max 12 words, only if non-obvious>
+```

--- a/instructions/knowledge_update/output_rules.md
+++ b/instructions/knowledge_update/output_rules.md
@@ -1,0 +1,33 @@
+## Knowledge Update — Output Rules
+
+This agent does not open a PR/MR and does not post review replies — it only edits
+files under `<knowledgeDir>` (named in `input/<TICKET>/knowledge_task.md`) and writes
+a short summary.
+
+### Constraints
+
+- Touch **only** files under `<knowledgeDir>`. Never edit product source code, tests,
+  or any other part of the repository in this flow.
+- Never delete or rewrite an existing heuristic's core rule without a clear semantic
+  match justifying it — see general_guidelines.md's dedup rule.
+- Each heuristic body is ONE sentence. The optional `> why:` line is at most 12 words.
+- Compaction (merging near-duplicates, deleting stale `weight: 1` heuristics older than
+  ~90 days) is a separate, occasional pass — do not attempt it automatically as part of
+  a single PR's lesson extraction unless `<knowledgeDir>/README.md` explicitly asks for
+  it every run.
+
+### Required file
+
+`outputs/response.md` — a concise Markdown summary:
+
+```markdown
+## Knowledge Update
+
+| action | id | rule | reason |
+|---|---|---|---|
+| new | <id> | <one-line rule> | <why> |
+| reinforced | <id> | <one-line rule> | <why> |
+
+(or, if nothing qualified:)
+No generalizable lesson found — <short reason, e.g. "routine dependency bump, no review pushback">.
+```

--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -83,6 +83,45 @@ function findPRForTicket(scmOrWorkspace, repositoryOrTicketKey, ticketKeyOpt) {
     }
 }
 
+/**
+ * Finds the most recently MERGED PR/MR for a ticket — the counterpart to
+ * findPRForTicket() (which only looks at open PRs). Used by flows that run
+ * after a ticket reaches a "merged" status, e.g. distilling review-knowledge
+ * lessons once the PR is closed and no longer editable.
+ *
+ * Matches by ticket key in the PR title or head branch name, same as
+ * findPRForTicket(). Only the scm-object calling convention is supported
+ * (unlike findPRForTicket, no legacy workspace/repository overload).
+ */
+function findMergedPRForTicket(scm, ticketKey) {
+    try {
+        console.log('Searching for merged PR related to', ticketKey);
+        var closedPRs = scm.listPrs('closed') || [];
+        console.log('Found', closedPRs.length, 'closed PRs');
+
+        var match = function(pr) {
+            return (pr.title && pr.title.indexOf(ticketKey) !== -1) ||
+                   (pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1);
+        };
+
+        var merged = closedPRs.filter(function(pr) { return match(pr) && !!pr.merged_at; });
+        if (merged.length === 0) {
+            console.warn('No merged PR found for ticket', ticketKey);
+            return null;
+        }
+
+        merged.sort(function(a, b) {
+            return new Date(b.merged_at).getTime() - new Date(a.merged_at).getTime();
+        });
+
+        console.log('Found merged PR #' + merged[0].number + ':', merged[0].title);
+        return merged[0];
+    } catch (e) {
+        console.error('Failed to find merged PR for ticket:', e);
+        return null;
+    }
+}
+
 function getPRDetails(scmOrWorkspace, repositoryOrPrId, pullRequestIdOpt) {
     try {
         var pr;
@@ -476,6 +515,7 @@ module.exports = {
     getGitHubRepoInfo: getGitHubRepoInfo,
     _isScm: _isScm,
     findPRForTicket: findPRForTicket,
+    findMergedPRForTicket: findMergedPRForTicket,
     getPRDetails: getPRDetails,
     fetchDiscussionsAndRawData: fetchDiscussionsAndRawData,
     detectFailedChecks: detectFailedChecks,

--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -184,6 +184,18 @@ function _createGithubProvider(workspace, repository) {
         getPrComments: function(prId) {
             return github_get_pr_comments({ workspace: workspace, repository: repository, pullRequestId: String(prId) });
         },
+        // Raw unified diff text via the PR API — works even after the PR is merged and
+        // its head branch deleted (unlike a local `git diff <head>..<base>`).
+        // Requires IS_READ_PULL_REQUEST_DIFF to be enabled; returns null on failure so
+        // callers can fall back gracefully.
+        getDiffText: function(prId) {
+            try {
+                return github_get_pr_diff_text({ workspace: workspace, repository: repository, pullRequestID: String(prId) });
+            } catch (e) {
+                console.warn('getDiffText (github) failed:', e && e.toString ? e.toString() : String(e));
+                return null;
+            }
+        },
         addComment: function(prId, text) {
             return github_add_pr_comment({ workspace: workspace, repository: repository, pullRequestId: String(prId), text: text });
         },
@@ -530,6 +542,15 @@ function _createGitLabProvider(workspace, repository) {
         getPrComments: function(prId) {
             return _toArray(gitlab_get_mr_comments({ workspace: workspace, repository: repository, pullRequestId: String(prId) }));
         },
+        // See _createGithubProvider.getDiffText — same rationale (works post-merge).
+        getDiffText: function(prId) {
+            try {
+                return gitlab_get_mr_diff_text({ workspace: workspace, repository: repository, pullRequestId: String(prId) });
+            } catch (e) {
+                console.warn('getDiffText (gitlab) failed:', e && e.toString ? e.toString() : String(e));
+                return null;
+            }
+        },
         addComment: function(prId, text) {
             return gitlab_add_mr_comment({ workspace: workspace, repository: repository, pullRequestId: String(prId), text: text });
         },
@@ -802,6 +823,11 @@ function _createAdoProvider(repository) {
         getPrComments: function(prId) {
             var parsed = _parseJson(ado_get_pr_comments({ repository: repository, pullRequestId: String(prId) }));
             return (parsed && parsed.value) ? parsed.value : (parsed || []);
+        },
+        // ADO has no raw-unified-diff-text API (only file-level change stats via
+        // ado_get_pr_diff) — return null so callers fall back to a file list.
+        getDiffText: function() {
+            return null;
         },
         addComment: function(prId, text) {
             return ado_add_pr_comment({ repository: repository, pullRequestId: String(prId), text: text });

--- a/js/preCliKnowledgeUpdateSetup.js
+++ b/js/preCliKnowledgeUpdateSetup.js
@@ -1,11 +1,19 @@
 /**
  * Pre-CLI Knowledge Update Setup Action (preCliJSAction for pr_knowledge_update agent)
  *
- * Runs after a ticket reaches a "merged" status. Prepares input context so a
- * CLI agent can distill review-thread pain points from the just-merged PR/MR
- * into a self-curated, repo-specific knowledge base — without any repo-specific
- * logic living here. See agents/instructions/knowledge_update/ for the
- * generic read/write protocol the CLI agent follows.
+ * Prepares input context so a CLI agent can distill review-thread pain points
+ * from a merged PR/MR into a self-curated, repo-specific knowledge base —
+ * without any repo-specific or tracker-specific logic living here. See
+ * agents/instructions/knowledge_update/ for the generic read/write protocol
+ * the CLI agent follows.
+ *
+ * This job is intentionally NOT bound to a ticket/tracker. It is driven purely
+ * by customParams, so it can be:
+ *   - run standalone against any already-merged PR/MR to backfill a knowledge
+ *     base in bulk (e.g. looping over a list of historical PR numbers), or
+ *   - wired to whatever "PR merged" trigger a project chooses (a webhook, a
+ *     scheduled scan of recently-merged PRs, a manual one-off invocation,
+ *     etc.) — that trigger mechanism is deliberately out of scope here.
  *
  * customParams.knowledgeDir is the ONLY repo-specific piece of configuration
  * this action reads, and it is entirely optional: when it is not set (the
@@ -16,17 +24,31 @@
  * (e.g. baseBranchResolverFnPath, snapshotBranchResolverFnPath) — a project
  * that hasn't opted in must never fail or produce noise.
  *
- * When knowledgeDir IS configured:
- * 1. Finds the most recently MERGED PR/MR for the ticket (not open — the
- *    ticket already transitioned to "Merged").
- * 2. Fetches its diff text and review discussions via the PR API (works even
- *    after the head branch was deleted post-merge — no local git checkout of
- *    the target repo is required for this flow).
- * 3. Writes the standard pr_info.md / pr_diff.txt / pr_discussions.md /
- *    pr_discussions_raw.json context files.
- * 4. Writes knowledge_task.md naming the resolved knowledge directory, which
- *    the generic write-protocol prompt reads to know where to read/write
- *    MOC.md + heuristics/*.md.
+ * When knowledgeDir IS configured, one of three input modes is used (checked
+ * in this order):
+ *
+ *   1. Direct content (customParams.diffText and/or customParams.discussionsMarkdown
+ *      already provided) — no SCM calls at all. Use this to feed the agent
+ *      diff-only or conversations-only material gathered by some external
+ *      process (e.g. a bulk-export script, or a PR whose head branch/API
+ *      access is no longer available).
+ *
+ *   2. Direct PR/MR reference (customParams.prNumber) — fetches PR details,
+ *      diff text, and discussions straight from the SCM API for that single
+ *      PR/MR number. This is the primary way to run this job standalone,
+ *      e.g. `dmtools run pr_knowledge_update.json --customParams
+ *      '{"knowledgeDir":"...","prNumber":"123"}'`, including in a loop over
+ *      many historical PR numbers to backfill a knowledge base quickly.
+ *
+ *   3. Ticket-based (only if this action is invoked with a ticket in context,
+ *      e.g. params.ticket) — finds the most recently MERGED PR/MR for that
+ *      ticket via findMergedPRForTicket(). Kept for projects that prefer to
+ *      drive this from their own ticket-status automation.
+ *
+ * In every mode, diff text and discussions are each optional on their own —
+ * a PR with no review comments (diff-only) or a PR whose diff could not be
+ * fetched (discussions-only) both still produce useful, if narrower, context.
+ * Only the total absence of both is treated as "nothing to learn from".
  */
 
 var configLoader = require('./configLoader.js');
@@ -41,15 +63,103 @@ function writeNoOpMarker(inputFolder, reason) {
     });
 }
 
+function writeTaskMarker(inputFolder, knowledgeDir, prDetails) {
+    var prLine = prDetails && prDetails.number
+        ? 'Source PR/MR: [#' + prDetails.number + '](' + (prDetails.html_url || 'unknown') + ')\n\n'
+        : 'Source PR/MR: unknown (content supplied directly, no PR reference available)\n\n';
+
+    file_write({
+        path: inputFolder + '/knowledge_task.md',
+        content: '# Knowledge Update Task\n\n' + prLine +
+            'Target knowledge directory (relative to your current working directory): `' +
+            knowledgeDir + '`\n\n' +
+            'Follow the read/write protocol described in your instructions to distill ' +
+            'generalized heuristics from pr_discussions.md and/or pr_diff.txt (either may be ' +
+            'absent — work with whichever is available) into that directory. Do not invent a ' +
+            'different location.\n'
+    });
+}
+
+/**
+ * Resolves how to source PR context, in priority order:
+ * direct content > direct PR reference > ticket-based lookup.
+ *
+ * Returns { prDetails, diffText, discussionsMarkdown, discussionsRaw } or null
+ * if nothing usable could be resolved (caller writes the no-op marker).
+ */
+function resolvePrContext(scm, customParams, ticketKey) {
+    // Mode 1: direct content — fully offline, no SCM calls.
+    if (customParams.diffText || customParams.discussionsMarkdown) {
+        console.log('Knowledge update: using directly supplied diff/discussions content (no SCM calls).');
+        var directPr = {
+            number: customParams.prNumber || null,
+            html_url: customParams.prUrl || null,
+            title: customParams.prTitle || null,
+            state: 'merged'
+        };
+        return {
+            prDetails: directPr,
+            diffText: customParams.diffText || null,
+            discussionsMarkdown: customParams.discussionsMarkdown || null,
+            discussionsRaw: null
+        };
+    }
+
+    // Mode 2: direct PR/MR reference — the primary standalone/backfill entry point.
+    if (customParams.prNumber) {
+        console.log('Knowledge update: resolving PR/MR #' + customParams.prNumber + ' directly.');
+        var prByNumber = gh.getPRDetails(scm, customParams.prNumber);
+        if (!prByNumber) {
+            console.warn('Could not fetch PR/MR #' + customParams.prNumber + ' — skipping.');
+            return null;
+        }
+        return fetchDiffAndDiscussions(scm, prByNumber);
+    }
+
+    // Mode 3: ticket-based — only when this action happens to be invoked with a ticket.
+    if (ticketKey) {
+        console.log('Knowledge update: resolving merged PR/MR for ticket', ticketKey, '.');
+        var prByTicket = gh.findMergedPRForTicket(scm, ticketKey);
+        if (!prByTicket) {
+            console.warn('No merged PR found for ticket', ticketKey, '— skipping.');
+            return null;
+        }
+        var prDetails = gh.getPRDetails(scm, prByTicket.number) || prByTicket;
+        return fetchDiffAndDiscussions(scm, prDetails);
+    }
+
+    return null;
+}
+
+function fetchDiffAndDiscussions(scm, prDetails) {
+    var diffText = null;
+    if (typeof scm.getDiffText === 'function') {
+        diffText = scm.getDiffText(prDetails.number);
+    }
+    if (!diffText) {
+        console.warn('Diff text unavailable for PR #' + prDetails.number + ' — proceeding with discussions only (if any).');
+    }
+
+    console.log('Fetching discussions for PR/MR #' + prDetails.number + '...');
+    var discussionData = gh.fetchDiscussionsAndRawData(scm, prDetails.number) || {};
+
+    return {
+        prDetails: prDetails,
+        diffText: diffText,
+        discussionsMarkdown: discussionData.markdown || null,
+        discussionsRaw: discussionData.rawThreads || null
+    };
+}
+
 function action(params) {
     try {
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
         var inputFolder = actualParams.inputFolderPath;
-        var ticketKey = inputFolder.split('/').pop();
         var config = configLoader.loadProjectConfig(params.jobParams || params);
         var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams || {};
+        var ticketKey = actualParams.ticket ? (actualParams.ticket.key || actualParams.ticket) : (customParams.ticket || null);
 
-        console.log('=== Knowledge update setup for:', ticketKey, '===');
+        console.log('=== Knowledge update setup ===');
 
         var knowledgeDir = customParams.knowledgeDir;
         if (!knowledgeDir) {
@@ -60,49 +170,36 @@ function action(params) {
             return { success: true, skipped: true, reason: 'knowledgeDir not configured' };
         }
 
-        var scm = configLoader.createScm(config);
+        var hasDirectContent = !!(customParams.diffText || customParams.discussionsMarkdown);
+        var scm = hasDirectContent ? null : configLoader.createScm(config);
 
-        var pr = gh.findMergedPRForTicket(scm, ticketKey);
-        if (!pr) {
-            console.warn('No merged PR found for ticket', ticketKey, '— skipping.');
+        var resolved = resolvePrContext(scm, customParams, ticketKey);
+        if (!resolved) {
             writeNoOpMarker(inputFolder,
-                'No merged Pull Request / Merge Request could be found for ' + ticketKey + '.');
-            return { success: true, skipped: true, reason: 'no merged PR found' };
+                'No PR/MR context could be resolved. Provide `customParams.prNumber` (direct ' +
+                'backfill run), `customParams.diffText`/`discussionsMarkdown` (direct content), ' +
+                'or invoke this action with a ticket in context.');
+            return { success: true, skipped: true, reason: 'no PR context resolved' };
         }
 
-        var prDetails = gh.getPRDetails(scm, pr.number) || pr;
-
-        var diffText = null;
-        if (typeof scm.getDiffText === 'function') {
-            diffText = scm.getDiffText(pr.number);
-        }
-        if (!diffText) {
-            console.warn('Diff text unavailable for PR #' + pr.number + ' — proceeding with discussions only.');
+        if (!resolved.diffText && !resolved.discussionsMarkdown) {
+            console.warn('Neither diff nor discussions could be obtained — nothing to learn from.');
+            writeNoOpMarker(inputFolder,
+                'Both the diff and the discussions were unavailable for this PR/MR — there is ' +
+                'nothing to distill.');
+            return { success: true, skipped: true, reason: 'no diff or discussions available' };
         }
 
-        console.log('Fetching PR discussions for merged PR #' + pr.number + '...');
-        var discussionData = gh.fetchDiscussionsAndRawData(scm, pr.number) || {};
+        var prDetailsForContext = resolved.prDetails || {};
+        gh.writePRContext(inputFolder, prDetailsForContext, resolved.diffText, resolved.discussionsMarkdown, resolved.discussionsRaw);
+        writeTaskMarker(inputFolder, knowledgeDir, resolved.prDetails);
 
-        gh.writePRContext(inputFolder, prDetails, diffText, discussionData.markdown, discussionData.rawThreads);
-
-        file_write({
-            path: inputFolder + '/knowledge_task.md',
-            content: '# Knowledge Update Task\n\n' +
-                'Ticket: ' + ticketKey + '\n' +
-                'Merged PR: [#' + prDetails.number + '](' + prDetails.html_url + ')\n\n' +
-                'Target knowledge directory (relative to your current working directory): `' +
-                knowledgeDir + '`\n\n' +
-                'Follow the read/write protocol described in your instructions to distill ' +
-                'generalized heuristics from pr_discussions.md and pr_diff.txt into that ' +
-                'directory. Do not invent a different location.\n'
-        });
-
-        console.log('✅ Knowledge update setup complete — PR #' + prDetails.number, '| target:', knowledgeDir);
+        console.log('✅ Knowledge update setup complete — target:', knowledgeDir);
 
         return {
             success: true,
-            prNumber: prDetails.number,
-            prUrl: prDetails.html_url,
+            prNumber: prDetailsForContext.number || null,
+            prUrl: prDetailsForContext.html_url || null,
             knowledgeDir: knowledgeDir
         };
 
@@ -113,5 +210,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, writeNoOpMarker };
+    module.exports = { action, writeNoOpMarker, resolvePrContext };
 }

--- a/js/preCliKnowledgeUpdateSetup.js
+++ b/js/preCliKnowledgeUpdateSetup.js
@@ -1,0 +1,117 @@
+/**
+ * Pre-CLI Knowledge Update Setup Action (preCliJSAction for pr_knowledge_update agent)
+ *
+ * Runs after a ticket reaches a "merged" status. Prepares input context so a
+ * CLI agent can distill review-thread pain points from the just-merged PR/MR
+ * into a self-curated, repo-specific knowledge base — without any repo-specific
+ * logic living here. See agents/instructions/knowledge_update/ for the
+ * generic read/write protocol the CLI agent follows.
+ *
+ * customParams.knowledgeDir is the ONLY repo-specific piece of configuration
+ * this action reads, and it is entirely optional: when it is not set (the
+ * default in this generic config), this action is a no-op — it writes a
+ * knowledge_task.md explaining there is nothing to do, and the CLI agent's
+ * instructions tell it to stop immediately on seeing that. This mirrors the
+ * existing no-op convention for other optional resolver hooks in this repo
+ * (e.g. baseBranchResolverFnPath, snapshotBranchResolverFnPath) — a project
+ * that hasn't opted in must never fail or produce noise.
+ *
+ * When knowledgeDir IS configured:
+ * 1. Finds the most recently MERGED PR/MR for the ticket (not open — the
+ *    ticket already transitioned to "Merged").
+ * 2. Fetches its diff text and review discussions via the PR API (works even
+ *    after the head branch was deleted post-merge — no local git checkout of
+ *    the target repo is required for this flow).
+ * 3. Writes the standard pr_info.md / pr_diff.txt / pr_discussions.md /
+ *    pr_discussions_raw.json context files.
+ * 4. Writes knowledge_task.md naming the resolved knowledge directory, which
+ *    the generic write-protocol prompt reads to know where to read/write
+ *    MOC.md + heuristics/*.md.
+ */
+
+var configLoader = require('./configLoader.js');
+const gh = require('./common/githubHelpers.js');
+
+function writeNoOpMarker(inputFolder, reason) {
+    file_write({
+        path: inputFolder + '/knowledge_task.md',
+        content: '# Knowledge Update — nothing to do\n\n' + reason +
+            '\n\nDo NOT read or modify any knowledge/ directory this run. Stop after ' +
+            'confirming this file says so; do not attempt to find one yourself.\n'
+    });
+}
+
+function action(params) {
+    try {
+        var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
+        var inputFolder = actualParams.inputFolderPath;
+        var ticketKey = inputFolder.split('/').pop();
+        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams || {};
+
+        console.log('=== Knowledge update setup for:', ticketKey, '===');
+
+        var knowledgeDir = customParams.knowledgeDir;
+        if (!knowledgeDir) {
+            console.log('No customParams.knowledgeDir configured for this repo — skipping (no-op).');
+            writeNoOpMarker(inputFolder,
+                'This repo has not configured `customParams.knowledgeDir`, so there is no ' +
+                'review-knowledge base to update yet.');
+            return { success: true, skipped: true, reason: 'knowledgeDir not configured' };
+        }
+
+        var scm = configLoader.createScm(config);
+
+        var pr = gh.findMergedPRForTicket(scm, ticketKey);
+        if (!pr) {
+            console.warn('No merged PR found for ticket', ticketKey, '— skipping.');
+            writeNoOpMarker(inputFolder,
+                'No merged Pull Request / Merge Request could be found for ' + ticketKey + '.');
+            return { success: true, skipped: true, reason: 'no merged PR found' };
+        }
+
+        var prDetails = gh.getPRDetails(scm, pr.number) || pr;
+
+        var diffText = null;
+        if (typeof scm.getDiffText === 'function') {
+            diffText = scm.getDiffText(pr.number);
+        }
+        if (!diffText) {
+            console.warn('Diff text unavailable for PR #' + pr.number + ' — proceeding with discussions only.');
+        }
+
+        console.log('Fetching PR discussions for merged PR #' + pr.number + '...');
+        var discussionData = gh.fetchDiscussionsAndRawData(scm, pr.number) || {};
+
+        gh.writePRContext(inputFolder, prDetails, diffText, discussionData.markdown, discussionData.rawThreads);
+
+        file_write({
+            path: inputFolder + '/knowledge_task.md',
+            content: '# Knowledge Update Task\n\n' +
+                'Ticket: ' + ticketKey + '\n' +
+                'Merged PR: [#' + prDetails.number + '](' + prDetails.html_url + ')\n\n' +
+                'Target knowledge directory (relative to your current working directory): `' +
+                knowledgeDir + '`\n\n' +
+                'Follow the read/write protocol described in your instructions to distill ' +
+                'generalized heuristics from pr_discussions.md and pr_diff.txt into that ' +
+                'directory. Do not invent a different location.\n'
+        });
+
+        console.log('✅ Knowledge update setup complete — PR #' + prDetails.number, '| target:', knowledgeDir);
+
+        return {
+            success: true,
+            prNumber: prDetails.number,
+            prUrl: prDetails.html_url,
+            knowledgeDir: knowledgeDir
+        };
+
+    } catch (error) {
+        console.error('❌ Error in preCliKnowledgeUpdateSetup:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action, writeNoOpMarker };
+}

--- a/js/pushKnowledgeUpdate.js
+++ b/js/pushKnowledgeUpdate.js
@@ -1,0 +1,72 @@
+/**
+ * Push Knowledge Update Post-Action (postJSAction for pr_knowledge_update agent)
+ *
+ * Commits and pushes whatever the CLI agent changed under customParams.knowledgeDir
+ * — the ONLY repo-specific piece of config this action reads, same as its
+ * preCliJSAction counterpart (preCliKnowledgeUpdateSetup.js). Fully generic
+ * otherwise: no knowledge of any particular repo's directory layout or content.
+ *
+ * Behavior:
+ * - If knowledgeDir isn't configured, or the CLI agent made no changes under it
+ *   (e.g. it correctly no-op'd per knowledge_task.md), this is a silent no-op.
+ * - Otherwise: commits the changes under knowledgeDir only (nothing else in the
+ *   working tree is touched/staged) on a new branch, pushes it, and logs the
+ *   compare URL so a human can open a merge/pull request from it. Opening the
+ *   MR/PR itself is intentionally left to a human for now — see the write
+ *   protocol docs (agents/instructions/knowledge_update/) for why review stays
+ *   human-in-the-loop at this stage.
+ */
+
+var configLoader = require('./configLoader.js');
+const { GIT_CONFIG } = require('./config.js');
+
+function cleanOutput(output) {
+    return (output || '').toString().trim();
+}
+
+function action(params) {
+    try {
+        var actualParams = params.ticket ? params : (params.jobParams || params);
+        var ticketKey = actualParams.ticket ? actualParams.ticket.key : (actualParams.inputFolderPath || '').split('/').pop();
+        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams || {};
+
+        var knowledgeDir = customParams.knowledgeDir;
+        if (!knowledgeDir) {
+            console.log('pushKnowledgeUpdate: no customParams.knowledgeDir configured — nothing to push.');
+            return { success: true, skipped: true };
+        }
+
+        var status = cleanOutput(cli_execute_command({ command: 'git status --porcelain -- "' + knowledgeDir + '"' }));
+        if (!status) {
+            console.log('pushKnowledgeUpdate: no changes under', knowledgeDir, '— nothing to push.');
+            return { success: true, skipped: true };
+        }
+
+        console.log('pushKnowledgeUpdate: detected changes under', knowledgeDir, ':\n' + status);
+
+        cli_execute_command({ command: 'git config user.name "' + GIT_CONFIG.AUTHOR_NAME + '"' });
+        cli_execute_command({ command: 'git config user.email "' + GIT_CONFIG.AUTHOR_EMAIL + '"' });
+
+        var branchName = 'knowledge/' + (ticketKey || 'update').toLowerCase() + '-review-lessons';
+        cli_execute_command({ command: 'git checkout -b "' + branchName + '"' });
+        cli_execute_command({ command: 'git add -- "' + knowledgeDir + '"' });
+        cli_execute_command({
+            command: 'git commit -m "knowledge(' + (ticketKey || 'update') + '): distill review lessons from merged PR"'
+        });
+
+        var pushOutput = cleanOutput(cli_execute_command({ command: 'git push -u origin "' + branchName + '"' }));
+        console.log('pushKnowledgeUpdate: pushed branch', branchName);
+        console.log(pushOutput);
+
+        return { success: true, branchName: branchName, knowledgeDir: knowledgeDir };
+
+    } catch (error) {
+        console.error('❌ Error in pushKnowledgeUpdate:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { action };
+}

--- a/js/pushKnowledgeUpdate.js
+++ b/js/pushKnowledgeUpdate.js
@@ -4,7 +4,11 @@
  * Commits and pushes whatever the CLI agent changed under customParams.knowledgeDir
  * — the ONLY repo-specific piece of config this action reads, same as its
  * preCliJSAction counterpart (preCliKnowledgeUpdateSetup.js). Fully generic
- * otherwise: no knowledge of any particular repo's directory layout or content.
+ * otherwise: no knowledge of any particular repo's directory layout or content,
+ * and no dependency on a ticket/tracker — this job is driven purely by
+ * customParams (see preCliKnowledgeUpdateSetup.js), so the branch name is
+ * derived from customParams.prNumber (or a timestamp when no PR number is
+ * available, e.g. a direct-content-only run) instead of a ticket key.
  *
  * Behavior:
  * - If knowledgeDir isn't configured, or the CLI agent made no changes under it
@@ -24,10 +28,19 @@ function cleanOutput(output) {
     return (output || '').toString().trim();
 }
 
+function branchSlugFor(customParams) {
+    if (customParams.prNumber) {
+        return 'pr-' + String(customParams.prNumber).toLowerCase();
+    }
+    // No PR reference available (e.g. a direct-content-only run) — fall back to
+    // a timestamp so concurrent/repeated runs don't collide on the same branch name.
+    var ts = new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14);
+    return 'update-' + ts;
+}
+
 function action(params) {
     try {
-        var actualParams = params.ticket ? params : (params.jobParams || params);
-        var ticketKey = actualParams.ticket ? actualParams.ticket.key : (actualParams.inputFolderPath || '').split('/').pop();
+        var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
         var config = configLoader.loadProjectConfig(params.jobParams || params);
         var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams || {};
 
@@ -48,12 +61,15 @@ function action(params) {
         cli_execute_command({ command: 'git config user.name "' + GIT_CONFIG.AUTHOR_NAME + '"' });
         cli_execute_command({ command: 'git config user.email "' + GIT_CONFIG.AUTHOR_EMAIL + '"' });
 
-        var branchName = 'knowledge/' + (ticketKey || 'update').toLowerCase() + '-review-lessons';
+        var slug = branchSlugFor(customParams);
+        var branchName = 'knowledge/' + slug + '-review-lessons';
+        var commitSubject = customParams.prNumber
+            ? 'knowledge(pr-' + customParams.prNumber + '): distill review lessons from merged PR'
+            : 'knowledge: distill review lessons';
+
         cli_execute_command({ command: 'git checkout -b "' + branchName + '"' });
         cli_execute_command({ command: 'git add -- "' + knowledgeDir + '"' });
-        cli_execute_command({
-            command: 'git commit -m "knowledge(' + (ticketKey || 'update') + '): distill review lessons from merged PR"'
-        });
+        cli_execute_command({ command: 'git commit -m "' + commitSubject + '"' });
 
         var pushOutput = cleanOutput(cli_execute_command({ command: 'git push -u origin "' + branchName + '"' }));
         console.log('pushKnowledgeUpdate: pushed branch', branchName);

--- a/js/resolveRepoFromTicket.js
+++ b/js/resolveRepoFromTicket.js
@@ -7,7 +7,7 @@
  *
  * Strategy (customParams.repoNameStrategy, default: 'fromSummary'):
  *   fromSummary — parses the leading [bracket-tag] from ticket summary, e.g.
- *                 "[gens-igt] Create PacBio WF" → "gens-igt"
+ *                 "[payments-api] Create webhook" → "payments-api"
  *
  * Additional strategies can be registered in STRATEGIES by extending this file
  * in the future (e.g. fromLabel, fromCustomField).

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -69,7 +69,9 @@
         "js/unit-tests/test_preCliDevelopmentSetupDynamicRepo.js",
         "js/unit-tests/test_checkoutBranch.js",
         "js/unit-tests/test_preCliReworkSetup.js",
-        "js/unit-tests/test_preCliDevelopmentSetup.js"
+        "js/unit-tests/test_preCliDevelopmentSetup.js",
+        "js/unit-tests/test_preCliKnowledgeUpdateSetup.js",
+        "js/unit-tests/test_pushKnowledgeUpdate.js"
       ]
     }
   }

--- a/js/unit-tests/run_preCliKnowledgeUpdateSetup.json
+++ b/js/unit-tests/run_preCliKnowledgeUpdateSetup.json
@@ -1,0 +1,12 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_preCliKnowledgeUpdateSetup.js",
+        "js/unit-tests/test_pushKnowledgeUpdate.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_createRepoTasks.js
+++ b/js/unit-tests/test_createRepoTasks.js
@@ -62,8 +62,8 @@ suite('createRepoTasks — parseAffectedRepos', function() {
 
 suite('createRepoTasks — action', function() {
     var reposJson = JSON.stringify([
-        { name: 'sample-db', reason: 'DB migration' },
-        { name: 'gens-igt',    reason: 'API change', depends_on: ['sample-db'] }
+        { name: 'core-db', reason: 'DB migration' },
+        { name: 'service-api',    reason: 'API change', depends_on: ['core-db'] }
     ]);
     var description = 'Solution text\n\n{code:json|title=affected_repos}\n' + reposJson + '\n{code}\n\n----';
 
@@ -71,32 +71,32 @@ suite('createRepoTasks — action', function() {
         var created = [];
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Build PacBio workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function(opts) {
                 created.push(opts);
-                return '{"key":"GENSGENP-' + (200 + created.length) + '"}';
+                return '{"key":"PROJ-' + (200 + created.length) + '"}';
             },
             jira_link_issues: function() {},
             jira_move_to_status: function() {},
             jira_post_comment: function() {}
         });
 
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
 
         assert.equal(result.success, true, 'succeeds');
         assert.equal(created.length, 2, 'two sub-tasks created');
-        assert.equal(created[0].parentKey, 'GENSGENP-50', 'parent is story');
+        assert.equal(created[0].parentKey, 'PROJ-50', 'parent is story');
         assert.equal(created[0].issueType, 'Sub-task', 'issueType is Sub-task');
-        assert.equal(created[0].summary.indexOf('[sample-db]') === 0, true, 'summary starts with [repo]');
+        assert.equal(created[0].summary.indexOf('[core-db]') === 0, true, 'summary starts with [repo]');
         assert.equal(created[0].summary.indexOf('Build PacBio workflow') !== -1, true, 'parent summary in subtask summary');
-        assert.equal(created[0].description.indexOf('sample-db') !== -1, true, 'repo name in description');
-        assert.equal(created[0].description.indexOf('GENSGENP-100') !== -1, true, 'SA ticket link in description');
-        assert.equal(created[0].description.indexOf('GENSGENP-50') !== -1, true, 'parent link in description');
+        assert.equal(created[0].description.indexOf('core-db') !== -1, true, 'repo name in description');
+        assert.equal(created[0].description.indexOf('PROJ-100') !== -1, true, 'SA ticket link in description');
+        assert.equal(created[0].description.indexOf('PROJ-50') !== -1, true, 'parent link in description');
         assert.deepEqual(created[0].labels, ['development'], 'default development label set');
     });
 
@@ -106,30 +106,30 @@ suite('createRepoTasks — action', function() {
         var ticketCounter = 200;
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Build PacBio workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function() {
                 ticketCounter++;
-                return '{"key":"GENSGENP-' + ticketCounter + '"}';
+                return '{"key":"PROJ-' + ticketCounter + '"}';
             },
             jira_link_issues: function(opts) { links.push(opts); },
             jira_move_to_status: function(opts) { moved.push(opts); },
             jira_post_comment: function() {}
         });
 
-        mod.action({ ticket: { key: 'GENSGENP-100' } });
+        mod.action({ ticket: { key: 'PROJ-100' } });
 
-        // gens-igt depends_on sample-db → sample-db (GENSGENP-201) blocks gens-igt (GENSGENP-202)
+        // service-api depends_on core-db → core-db (PROJ-201) blocks service-api (PROJ-202)
         assert.equal(links.length, 1, 'one Blocks link created');
         assert.equal(links[0].relationship, 'Blocks', 'relationship is Blocks');
-        assert.equal(links[0].sourceKey, 'GENSGENP-201', 'blocker is sample-db ticket');
-        assert.equal(links[0].anotherKey, 'GENSGENP-202', 'dependent is gens-igt ticket');
+        assert.equal(links[0].sourceKey, 'PROJ-201', 'blocker is core-db ticket');
+        assert.equal(links[0].anotherKey, 'PROJ-202', 'dependent is service-api ticket');
         assert.equal(moved.length, 1, 'one ticket moved to Blocked');
-        assert.equal(moved[0].key, 'GENSGENP-202', 'gens-igt moved to Blocked');
+        assert.equal(moved[0].key, 'PROJ-202', 'service-api moved to Blocked');
         assert.equal(moved[0].statusName, 'Blocked', 'status is Blocked');
     });
 
@@ -139,15 +139,15 @@ suite('createRepoTasks — action', function() {
         var ticketCounter = 300;
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Story' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function() {
                 ticketCounter++;
-                return '{"key":"GENSGENP-' + ticketCounter + '"}';
+                return '{"key":"PROJ-' + ticketCounter + '"}';
             },
             jira_link_issues: function(opts) { links.push(opts); },
             jira_move_to_status: function(opts) { moved.push(opts); },
@@ -155,7 +155,7 @@ suite('createRepoTasks — action', function() {
         });
 
         mod.action({
-            ticket: { key: 'GENSGENP-100' },
+            ticket: { key: 'PROJ-100' },
             customParams: { blocksRelationship: 'is blocked by', blockedStatus: 'On Hold' }
         });
 
@@ -168,24 +168,24 @@ suite('createRepoTasks — action', function() {
         var created = [];
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Parent story' } };
             },
             jira_search_by_jql: function() {
-                return [{ fields: { summary: '[sample-db] Parent story' } }]; // already exists
+                return [{ fields: { summary: '[core-db] Parent story' } }]; // already exists
             },
-            jira_create_ticket_with_parent: function(opts) { created.push(opts); return '{"key":"GENSGENP-201"}'; },
+            jira_create_ticket_with_parent: function(opts) { created.push(opts); return '{"key":"PROJ-201"}'; },
             jira_post_comment: function() {}
         });
 
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
 
         assert.equal(result.success, true, 'succeeds');
-        assert.equal(created.length, 1, 'only one created (sample-db skipped)');
+        assert.equal(created.length, 1, 'only one created (core-db skipped)');
         assert.equal(result.skipped, 1, 'one skipped');
-        assert.equal(created[0].summary.indexOf('[gens-igt]') === 0, true, 'gens-igt was created');
+        assert.equal(created[0].summary.indexOf('[service-api]') === 0, true, 'service-api was created');
     });
 
     test('returns error when SA ticket has no parent', function() {
@@ -194,7 +194,7 @@ suite('createRepoTasks — action', function() {
                 return { fields: { description: description, parent: null } };
             }
         });
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
         assert.equal(result.success, false, 'fails without parent');
         assert.equal(result.error.indexOf('no parent') !== -1, true, 'error mentions parent');
     });
@@ -202,13 +202,13 @@ suite('createRepoTasks — action', function() {
     test('returns error when no affected_repos block in description', function() {
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: 'Just some text, no repos block', parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: 'Just some text, no repos block', parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Parent story' } };
             }
         });
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
         assert.equal(result.success, false, 'fails without repos block');
     });
 

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -401,11 +401,11 @@ suite('scm GitLab provider', function() {
         var failed = scmModule._normalizeGitLabCommitStatus({
             name: 'sonar-tests/Merge requests check',
             status: 'failed',
-            target_url: 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/'
+            target_url: 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/'
         });
         assert.equal(failed.name, 'sonar-tests/Merge requests check');
         assert.equal(failed.conclusion, 'failure');
-        assert.equal(failed.details_url, 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/');
+        assert.equal(failed.details_url, 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/');
 
         var succeeded = scmModule._normalizeGitLabCommitStatus({ name: 'ai-teammate', status: 'success' });
         assert.equal(succeeded.conclusion, 'success');
@@ -423,17 +423,17 @@ suite('scm GitLab provider', function() {
             gitlab_get_commit_statuses: function(args) {
                 calledArgs = args;
                 return JSON.stringify([
-                    { name: 'sonar-tests/Merge requests check', status: 'failed', target_url: 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/' },
-                    { name: 'ai-teammate', status: 'success', target_url: 'https://git.epam.com/gens-sup/ai-teammate/-/pipelines/1' }
+                    { name: 'sonar-tests/Merge requests check', status: 'failed', target_url: 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/' },
+                    { name: 'ai-teammate', status: 'success', target_url: 'https://git.epam.com/acme-org/ai-teammate/-/pipelines/1' }
                 ]);
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var runs = provider.getCommitCheckRuns('7b74c0eb5f0fdfa3d18472d3c55e91235a0924aa');
 
-        assert.equal(calledArgs.workspace, 'gens-sup/develop');
-        assert.equal(calledArgs.repository, 'gens-igt');
+        assert.equal(calledArgs.workspace, 'acme-org/develop');
+        assert.equal(calledArgs.repository, 'service-api');
         assert.equal(calledArgs.commitSha, '7b74c0eb5f0fdfa3d18472d3c55e91235a0924aa');
         assert.equal(runs.length, 2);
         assert.equal(runs[0].conclusion, 'failure');
@@ -444,7 +444,7 @@ suite('scm GitLab provider', function() {
         var scmModule = loadScm({
             gitlab_get_commit_statuses: function() { return '[]'; }
         });
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         assert.equal(provider.getCommitCheckRuns('deadbeef'), null);
     });
 
@@ -452,7 +452,7 @@ suite('scm GitLab provider', function() {
         var scmModule = loadScm({
             gitlab_get_commit_statuses: function() { throw new Error('boom'); }
         });
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         assert.equal(provider.getCommitCheckRuns('deadbeef'), null);
     });
 
@@ -765,7 +765,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function() { throw new Error('git diff should not be called'); }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return diff from new tool');
@@ -783,7 +783,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should fall back to legacy tool result');
@@ -802,7 +802,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function(args) { gitCalls.push(args.command); return ''; }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable diff');
@@ -835,8 +835,8 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        var diff = provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        var diff = provider.getPrDiff('7860', './dependencies/service-api');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable local diff');
         assert.equal(mrDiffCalls.length, 1);
@@ -859,10 +859,10 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        provider.getPrDiff('7860', './dependencies/service-api');
 
-        assert.equal(gitOpts[0].workingDirectory, './dependencies/gens-igt', 'should run git diff in the checked-out repo dir');
+        assert.equal(gitOpts[0].workingDirectory, './dependencies/service-api', 'should run git diff in the checked-out repo dir');
     });
 
     test('returns raw (unusable) value when both MCP diff and local git diff fail', function() {
@@ -873,8 +873,8 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function() { throw new Error('should not be called without diff_refs'); }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        var diff = provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        var diff = provider.getPrDiff('7860', './dependencies/service-api');
 
         assert.equal(diff, 'com.github.istin.dmtools.gitlab.GitLab$4@b2c4a8b', 'should fall back to raw value, not throw');
     });

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -1021,3 +1021,137 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
         assert.ok(!fullLogWrite, 'ci_failures_full.log should not be written when no logs were fetched');
     });
 });
+
+suite('githubHelpers.findMergedPRForTicket', function() {
+
+    function scmWithClosedPrs(prs) {
+        return {
+            listPrs: function(state) {
+                assert.equal(state, 'closed', 'findMergedPRForTicket must request closed PRs');
+                return prs;
+            }
+        };
+    }
+
+    test('returns null when no closed PR matches the ticket key', function() {
+        var gh = loadGithubHelpers();
+        var scm = scmWithClosedPrs([
+            { number: 1, title: 'OTHER-1: unrelated', merged_at: '2026-01-01T00:00:00Z' }
+        ]);
+
+        var result = gh.findMergedPRForTicket(scm, 'ABC-123');
+
+        assert.ok(!result, 'no matching PR should return null/falsy');
+    });
+
+    test('ignores closed-but-not-merged PRs even when the title matches', function() {
+        var gh = loadGithubHelpers();
+        var scm = scmWithClosedPrs([
+            { number: 1, title: 'ABC-123: fix', merged_at: null }
+        ]);
+
+        var result = gh.findMergedPRForTicket(scm, 'ABC-123');
+
+        assert.ok(!result, 'closed-without-merge PR must not be returned');
+    });
+
+    test('matches by ticket key in the head branch ref when title has no match', function() {
+        var gh = loadGithubHelpers();
+        var scm = scmWithClosedPrs([
+            { number: 7, title: 'Unrelated title', head: { ref: 'feature/ABC-123-fix' }, merged_at: '2026-02-01T00:00:00Z' }
+        ]);
+
+        var result = gh.findMergedPRForTicket(scm, 'ABC-123');
+
+        assert.ok(result, 'should match via head.ref');
+        assert.equal(result.number, 7);
+    });
+
+    test('when several merged PRs match, returns the most recently merged one', function() {
+        var gh = loadGithubHelpers();
+        var scm = scmWithClosedPrs([
+            { number: 1, title: 'ABC-123: first attempt', merged_at: '2026-01-01T00:00:00Z' },
+            { number: 2, title: 'ABC-123: second attempt', merged_at: '2026-03-01T00:00:00Z' },
+            { number: 3, title: 'ABC-123: third attempt (older)', merged_at: '2026-02-01T00:00:00Z' }
+        ]);
+
+        var result = gh.findMergedPRForTicket(scm, 'ABC-123');
+
+        assert.equal(result.number, 2, 'the PR with the latest merged_at should win');
+    });
+
+    test('returns null and does not throw when scm.listPrs throws', function() {
+        var gh = loadGithubHelpers();
+        var scm = {
+            listPrs: function() { throw new Error('boom'); }
+        };
+
+        var result = gh.findMergedPRForTicket(scm, 'ABC-123');
+
+        assert.ok(!result, 'errors should be swallowed and null returned');
+    });
+});
+
+suite('scm.getDiffText', function() {
+
+    test('GitHub provider calls github_get_pr_diff_text with workspace/repository/pullRequestID', function() {
+        var call = null;
+        var scmModule = loadScm({
+            github_get_pr_diff_text: function(args) {
+                call = args;
+                return 'diff --git a/x b/x';
+            }
+        });
+
+        var provider = scmModule._createGithubProvider('epam', 'dm.ai');
+        var diff = provider.getDiffText(42);
+
+        assert.deepEqual(call, { workspace: 'epam', repository: 'dm.ai', pullRequestID: '42' });
+        assert.equal(diff, 'diff --git a/x b/x');
+    });
+
+    test('GitHub provider returns null instead of throwing when the diff-text tool fails', function() {
+        var scmModule = loadScm({
+            github_get_pr_diff_text: function() { throw new Error('IS_READ_PULL_REQUEST_DIFF disabled'); }
+        });
+
+        var provider = scmModule._createGithubProvider('epam', 'dm.ai');
+        var diff = provider.getDiffText(42);
+
+        assert.ok(diff === null, 'must gracefully return null on failure');
+    });
+
+    test('GitLab provider calls gitlab_get_mr_diff_text with workspace/repository/pullRequestId', function() {
+        var call = null;
+        var scmModule = loadScm({
+            gitlab_get_mr_diff_text: function(args) {
+                call = args;
+                return 'diff --git a/x b/x';
+            }
+        });
+
+        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var diff = provider.getDiffText(7);
+
+        assert.deepEqual(call, { workspace: 'mobile', repository: 'dmtools-epamsample', pullRequestId: '7' });
+        assert.equal(diff, 'diff --git a/x b/x');
+    });
+
+    test('GitLab provider returns null instead of throwing when the diff-text tool fails', function() {
+        var scmModule = loadScm({
+            gitlab_get_mr_diff_text: function() { throw new Error('boom'); }
+        });
+
+        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var diff = provider.getDiffText(7);
+
+        assert.ok(diff === null, 'must gracefully return null on failure');
+    });
+
+    test('ADO provider always returns null (no raw diff-text API available)', function() {
+        var scmModule = loadScm({});
+        var provider = scmModule._createAdoProvider('dmtools-epamsample');
+
+        assert.ok(provider.getDiffText(7) === null);
+    });
+});

--- a/js/unit-tests/test_preCliKnowledgeUpdateSetup.js
+++ b/js/unit-tests/test_preCliKnowledgeUpdateSetup.js
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for js/preCliKnowledgeUpdateSetup.js
+ *
+ * Scope: the three PR-context resolution modes (direct content, direct PR/MR
+ * reference, ticket-based fallback), the knowledgeDir no-op gate, and the
+ * "neither diff nor discussions available" no-op path. This action is
+ * intentionally NOT tracker-bound — see the module docstring — so most tests
+ * exercise it purely via customParams, without any ticket in context.
+ */
+
+function makeGhStub(overrides) {
+    var base = {
+        getPRDetails: function() { return null; },
+        findMergedPRForTicket: function() { return null; },
+        fetchDiscussionsAndRawData: function() { return {}; },
+        writePRContext: function() {}
+    };
+    return Object.assign(base, overrides || {});
+}
+
+function loadPreCliKnowledgeUpdateSetup(ghStub, scm, mocks) {
+    return loadModule(
+        'js/preCliKnowledgeUpdateSetup.js',
+        makeRequire({
+            './configLoader.js': {
+                loadProjectConfig: function() { return {}; },
+                createScm: function() { return scm || {}; }
+            },
+            './common/githubHelpers.js': ghStub
+        }),
+        mocks || {}
+    );
+}
+
+function makeWriteTracker() {
+    var writes = [];
+    return {
+        writes: writes,
+        file_write: function(opts) { writes.push(opts); },
+        find: function(path) {
+            for (var i = 0; i < writes.length; i++) {
+                if (writes[i].path === path) return writes[i];
+            }
+            return null;
+        }
+    };
+}
+
+suite('preCliKnowledgeUpdateSetup — knowledgeDir no-op gate', function() {
+
+    test('no-ops when customParams.knowledgeDir is not set, regardless of other params', function() {
+        var tracker = makeWriteTracker();
+        var mod = loadPreCliKnowledgeUpdateSetup(makeGhStub(), {}, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        assert.equal(result.reason, 'knowledgeDir not configured');
+
+        var marker = tracker.find('input/pr_knowledge_update/knowledge_task.md');
+        assert.ok(marker, 'should still write a no-op knowledge_task.md');
+        assert.contains(marker.content, 'has not configured');
+    });
+});
+
+suite('preCliKnowledgeUpdateSetup — direct PR reference mode (customParams.prNumber)', function() {
+
+    test('fetches PR details/diff/discussions directly via scm, with no ticket involved', function() {
+        var tracker = makeWriteTracker();
+        var getPrDetailsCalls = [];
+        var getDiffTextCalls = [];
+        var fetchDiscussionsCalls = [];
+        var writePRContextCalls = [];
+
+        var scm = {
+            getDiffText: function(prId) {
+                getDiffTextCalls.push(prId);
+                return 'diff --git a/x b/x';
+            }
+        };
+
+        var gh = makeGhStub({
+            getPRDetails: function(scmArg, prId) {
+                getPrDetailsCalls.push(prId);
+                return { number: 42, html_url: 'https://example.com/pr/42', title: 'Fix thing', state: 'merged' };
+            },
+            fetchDiscussionsAndRawData: function(scmArg, prId) {
+                fetchDiscussionsCalls.push(prId);
+                return { markdown: '## Thread\nSome comment', rawThreads: { threads: [] } };
+            },
+            writePRContext: function(inputFolder, prDetails, diff, markdown, rawThreads) {
+                writePRContextCalls.push({ inputFolder: inputFolder, prDetails: prDetails, diff: diff, markdown: markdown, rawThreads: rawThreads });
+            }
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, scm, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped, 'should not be skipped when a PR reference resolves successfully');
+        assert.equal(result.prNumber, 42);
+        assert.equal(result.knowledgeDir, 'knowledge');
+
+        assert.deepEqual(getPrDetailsCalls, ['42']);
+        assert.deepEqual(getDiffTextCalls, [42]);
+        assert.deepEqual(fetchDiscussionsCalls, [42]);
+
+        assert.equal(writePRContextCalls.length, 1);
+        assert.equal(writePRContextCalls[0].diff, 'diff --git a/x b/x');
+        assert.equal(writePRContextCalls[0].markdown, '## Thread\nSome comment');
+
+        var taskMarker = tracker.find('input/pr_knowledge_update/knowledge_task.md');
+        assert.ok(taskMarker, 'should write knowledge_task.md');
+        assert.contains(taskMarker.content, 'knowledge');
+        assert.contains(taskMarker.content, '#42');
+    });
+
+    test('no-ops when the referenced PR/MR cannot be fetched', function() {
+        var tracker = makeWriteTracker();
+        var gh = makeGhStub({ getPRDetails: function() { return null; } });
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, {}, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '999' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        var marker = tracker.find('input/pr_knowledge_update/knowledge_task.md');
+        assert.ok(marker);
+        assert.contains(marker.content, 'nothing to do');
+    });
+});
+
+suite('preCliKnowledgeUpdateSetup — direct content mode (customParams.diffText / discussionsMarkdown)', function() {
+
+    test('uses supplied diff/discussions directly without touching the SCM at all', function() {
+        var tracker = makeWriteTracker();
+        var createScmCalls = 0;
+        var writePRContextCalls = [];
+
+        var gh = makeGhStub({
+            writePRContext: function(inputFolder, prDetails, diff, markdown, rawThreads) {
+                writePRContextCalls.push({ prDetails: prDetails, diff: diff, markdown: markdown });
+            }
+        });
+
+        var mod = loadModule(
+            'js/preCliKnowledgeUpdateSetup.js',
+            makeRequire({
+                './configLoader.js': {
+                    loadProjectConfig: function() { return {}; },
+                    createScm: function() { createScmCalls++; return {}; }
+                },
+                './common/githubHelpers.js': gh
+            }),
+            { file_write: tracker.file_write }
+        );
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: {
+                knowledgeDir: 'knowledge',
+                diffText: 'diff --git a/x b/x',
+                discussionsMarkdown: '## Thread\nComment',
+                prNumber: '7',
+                prUrl: 'https://example.com/pr/7'
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.equal(createScmCalls, 0, 'must not create an scm client in direct-content mode');
+        assert.equal(writePRContextCalls.length, 1);
+        assert.equal(writePRContextCalls[0].diff, 'diff --git a/x b/x');
+        assert.equal(writePRContextCalls[0].markdown, '## Thread\nComment');
+    });
+
+    test('works with diff only (no discussions supplied)', function() {
+        var tracker = makeWriteTracker();
+        var writePRContextCalls = [];
+        var gh = makeGhStub({
+            writePRContext: function(inputFolder, prDetails, diff, markdown) {
+                writePRContextCalls.push({ diff: diff, markdown: markdown });
+            }
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, {}, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', diffText: 'diff --git a/x b/x' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.equal(writePRContextCalls[0].diff, 'diff --git a/x b/x');
+        assert.ok(!writePRContextCalls[0].markdown);
+    });
+
+    test('works with discussions only (no diff supplied)', function() {
+        var tracker = makeWriteTracker();
+        var writePRContextCalls = [];
+        var gh = makeGhStub({
+            writePRContext: function(inputFolder, prDetails, diff, markdown) {
+                writePRContextCalls.push({ diff: diff, markdown: markdown });
+            }
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, {}, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', discussionsMarkdown: '## Thread\nComment' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.ok(!writePRContextCalls[0].diff);
+        assert.equal(writePRContextCalls[0].markdown, '## Thread\nComment');
+    });
+});
+
+suite('preCliKnowledgeUpdateSetup — ticket-based fallback mode', function() {
+
+    test('resolves via findMergedPRForTicket when a ticket is present and no direct PR/content params are given', function() {
+        var tracker = makeWriteTracker();
+        var findCalls = [];
+        var scm = { getDiffText: function() { return 'diff text'; } };
+        var gh = makeGhStub({
+            findMergedPRForTicket: function(scmArg, ticketKey) {
+                findCalls.push(ticketKey);
+                return { number: 55 };
+            },
+            getPRDetails: function() {
+                return { number: 55, html_url: 'https://example.com/pr/55', title: 'x', state: 'merged' };
+            },
+            fetchDiscussionsAndRawData: function() { return { markdown: 'comments', rawThreads: null }; },
+            writePRContext: function() {}
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, scm, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            ticket: { key: 'ABC-123' },
+            customParams: { knowledgeDir: 'knowledge' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.deepEqual(findCalls, ['ABC-123']);
+    });
+
+    test('no-ops when there is no direct PR reference, no direct content, and no ticket in context', function() {
+        var tracker = makeWriteTracker();
+        var gh = makeGhStub();
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, {}, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        var marker = tracker.find('input/pr_knowledge_update/knowledge_task.md');
+        assert.contains(marker.content, 'customParams.prNumber');
+    });
+});
+
+suite('preCliKnowledgeUpdateSetup — no usable material at all', function() {
+
+    test('no-ops when both diff and discussions come back empty for a resolved PR', function() {
+        var tracker = makeWriteTracker();
+        var scm = { getDiffText: function() { return null; } };
+        var gh = makeGhStub({
+            getPRDetails: function() { return { number: 42, html_url: 'x', title: 'x', state: 'merged' }; },
+            fetchDiscussionsAndRawData: function() { return { markdown: null, rawThreads: null }; },
+            writePRContext: function() {}
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, scm, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        assert.equal(result.reason, 'no diff or discussions available');
+    });
+});

--- a/js/unit-tests/test_pushKnowledgeUpdate.js
+++ b/js/unit-tests/test_pushKnowledgeUpdate.js
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for js/pushKnowledgeUpdate.js
+ *
+ * Scope: the knowledgeDir no-op gate, the "no changes to push" no-op path, and
+ * the branch/commit naming — which is derived from customParams.prNumber (or a
+ * timestamp fallback when no PR number is available, e.g. a direct-content-only
+ * run) since this action is not tracker-bound.
+ */
+
+function loadPushKnowledgeUpdate(cliCalls) {
+    return loadModule(
+        'js/pushKnowledgeUpdate.js',
+        makeRequire({
+            './configLoader.js': { loadProjectConfig: function() { return {}; } },
+            './config.js': configModule,
+            'config': configModule
+        }),
+        {
+            cli_execute_command: function(opts) {
+                cliCalls.push(opts.command);
+                if (opts.command.indexOf('git status --porcelain') === 0) {
+                    return cliCalls.__statusOutput || '';
+                }
+                return '';
+            }
+        }
+    );
+}
+
+suite('pushKnowledgeUpdate — knowledgeDir no-op gate', function() {
+
+    test('no-ops when customParams.knowledgeDir is not configured', function() {
+        var cliCalls = [];
+        var mod = loadPushKnowledgeUpdate(cliCalls);
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        assert.equal(cliCalls.length, 0, 'must not run any git command when knowledgeDir is unset');
+    });
+});
+
+suite('pushKnowledgeUpdate — no changes to push', function() {
+
+    test('no-ops when git status reports no changes under knowledgeDir', function() {
+        var cliCalls = [];
+        var mod = loadModule(
+            'js/pushKnowledgeUpdate.js',
+            makeRequire({
+                './configLoader.js': { loadProjectConfig: function() { return {}; } },
+                './config.js': configModule,
+                'config': configModule
+            }),
+            {
+                cli_execute_command: function(opts) {
+                    cliCalls.push(opts.command);
+                    return ''; // empty status → nothing changed
+                }
+            }
+        );
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        assert.equal(cliCalls.length, 1, 'should only check git status, nothing else');
+        assert.contains(cliCalls[0], 'git status --porcelain');
+    });
+});
+
+suite('pushKnowledgeUpdate — commits and pushes changes', function() {
+
+    function loadWithStatus(statusOutput) {
+        var cliCalls = [];
+        var mod = loadModule(
+            'js/pushKnowledgeUpdate.js',
+            makeRequire({
+                './configLoader.js': { loadProjectConfig: function() { return {}; } },
+                './config.js': configModule,
+                'config': configModule
+            }),
+            {
+                cli_execute_command: function(opts) {
+                    cliCalls.push(opts.command);
+                    if (opts.command.indexOf('git status --porcelain') === 0) return statusOutput;
+                    return '';
+                }
+            }
+        );
+        return { mod: mod, cliCalls: cliCalls };
+    }
+
+    test('branch/commit names are derived from customParams.prNumber when present', function() {
+        var loaded = loadWithStatus(' M knowledge/heuristics/foo.md\n');
+
+        var result = loaded.mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '42' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.equal(result.branchName, 'knowledge/pr-42-review-lessons');
+
+        var checkoutCall = loaded.cliCalls.filter(function(c) { return c.indexOf('git checkout -b') === 0; })[0];
+        assert.contains(checkoutCall, 'knowledge/pr-42-review-lessons');
+
+        var commitCall = loaded.cliCalls.filter(function(c) { return c.indexOf('git commit') === 0; })[0];
+        assert.contains(commitCall, 'pr-42');
+
+        var addCall = loaded.cliCalls.filter(function(c) { return c.indexOf('git add') === 0; })[0];
+        assert.contains(addCall, 'knowledge');
+
+        var pushCall = loaded.cliCalls.filter(function(c) { return c.indexOf('git push') === 0; })[0];
+        assert.contains(pushCall, 'knowledge/pr-42-review-lessons');
+    });
+
+    test('falls back to a timestamp-based branch name when no prNumber is available (direct-content-only run)', function() {
+        var loaded = loadWithStatus(' M knowledge/heuristics/foo.md\n');
+
+        var result = loaded.mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', diffText: 'diff --git a/x b/x' }
+        });
+
+        assert.equal(result.success, true);
+        assert.ok(!result.skipped);
+        assert.ok(/^knowledge\/update-\d{14}-review-lessons$/.test(result.branchName),
+            'expected a timestamp-based branch name, got: ' + result.branchName);
+    });
+
+    test('only stages the knowledgeDir path, not the whole working tree', function() {
+        var loaded = loadWithStatus(' M knowledge/heuristics/foo.md\n');
+
+        loaded.mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: { knowledgeDir: 'knowledge', prNumber: '7' }
+        });
+
+        var addCalls = loaded.cliCalls.filter(function(c) { return c.indexOf('git add') === 0; });
+        assert.equal(addCalls.length, 1);
+        assert.equal(addCalls[0], 'git add -- "knowledge"');
+    });
+});

--- a/js/unit-tests/test_resolveRepoFromTicket.js
+++ b/js/unit-tests/test_resolveRepoFromTicket.js
@@ -5,11 +5,11 @@
 var GROUPED_REPOS_JSON = JSON.stringify({
     git: { userName: 'AI', userEmail: 'ai@test.com' },
     repositories: {
-        'gens-sup': [
-            { provider: 'gitlab', repo: 'sample-db', gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'gens-igt',    gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'lims-ui',     gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'ultraqc',     gitlabGroup: 'gens-sup/develop', branch: 'master'  }
+        'acme-org': [
+            { provider: 'gitlab', repo: 'core-db', gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'service-api',    gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'web-ui',     gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'qa-tools',     gitlabGroup: 'acme-org/develop', branch: 'master'  }
         ]
     }
 });
@@ -47,15 +47,15 @@ suite('resolveRepoFromTicket — STRATEGIES.fromSummary', function() {
 
     test('extracts repo name from [bracket] at start of summary', function() {
         var mod = makeModule();
-        var ticket = { key: 'X-1', fields: { summary: '[gens-igt] Create PacBio WF' } };
+        var ticket = { key: 'X-1', fields: { summary: '[service-api] Create Create webhook' } };
         var name = mod.STRATEGIES.fromSummary(ticket);
-        assert.equal(name, 'gens-igt', 'repo name extracted');
+        assert.equal(name, 'service-api', 'repo name extracted');
     });
 
     test('handles hyphenated and dotted repo names', function() {
         var mod = makeModule();
-        var ticket = { key: 'X-2', fields: { summary: '[sample-db] Migrate schema' } };
-        assert.equal(mod.STRATEGIES.fromSummary(ticket), 'sample-db', 'hyphenated name');
+        var ticket = { key: 'X-2', fields: { summary: '[core-db] Migrate schema' } };
+        assert.equal(mod.STRATEGIES.fromSummary(ticket), 'core-db', 'hyphenated name');
     });
 
     test('returns null when summary has no leading bracket', function() {
@@ -83,15 +83,15 @@ suite('resolveRepoFromTicket — findRepoEntry', function() {
 
     test('finds repo in grouped repositories structure', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
-        var entry = mod.findRepoEntry('gens-igt');
+        var entry = mod.findRepoEntry('service-api');
         assert.equal(entry !== null, true, 'entry found');
         assert.equal(entry.branch, 'develop', 'correct branch');
-        assert.equal(entry.gitlabGroup, 'gens-sup/develop', 'correct group');
+        assert.equal(entry.gitlabGroup, 'acme-org/develop', 'correct group');
     });
 
     test('finds repo with non-default branch in grouped structure', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
-        var entry = mod.findRepoEntry('ultraqc');
+        var entry = mod.findRepoEntry('qa-tools');
         assert.equal(entry.branch, 'master', 'master branch resolved');
     });
 
@@ -134,15 +134,15 @@ suite('resolveRepoFromTicket — action', function() {
     test('writes targetRepository to params.customParams when repo found in file', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-1', fields: { summary: '[gens-igt] Create feature' } }
+            ticket: { key: 'PROJ-1', fields: { summary: '[service-api] Create feature' } }
         };
         var result = mod.action(params);
         assert.equal(result, true, 'returns true (continue)');
         assert.equal(params.customParams !== null && params.customParams !== undefined, true, 'customParams created');
-        assert.equal(params.customParams.targetRepository.repo, 'gens-igt', 'repo name set');
+        assert.equal(params.customParams.targetRepository.repo, 'service-api', 'repo name set');
         assert.equal(params.customParams.targetRepository.baseBranch, 'develop', 'baseBranch from file');
-        assert.equal(params.customParams.targetRepository.owner, 'gens-sup/develop', 'owner from file');
-        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/gens-igt', 'default workingDir derived');
+        assert.equal(params.customParams.targetRepository.owner, 'acme-org/develop', 'owner from file');
+        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/service-api', 'default workingDir derived');
     });
 
     test('writes only repoName when repo not found in repositories file', function() {
@@ -175,11 +175,11 @@ suite('resolveRepoFromTicket — action', function() {
     test('uses fromSummary strategy by default', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-5', fields: { summary: '[lims-ui] Add filter' } },
+            ticket: { key: 'PROJ-5', fields: { summary: '[web-ui] Add filter' } },
             customParams: {}
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.repo, 'lims-ui', 'default strategy resolves from summary');
+        assert.equal(params.customParams.targetRepository.repo, 'web-ui', 'default strategy resolves from summary');
     });
 
     test('uses custom repositoriesFile from customParams', function() {
@@ -195,21 +195,21 @@ suite('resolveRepoFromTicket — action', function() {
     test('derives workingDir from dependenciesDir/repoName by default', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-11', fields: { summary: '[sample-db] Schema' } },
+            ticket: { key: 'PROJ-11', fields: { summary: '[core-db] Schema' } },
             customParams: {}
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/sample-db', 'default workingDir');
+        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/core-db', 'default workingDir');
     });
 
     test('respects custom dependenciesDir from customParams', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-12', fields: { summary: '[lims-ui] Feature' } },
+            ticket: { key: 'PROJ-12', fields: { summary: '[web-ui] Feature' } },
             customParams: { dependenciesDir: '/workspace/repos' }
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.workingDir, '/workspace/repos/lims-ui', 'custom dependenciesDir used');
+        assert.equal(params.customParams.targetRepository.workingDir, '/workspace/repos/web-ui', 'custom dependenciesDir used');
     });
 
     test('returns true for unknown strategy (graceful skip)', function() {
@@ -225,34 +225,34 @@ suite('resolveRepoFromTicket — action', function() {
     test('also writes targetRepository into params.jobParams.customParams for postJSAction path', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-9', fields: { summary: '[gens-igt] Feature' } },
+            ticket: { key: 'PROJ-9', fields: { summary: '[service-api] Feature' } },
             jobParams: { customParams: { existingKey: 'value' } }
         };
         mod.action(params);
-        assert.equal(params.jobParams.customParams.targetRepository.repo, 'gens-igt', 'jobParams.customParams.targetRepository set');
+        assert.equal(params.jobParams.customParams.targetRepository.repo, 'service-api', 'jobParams.customParams.targetRepository set');
         assert.equal(params.jobParams.customParams.existingKey, 'value', 'existing jobParams.customParams fields preserved');
     });
 
     test('creates params.jobParams.customParams if absent', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-10', fields: { summary: '[lims-ui] Fix' } },
+            ticket: { key: 'PROJ-10', fields: { summary: '[web-ui] Fix' } },
             jobParams: {}
         };
         mod.action(params);
-        assert.equal(params.jobParams.customParams.targetRepository.repo, 'lims-ui', 'targetRepository created in jobParams.customParams');
+        assert.equal(params.jobParams.customParams.targetRepository.repo, 'web-ui', 'targetRepository created in jobParams.customParams');
     });
 
     test('preserves existing customParams fields while adding targetRepository', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-8', fields: { summary: '[sample-db] Schema' } },
+            ticket: { key: 'PROJ-8', fields: { summary: '[core-db] Schema' } },
             customParams: { blocksRelationship: 'Blocks', labels: ['development'] }
         };
         mod.action(params);
         assert.equal(params.customParams.blocksRelationship, 'Blocks', 'existing fields preserved');
         assert.deepEqual(params.customParams.labels, ['development'], 'labels preserved');
-        assert.equal(params.customParams.targetRepository.repo, 'sample-db', 'targetRepository added');
+        assert.equal(params.customParams.targetRepository.repo, 'core-db', 'targetRepository added');
     });
 });
 

--- a/js/unit-tests/test_writeSolutionAndLabels.js
+++ b/js/unit-tests/test_writeSolutionAndLabels.js
@@ -77,14 +77,14 @@ suite('writeSolutionAndLabels — topologicalSort', function() {
     test('returns items with no deps first', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'lims-ui', reason: 'UI', depends_on: ['gens-igt'] },
-            { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] },
-            { name: 'sample-db', reason: 'DB' }
+            { name: 'web-ui', reason: 'UI', depends_on: ['service-api'] },
+            { name: 'service-api', reason: 'API', depends_on: ['core-db'] },
+            { name: 'core-db', reason: 'DB' }
         ];
         var sorted = mod.topologicalSort(repos);
         var names = sorted.map(function(r) { return r.name; });
-        assert.equal(names.indexOf('sample-db') < names.indexOf('gens-igt'), true, 'sample-db before gens-igt');
-        assert.equal(names.indexOf('gens-igt') < names.indexOf('lims-ui'), true, 'gens-igt before lims-ui');
+        assert.equal(names.indexOf('core-db') < names.indexOf('service-api'), true, 'core-db before service-api');
+        assert.equal(names.indexOf('service-api') < names.indexOf('web-ui'), true, 'service-api before web-ui');
     });
 
     test('handles plain strings', function() {
@@ -99,13 +99,13 @@ suite('writeSolutionAndLabels — buildJiraSection', function() {
     test('produces wiki table with || headers and {code:json|title=affected_repos} anchor', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'sample-db', reason: 'DB migration' },
-            { name: 'gens-igt', reason: 'API change', depends_on: ['sample-db'] }
+            { name: 'core-db', reason: 'DB migration' },
+            { name: 'service-api', reason: 'API change', depends_on: ['core-db'] }
         ];
         var section = mod.buildJiraSection(repos);
         assert.equal(section.indexOf('|| # ||') !== -1, true, 'Jira table header');
         assert.equal(section.indexOf('{code:json|title=affected_repos}') !== -1, true, 'JSON anchor present');
-        assert.equal(section.indexOf('sample-db --> gens-igt') !== -1, true, 'mermaid edge present');
+        assert.equal(section.indexOf('core-db --> service-api') !== -1, true, 'mermaid edge present');
         assert.equal(section.indexOf('----') !== -1, true, 'section delimiters');
         assert.equal(section.indexOf('{code:mermaid}'), -1, '{code:mermaid} must NOT be used (Jira Server does not support mermaid formatter)');
         assert.equal(section.indexOf('{code}') !== -1, true, 'plain {code} block used for diagram');
@@ -122,8 +122,8 @@ suite('writeSolutionAndLabels — buildMarkdownSection', function() {
     test('produces markdown table with --- delimiters and json code block', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'sample-db', reason: 'DB migration' },
-            { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] }
+            { name: 'core-db', reason: 'DB migration' },
+            { name: 'service-api', reason: 'API', depends_on: ['core-db'] }
         ];
         var section = mod.buildMarkdownSection(repos);
         assert.equal(section.indexOf('| # | Repository |') !== -1, true, 'markdown table header');
@@ -139,7 +139,7 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         var module = makeLabelsModule(
             {
                 'outputs/response.md': 'h2. Solution',
-                'outputs/affected_repos.json': '["gens-igt","admin-ui","sample-db"]'
+                'outputs/affected_repos.json': '["service-api","admin-portal","core-db"]'
             },
             {
                 jira_add_label: function(opts) { addedLabels.push(opts.label); }
@@ -152,17 +152,17 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         });
 
         assert.equal(result.success, true, 'action succeeds');
-        assert.equal(addedLabels.indexOf('gens-igt') !== -1, true, 'gens-igt label added');
-        assert.equal(addedLabels.indexOf('admin-ui') !== -1, true, 'admin-ui label added');
-        assert.equal(addedLabels.indexOf('sample-db') !== -1, true, 'sample-db label added');
+        assert.equal(addedLabels.indexOf('service-api') !== -1, true, 'service-api label added');
+        assert.equal(addedLabels.indexOf('admin-portal') !== -1, true, 'admin-portal label added');
+        assert.equal(addedLabels.indexOf('core-db') !== -1, true, 'core-db label added');
     });
 
     test('adds a label for each repo — enriched object format with name+reason+depends_on', function() {
         var addedLabels = [];
         var enriched = JSON.stringify([
-            { name: 'sample-db', reason: 'DB migration required.' },
-            { name: 'gens-igt', reason: 'New API endpoint.', depends_on: ['sample-db'] },
-            { name: 'lims-ui', reason: 'UI column update.', depends_on: ['gens-igt'] }
+            { name: 'core-db', reason: 'DB migration required.' },
+            { name: 'service-api', reason: 'New API endpoint.', depends_on: ['core-db'] },
+            { name: 'web-ui', reason: 'UI column update.', depends_on: ['service-api'] }
         ]);
         var module = makeLabelsModule(
             {
@@ -180,9 +180,9 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         });
 
         assert.equal(result.success, true, 'action succeeds');
-        assert.equal(addedLabels.indexOf('sample-db') !== -1, true, 'sample-db label added');
-        assert.equal(addedLabels.indexOf('gens-igt') !== -1, true, 'gens-igt label added');
-        assert.equal(addedLabels.indexOf('lims-ui') !== -1, true, 'lims-ui label added');
+        assert.equal(addedLabels.indexOf('core-db') !== -1, true, 'core-db label added');
+        assert.equal(addedLabels.indexOf('service-api') !== -1, true, 'service-api label added');
+        assert.equal(addedLabels.indexOf('web-ui') !== -1, true, 'web-ui label added');
     });
 
     test('skips labels gracefully when affected_repos.json is missing', function() {
@@ -233,8 +233,8 @@ suite('writeSolutionAndLabels — repo label flow', function() {
             {
                 'outputs/response.md': 'h2. Solution Design\n\nFull solution text.',
                 'outputs/affected_repos.json': JSON.stringify([
-                    { name: 'sample-db', reason: 'DB migration' },
-                    { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] }
+                    { name: 'core-db', reason: 'DB migration' },
+                    { name: 'service-api', reason: 'API', depends_on: ['core-db'] }
                 ])
             },
             {
@@ -263,7 +263,7 @@ suite('writeSolutionAndLabels — repo label flow', function() {
             {
                 'outputs/response.md': 'h2. Solution Design\n\nFull solution text.',
                 'outputs/affected_repos.json': JSON.stringify([
-                    { name: 'sample-db', reason: 'DB migration' }
+                    { name: 'core-db', reason: 'DB migration' }
                 ])
             },
             {

--- a/pr_knowledge_update.json
+++ b/pr_knowledge_update.json
@@ -2,7 +2,8 @@
   "name": "CliAgent",
   "params": {
     "metadata": {
-      "contextId": "pr_knowledge_update"
+      "contextId": "pr_knowledge_update",
+      "usage": "dmtools run agents/pr_knowledge_update.json --customParams '{\"knowledgeDir\":\"<path>\",\"prNumber\":\"<pr-or-mr-number>\"}'"
     },
     "cliCommands": [
       "./agents/scripts/run-agent.sh"
@@ -14,10 +15,7 @@
     },
     "preCliJSAction": "agents/js/preCliKnowledgeUpdateSetup.js",
     "postJSAction": "agents/js/pushKnowledgeUpdate.js",
-    "customParams": {
-      "removeLabel": "sm_knowledge_update_triggered"
-    },
-    "inputJql": "key = PROJ-1",
+    "customParams": {},
     "cliPrompts": [
       "Senior Engineer maintaining a self-curated review-knowledge base",
       "./agents/instructions/common/agent_task_preamble.md",

--- a/pr_knowledge_update.json
+++ b/pr_knowledge_update.json
@@ -1,0 +1,30 @@
+{
+  "name": "CliAgent",
+  "params": {
+    "metadata": {
+      "contextId": "pr_knowledge_update"
+    },
+    "cliCommands": [
+      "./agents/scripts/run-agent.sh"
+    ],
+    "outputType": "none",
+    "cleanupInputFolder": false,
+    "envVariables": {
+      "CLI_ALLOWED_COMMANDS": "find,ls,cat,mkdir,bash,run-agent.sh"
+    },
+    "preCliJSAction": "agents/js/preCliKnowledgeUpdateSetup.js",
+    "postJSAction": "agents/js/pushKnowledgeUpdate.js",
+    "customParams": {
+      "removeLabel": "sm_knowledge_update_triggered"
+    },
+    "inputJql": "key = PROJ-1",
+    "cliPrompts": [
+      "Senior Engineer maintaining a self-curated review-knowledge base",
+      "./agents/instructions/common/agent_task_preamble.md",
+      "./agents/instructions/knowledge_update/general_guidelines.md",
+      "./agents/instructions/knowledge_update/output_rules.md",
+      "./agents/instructions/common/dmtools_cli.md",
+      "./agents/prompts/bash_tools.md"
+    ]
+  }
+}

--- a/sm.json
+++ b/sm.json
@@ -176,15 +176,6 @@
           "localExecution": true
         },
         {
-          "description": "Merged Stories & Bugs → distill review-knowledge lessons (no-op unless repo-agent config sets customParams.knowledgeDir)",
-          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('Merged') AND (labels is EMPTY OR labels NOT IN ('sm_knowledge_update_triggered'))",
-          "configFile": "agents/pr_knowledge_update.json",
-          "skipIfLabel": "sm_knowledge_update_triggered",
-          "addLabel": "sm_knowledge_update_triggered",
-          "enabled": true,
-          "localExecution": true
-        },
-        {
           "description": "Ready For Testing Bugs → generate test cases",
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Ready For Testing') AND (labels is EMPTY OR labels NOT IN ('sm_bug_test_cases_triggered'))",
           "configFile": "agents/bug_test_cases_generator.json",

--- a/sm.json
+++ b/sm.json
@@ -176,6 +176,15 @@
           "localExecution": true
         },
         {
+          "description": "Merged Stories & Bugs → distill review-knowledge lessons (no-op unless repo-agent config sets customParams.knowledgeDir)",
+          "jql": "project = {jiraProject} AND issuetype in ('Story', 'Bug') AND status in ('Merged') AND (labels is EMPTY OR labels NOT IN ('sm_knowledge_update_triggered'))",
+          "configFile": "agents/pr_knowledge_update.json",
+          "skipIfLabel": "sm_knowledge_update_triggered",
+          "addLabel": "sm_knowledge_update_triggered",
+          "enabled": true,
+          "localExecution": true
+        },
+        {
           "description": "Ready For Testing Bugs → generate test cases",
           "jql": "project = {jiraProject} AND issuetype in ('Bug') AND status in ('Ready For Testing') AND (labels is EMPTY OR labels NOT IN ('sm_bug_test_cases_triggered'))",
           "configFile": "agents/bug_test_cases_generator.json",


### PR DESCRIPTION
## Summary
Adds a repo-agnostic `CliAgent` job that triggers when a Story/Bug ticket reaches **Merged** status and, if the consuming repo-agent config sets `customParams.knowledgeDir`, distills the merged PR/MR's review-thread lessons into an atomic `heuristics/*.md` + `MOC.md` knowledge base under that configured directory.

**No repo-specific logic lives in `dmtools-agents`.** `knowledgeDir` is unset/no-op by default, following the same established pattern as `baseBranchResolverFnPath`/`snapshotBranchResolverFnPath`. Any consuming repo wires its own `knowledgeDir` path in its own repo-agent config — `dmtools-agents` itself stays fully generic.

## Changes
- `js/common/githubHelpers.js`: `findMergedPRForTicket(scm, ticketKey)` — searches **closed** PRs/MRs (unlike `findPRForTicket`, open-only) and returns the most-recently-merged match.
- `js/common/scm.js`: `getDiffText(prId)` on all 3 providers — uses the PR/MR API's raw-diff-text endpoint (`github_get_pr_diff_text` / `gitlab_get_mr_diff_text`) instead of local `git diff`, since the head branch is often deleted post-merge. ADO has no equivalent API and returns `null`.
- `js/preCliKnowledgeUpdateSetup.js` (preCliJSAction): resolves the merged PR, writes `pr_info.md`/`pr_diff.txt`/`pr_discussions*.md/json` + `knowledge_task.md`; clean no-op when `knowledgeDir` isn't configured.
- `js/pushKnowledgeUpdate.js` (postJSAction): commits+pushes only `knowledgeDir` changes to a new `knowledge/<ticket>-review-lessons` branch; no-op if nothing changed. MR creation intentionally left to a human.
- `pr_knowledge_update.json`: new generic `CliAgent` config wiring the hooks + new prompts.
- `instructions/knowledge_update/general_guidelines.md`, `output_rules.md`: generic distillation protocol (extract, generalize, mandatory search-before-create dedup, reinforce/create, summarize).
- `sm.json`: new generic "Merged Stories & Bugs -> distill review-knowledge lessons" rule (`skipIfLabel`/`addLabel`, matching neighboring Merged-status rules).
- `js/unit-tests/test_githubHelpers.js`: new tests for `findMergedPRForTicket` and `getDiffText` (all 3 providers).

## Verification
- `dmtools run js/unit-tests/run_all.json` -> 703 passed, 0 failed.
- `js/agentValidator.js` `validateAll` -> `pr_knowledge_update.json` valid; no new failures vs. baseline (23 pre-existing unrelated failures untouched).
