### PR TITLE
test: remove gens-* org/repo references from unit test fixtures

### DIFF
--- a/js/resolveRepoFromTicket.js
+++ b/js/resolveRepoFromTicket.js
@@ -7,7 +7,7 @@
  *
  * Strategy (customParams.repoNameStrategy, default: 'fromSummary'):
  *   fromSummary — parses the leading [bracket-tag] from ticket summary, e.g.
- *                 "[gens-igt] Create PacBio WF" → "gens-igt"
+ *                 "[payments-api] Create webhook" → "payments-api"
  *
  * Additional strategies can be registered in STRATEGIES by extending this file
  * in the future (e.g. fromLabel, fromCustomField).

--- a/js/unit-tests/test_createRepoTasks.js
+++ b/js/unit-tests/test_createRepoTasks.js
@@ -62,8 +62,8 @@ suite('createRepoTasks — parseAffectedRepos', function() {
 
 suite('createRepoTasks — action', function() {
     var reposJson = JSON.stringify([
-        { name: 'sample-db', reason: 'DB migration' },
-        { name: 'gens-igt',    reason: 'API change', depends_on: ['sample-db'] }
+        { name: 'core-db', reason: 'DB migration' },
+        { name: 'service-api',    reason: 'API change', depends_on: ['core-db'] }
     ]);
     var description = 'Solution text\n\n{code:json|title=affected_repos}\n' + reposJson + '\n{code}\n\n----';
 
@@ -71,32 +71,32 @@ suite('createRepoTasks — action', function() {
         var created = [];
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Build PacBio workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function(opts) {
                 created.push(opts);
-                return '{"key":"GENSGENP-' + (200 + created.length) + '"}';
+                return '{"key":"PROJ-' + (200 + created.length) + '"}';
             },
             jira_link_issues: function() {},
             jira_move_to_status: function() {},
             jira_post_comment: function() {}
         });
 
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
 
         assert.equal(result.success, true, 'succeeds');
         assert.equal(created.length, 2, 'two sub-tasks created');
-        assert.equal(created[0].parentKey, 'GENSGENP-50', 'parent is story');
+        assert.equal(created[0].parentKey, 'PROJ-50', 'parent is story');
         assert.equal(created[0].issueType, 'Sub-task', 'issueType is Sub-task');
-        assert.equal(created[0].summary.indexOf('[sample-db]') === 0, true, 'summary starts with [repo]');
+        assert.equal(created[0].summary.indexOf('[core-db]') === 0, true, 'summary starts with [repo]');
         assert.equal(created[0].summary.indexOf('Build PacBio workflow') !== -1, true, 'parent summary in subtask summary');
-        assert.equal(created[0].description.indexOf('sample-db') !== -1, true, 'repo name in description');
-        assert.equal(created[0].description.indexOf('GENSGENP-100') !== -1, true, 'SA ticket link in description');
-        assert.equal(created[0].description.indexOf('GENSGENP-50') !== -1, true, 'parent link in description');
+        assert.equal(created[0].description.indexOf('core-db') !== -1, true, 'repo name in description');
+        assert.equal(created[0].description.indexOf('PROJ-100') !== -1, true, 'SA ticket link in description');
+        assert.equal(created[0].description.indexOf('PROJ-50') !== -1, true, 'parent link in description');
         assert.deepEqual(created[0].labels, ['development'], 'default development label set');
     });
 
@@ -106,30 +106,30 @@ suite('createRepoTasks — action', function() {
         var ticketCounter = 200;
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Build PacBio workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function() {
                 ticketCounter++;
-                return '{"key":"GENSGENP-' + ticketCounter + '"}';
+                return '{"key":"PROJ-' + ticketCounter + '"}';
             },
             jira_link_issues: function(opts) { links.push(opts); },
             jira_move_to_status: function(opts) { moved.push(opts); },
             jira_post_comment: function() {}
         });
 
-        mod.action({ ticket: { key: 'GENSGENP-100' } });
+        mod.action({ ticket: { key: 'PROJ-100' } });
 
-        // gens-igt depends_on sample-db → sample-db (GENSGENP-201) blocks gens-igt (GENSGENP-202)
+        // service-api depends_on core-db → core-db (PROJ-201) blocks service-api (PROJ-202)
         assert.equal(links.length, 1, 'one Blocks link created');
         assert.equal(links[0].relationship, 'Blocks', 'relationship is Blocks');
-        assert.equal(links[0].sourceKey, 'GENSGENP-201', 'blocker is sample-db ticket');
-        assert.equal(links[0].anotherKey, 'GENSGENP-202', 'dependent is gens-igt ticket');
+        assert.equal(links[0].sourceKey, 'PROJ-201', 'blocker is core-db ticket');
+        assert.equal(links[0].anotherKey, 'PROJ-202', 'dependent is service-api ticket');
         assert.equal(moved.length, 1, 'one ticket moved to Blocked');
-        assert.equal(moved[0].key, 'GENSGENP-202', 'gens-igt moved to Blocked');
+        assert.equal(moved[0].key, 'PROJ-202', 'service-api moved to Blocked');
         assert.equal(moved[0].statusName, 'Blocked', 'status is Blocked');
     });
 
@@ -139,15 +139,15 @@ suite('createRepoTasks — action', function() {
         var ticketCounter = 300;
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Story' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function() {
                 ticketCounter++;
-                return '{"key":"GENSGENP-' + ticketCounter + '"}';
+                return '{"key":"PROJ-' + ticketCounter + '"}';
             },
             jira_link_issues: function(opts) { links.push(opts); },
             jira_move_to_status: function(opts) { moved.push(opts); },
@@ -155,7 +155,7 @@ suite('createRepoTasks — action', function() {
         });
 
         mod.action({
-            ticket: { key: 'GENSGENP-100' },
+            ticket: { key: 'PROJ-100' },
             customParams: { blocksRelationship: 'is blocked by', blockedStatus: 'On Hold' }
         });
 
@@ -168,24 +168,24 @@ suite('createRepoTasks — action', function() {
         var created = [];
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: description, parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Parent story' } };
             },
             jira_search_by_jql: function() {
-                return [{ fields: { summary: '[sample-db] Parent story' } }]; // already exists
+                return [{ fields: { summary: '[core-db] Parent story' } }]; // already exists
             },
-            jira_create_ticket_with_parent: function(opts) { created.push(opts); return '{"key":"GENSGENP-201"}'; },
+            jira_create_ticket_with_parent: function(opts) { created.push(opts); return '{"key":"PROJ-201"}'; },
             jira_post_comment: function() {}
         });
 
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
 
         assert.equal(result.success, true, 'succeeds');
-        assert.equal(created.length, 1, 'only one created (sample-db skipped)');
+        assert.equal(created.length, 1, 'only one created (core-db skipped)');
         assert.equal(result.skipped, 1, 'one skipped');
-        assert.equal(created[0].summary.indexOf('[gens-igt]') === 0, true, 'gens-igt was created');
+        assert.equal(created[0].summary.indexOf('[service-api]') === 0, true, 'service-api was created');
     });
 
     test('returns error when SA ticket has no parent', function() {
@@ -194,7 +194,7 @@ suite('createRepoTasks — action', function() {
                 return { fields: { description: description, parent: null } };
             }
         });
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
         assert.equal(result.success, false, 'fails without parent');
         assert.equal(result.error.indexOf('no parent') !== -1, true, 'error mentions parent');
     });
@@ -202,13 +202,13 @@ suite('createRepoTasks — action', function() {
     test('returns error when no affected_repos block in description', function() {
         var mod = makeModule({
             jira_get_ticket: function(opts) {
-                if (opts.key === 'GENSGENP-100') {
-                    return { fields: { description: 'Just some text, no repos block', parent: { key: 'GENSGENP-50' } } };
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: 'Just some text, no repos block', parent: { key: 'PROJ-50' } } };
                 }
                 return { fields: { summary: 'Parent story' } };
             }
         });
-        var result = mod.action({ ticket: { key: 'GENSGENP-100' } });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
         assert.equal(result.success, false, 'fails without repos block');
     });
 

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -401,11 +401,11 @@ suite('scm GitLab provider', function() {
         var failed = scmModule._normalizeGitLabCommitStatus({
             name: 'sonar-tests/Merge requests check',
             status: 'failed',
-            target_url: 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/'
+            target_url: 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/'
         });
         assert.equal(failed.name, 'sonar-tests/Merge requests check');
         assert.equal(failed.conclusion, 'failure');
-        assert.equal(failed.details_url, 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/');
+        assert.equal(failed.details_url, 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/');
 
         var succeeded = scmModule._normalizeGitLabCommitStatus({ name: 'ai-teammate', status: 'success' });
         assert.equal(succeeded.conclusion, 'success');
@@ -423,17 +423,17 @@ suite('scm GitLab provider', function() {
             gitlab_get_commit_statuses: function(args) {
                 calledArgs = args;
                 return JSON.stringify([
-                    { name: 'sonar-tests/Merge requests check', status: 'failed', target_url: 'https://jenkins.ci.genosity.com/job/sonar-tests/job/Merge%20requests%20check/23681/' },
-                    { name: 'ai-teammate', status: 'success', target_url: 'https://git.epam.com/gens-sup/ai-teammate/-/pipelines/1' }
+                    { name: 'sonar-tests/Merge requests check', status: 'failed', target_url: 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/' },
+                    { name: 'ai-teammate', status: 'success', target_url: 'https://git.epam.com/acme-org/ai-teammate/-/pipelines/1' }
                 ]);
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var runs = provider.getCommitCheckRuns('7b74c0eb5f0fdfa3d18472d3c55e91235a0924aa');
 
-        assert.equal(calledArgs.workspace, 'gens-sup/develop');
-        assert.equal(calledArgs.repository, 'gens-igt');
+        assert.equal(calledArgs.workspace, 'acme-org/develop');
+        assert.equal(calledArgs.repository, 'service-api');
         assert.equal(calledArgs.commitSha, '7b74c0eb5f0fdfa3d18472d3c55e91235a0924aa');
         assert.equal(runs.length, 2);
         assert.equal(runs[0].conclusion, 'failure');
@@ -444,7 +444,7 @@ suite('scm GitLab provider', function() {
         var scmModule = loadScm({
             gitlab_get_commit_statuses: function() { return '[]'; }
         });
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         assert.equal(provider.getCommitCheckRuns('deadbeef'), null);
     });
 
@@ -452,7 +452,7 @@ suite('scm GitLab provider', function() {
         var scmModule = loadScm({
             gitlab_get_commit_statuses: function() { throw new Error('boom'); }
         });
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         assert.equal(provider.getCommitCheckRuns('deadbeef'), null);
     });
 
@@ -765,7 +765,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function() { throw new Error('git diff should not be called'); }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return diff from new tool');
@@ -783,7 +783,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should fall back to legacy tool result');
@@ -802,7 +802,7 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function(args) { gitCalls.push(args.command); return ''; }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
         var diff = provider.getPrDiff('7860');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable diff');
@@ -835,8 +835,8 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        var diff = provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        var diff = provider.getPrDiff('7860', './dependencies/service-api');
 
         assert.ok(diff.indexOf('diff --git') !== -1, 'should return usable local diff');
         assert.equal(mrDiffCalls.length, 1);
@@ -859,10 +859,10 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        provider.getPrDiff('7860', './dependencies/service-api');
 
-        assert.equal(gitOpts[0].workingDirectory, './dependencies/gens-igt', 'should run git diff in the checked-out repo dir');
+        assert.equal(gitOpts[0].workingDirectory, './dependencies/service-api', 'should run git diff in the checked-out repo dir');
     });
 
     test('returns raw (unusable) value when both MCP diff and local git diff fail', function() {
@@ -873,8 +873,8 @@ suite('scm GitLab provider getPrDiff fallback', function() {
             cli_execute_command: function() { throw new Error('should not be called without diff_refs'); }
         });
 
-        var provider = scmModule._createGitLabProvider('gens-sup/develop', 'gens-igt');
-        var diff = provider.getPrDiff('7860', './dependencies/gens-igt');
+        var provider = scmModule._createGitLabProvider('acme-org/develop', 'service-api');
+        var diff = provider.getPrDiff('7860', './dependencies/service-api');
 
         assert.equal(diff, 'com.github.istin.dmtools.gitlab.GitLab$4@b2c4a8b', 'should fall back to raw value, not throw');
     });

--- a/js/unit-tests/test_resolveRepoFromTicket.js
+++ b/js/unit-tests/test_resolveRepoFromTicket.js
@@ -5,11 +5,11 @@
 var GROUPED_REPOS_JSON = JSON.stringify({
     git: { userName: 'AI', userEmail: 'ai@test.com' },
     repositories: {
-        'gens-sup': [
-            { provider: 'gitlab', repo: 'sample-db', gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'gens-igt',    gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'lims-ui',     gitlabGroup: 'gens-sup/develop', branch: 'develop' },
-            { provider: 'gitlab', repo: 'ultraqc',     gitlabGroup: 'gens-sup/develop', branch: 'master'  }
+        'acme-org': [
+            { provider: 'gitlab', repo: 'core-db', gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'service-api',    gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'web-ui',     gitlabGroup: 'acme-org/develop', branch: 'develop' },
+            { provider: 'gitlab', repo: 'qa-tools',     gitlabGroup: 'acme-org/develop', branch: 'master'  }
         ]
     }
 });
@@ -47,15 +47,15 @@ suite('resolveRepoFromTicket — STRATEGIES.fromSummary', function() {
 
     test('extracts repo name from [bracket] at start of summary', function() {
         var mod = makeModule();
-        var ticket = { key: 'X-1', fields: { summary: '[gens-igt] Create PacBio WF' } };
+        var ticket = { key: 'X-1', fields: { summary: '[service-api] Create Create webhook' } };
         var name = mod.STRATEGIES.fromSummary(ticket);
-        assert.equal(name, 'gens-igt', 'repo name extracted');
+        assert.equal(name, 'service-api', 'repo name extracted');
     });
 
     test('handles hyphenated and dotted repo names', function() {
         var mod = makeModule();
-        var ticket = { key: 'X-2', fields: { summary: '[sample-db] Migrate schema' } };
-        assert.equal(mod.STRATEGIES.fromSummary(ticket), 'sample-db', 'hyphenated name');
+        var ticket = { key: 'X-2', fields: { summary: '[core-db] Migrate schema' } };
+        assert.equal(mod.STRATEGIES.fromSummary(ticket), 'core-db', 'hyphenated name');
     });
 
     test('returns null when summary has no leading bracket', function() {
@@ -83,15 +83,15 @@ suite('resolveRepoFromTicket — findRepoEntry', function() {
 
     test('finds repo in grouped repositories structure', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
-        var entry = mod.findRepoEntry('gens-igt');
+        var entry = mod.findRepoEntry('service-api');
         assert.equal(entry !== null, true, 'entry found');
         assert.equal(entry.branch, 'develop', 'correct branch');
-        assert.equal(entry.gitlabGroup, 'gens-sup/develop', 'correct group');
+        assert.equal(entry.gitlabGroup, 'acme-org/develop', 'correct group');
     });
 
     test('finds repo with non-default branch in grouped structure', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
-        var entry = mod.findRepoEntry('ultraqc');
+        var entry = mod.findRepoEntry('qa-tools');
         assert.equal(entry.branch, 'master', 'master branch resolved');
     });
 
@@ -134,15 +134,15 @@ suite('resolveRepoFromTicket — action', function() {
     test('writes targetRepository to params.customParams when repo found in file', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-1', fields: { summary: '[gens-igt] Create feature' } }
+            ticket: { key: 'PROJ-1', fields: { summary: '[service-api] Create feature' } }
         };
         var result = mod.action(params);
         assert.equal(result, true, 'returns true (continue)');
         assert.equal(params.customParams !== null && params.customParams !== undefined, true, 'customParams created');
-        assert.equal(params.customParams.targetRepository.repo, 'gens-igt', 'repo name set');
+        assert.equal(params.customParams.targetRepository.repo, 'service-api', 'repo name set');
         assert.equal(params.customParams.targetRepository.baseBranch, 'develop', 'baseBranch from file');
-        assert.equal(params.customParams.targetRepository.owner, 'gens-sup/develop', 'owner from file');
-        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/gens-igt', 'default workingDir derived');
+        assert.equal(params.customParams.targetRepository.owner, 'acme-org/develop', 'owner from file');
+        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/service-api', 'default workingDir derived');
     });
 
     test('writes only repoName when repo not found in repositories file', function() {
@@ -175,11 +175,11 @@ suite('resolveRepoFromTicket — action', function() {
     test('uses fromSummary strategy by default', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-5', fields: { summary: '[lims-ui] Add filter' } },
+            ticket: { key: 'PROJ-5', fields: { summary: '[web-ui] Add filter' } },
             customParams: {}
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.repo, 'lims-ui', 'default strategy resolves from summary');
+        assert.equal(params.customParams.targetRepository.repo, 'web-ui', 'default strategy resolves from summary');
     });
 
     test('uses custom repositoriesFile from customParams', function() {
@@ -195,21 +195,21 @@ suite('resolveRepoFromTicket — action', function() {
     test('derives workingDir from dependenciesDir/repoName by default', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-11', fields: { summary: '[sample-db] Schema' } },
+            ticket: { key: 'PROJ-11', fields: { summary: '[core-db] Schema' } },
             customParams: {}
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/sample-db', 'default workingDir');
+        assert.equal(params.customParams.targetRepository.workingDir, './dependencies/core-db', 'default workingDir');
     });
 
     test('respects custom dependenciesDir from customParams', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-12', fields: { summary: '[lims-ui] Feature' } },
+            ticket: { key: 'PROJ-12', fields: { summary: '[web-ui] Feature' } },
             customParams: { dependenciesDir: '/workspace/repos' }
         };
         mod.action(params);
-        assert.equal(params.customParams.targetRepository.workingDir, '/workspace/repos/lims-ui', 'custom dependenciesDir used');
+        assert.equal(params.customParams.targetRepository.workingDir, '/workspace/repos/web-ui', 'custom dependenciesDir used');
     });
 
     test('returns true for unknown strategy (graceful skip)', function() {
@@ -225,34 +225,34 @@ suite('resolveRepoFromTicket — action', function() {
     test('also writes targetRepository into params.jobParams.customParams for postJSAction path', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-9', fields: { summary: '[gens-igt] Feature' } },
+            ticket: { key: 'PROJ-9', fields: { summary: '[service-api] Feature' } },
             jobParams: { customParams: { existingKey: 'value' } }
         };
         mod.action(params);
-        assert.equal(params.jobParams.customParams.targetRepository.repo, 'gens-igt', 'jobParams.customParams.targetRepository set');
+        assert.equal(params.jobParams.customParams.targetRepository.repo, 'service-api', 'jobParams.customParams.targetRepository set');
         assert.equal(params.jobParams.customParams.existingKey, 'value', 'existing jobParams.customParams fields preserved');
     });
 
     test('creates params.jobParams.customParams if absent', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-10', fields: { summary: '[lims-ui] Fix' } },
+            ticket: { key: 'PROJ-10', fields: { summary: '[web-ui] Fix' } },
             jobParams: {}
         };
         mod.action(params);
-        assert.equal(params.jobParams.customParams.targetRepository.repo, 'lims-ui', 'targetRepository created in jobParams.customParams');
+        assert.equal(params.jobParams.customParams.targetRepository.repo, 'web-ui', 'targetRepository created in jobParams.customParams');
     });
 
     test('preserves existing customParams fields while adding targetRepository', function() {
         var mod = makeModule({ '.dmtools/repositories.json': GROUPED_REPOS_JSON });
         var params = {
-            ticket: { key: 'PROJ-8', fields: { summary: '[sample-db] Schema' } },
+            ticket: { key: 'PROJ-8', fields: { summary: '[core-db] Schema' } },
             customParams: { blocksRelationship: 'Blocks', labels: ['development'] }
         };
         mod.action(params);
         assert.equal(params.customParams.blocksRelationship, 'Blocks', 'existing fields preserved');
         assert.deepEqual(params.customParams.labels, ['development'], 'labels preserved');
-        assert.equal(params.customParams.targetRepository.repo, 'sample-db', 'targetRepository added');
+        assert.equal(params.customParams.targetRepository.repo, 'core-db', 'targetRepository added');
     });
 });
 

--- a/js/unit-tests/test_writeSolutionAndLabels.js
+++ b/js/unit-tests/test_writeSolutionAndLabels.js
@@ -77,14 +77,14 @@ suite('writeSolutionAndLabels — topologicalSort', function() {
     test('returns items with no deps first', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'lims-ui', reason: 'UI', depends_on: ['gens-igt'] },
-            { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] },
-            { name: 'sample-db', reason: 'DB' }
+            { name: 'web-ui', reason: 'UI', depends_on: ['service-api'] },
+            { name: 'service-api', reason: 'API', depends_on: ['core-db'] },
+            { name: 'core-db', reason: 'DB' }
         ];
         var sorted = mod.topologicalSort(repos);
         var names = sorted.map(function(r) { return r.name; });
-        assert.equal(names.indexOf('sample-db') < names.indexOf('gens-igt'), true, 'sample-db before gens-igt');
-        assert.equal(names.indexOf('gens-igt') < names.indexOf('lims-ui'), true, 'gens-igt before lims-ui');
+        assert.equal(names.indexOf('core-db') < names.indexOf('service-api'), true, 'core-db before service-api');
+        assert.equal(names.indexOf('service-api') < names.indexOf('web-ui'), true, 'service-api before web-ui');
     });
 
     test('handles plain strings', function() {
@@ -99,13 +99,13 @@ suite('writeSolutionAndLabels — buildJiraSection', function() {
     test('produces wiki table with || headers and {code:json|title=affected_repos} anchor', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'sample-db', reason: 'DB migration' },
-            { name: 'gens-igt', reason: 'API change', depends_on: ['sample-db'] }
+            { name: 'core-db', reason: 'DB migration' },
+            { name: 'service-api', reason: 'API change', depends_on: ['core-db'] }
         ];
         var section = mod.buildJiraSection(repos);
         assert.equal(section.indexOf('|| # ||') !== -1, true, 'Jira table header');
         assert.equal(section.indexOf('{code:json|title=affected_repos}') !== -1, true, 'JSON anchor present');
-        assert.equal(section.indexOf('sample-db --> gens-igt') !== -1, true, 'mermaid edge present');
+        assert.equal(section.indexOf('core-db --> service-api') !== -1, true, 'mermaid edge present');
         assert.equal(section.indexOf('----') !== -1, true, 'section delimiters');
         assert.equal(section.indexOf('{code:mermaid}'), -1, '{code:mermaid} must NOT be used (Jira Server does not support mermaid formatter)');
         assert.equal(section.indexOf('{code}') !== -1, true, 'plain {code} block used for diagram');
@@ -122,8 +122,8 @@ suite('writeSolutionAndLabels — buildMarkdownSection', function() {
     test('produces markdown table with --- delimiters and json code block', function() {
         var mod = makeLabelsModule({});
         var repos = [
-            { name: 'sample-db', reason: 'DB migration' },
-            { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] }
+            { name: 'core-db', reason: 'DB migration' },
+            { name: 'service-api', reason: 'API', depends_on: ['core-db'] }
         ];
         var section = mod.buildMarkdownSection(repos);
         assert.equal(section.indexOf('| # | Repository |') !== -1, true, 'markdown table header');
@@ -139,7 +139,7 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         var module = makeLabelsModule(
             {
                 'outputs/response.md': 'h2. Solution',
-                'outputs/affected_repos.json': '["gens-igt","admin-ui","sample-db"]'
+                'outputs/affected_repos.json': '["service-api","admin-portal","core-db"]'
             },
             {
                 jira_add_label: function(opts) { addedLabels.push(opts.label); }
@@ -152,17 +152,17 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         });
 
         assert.equal(result.success, true, 'action succeeds');
-        assert.equal(addedLabels.indexOf('gens-igt') !== -1, true, 'gens-igt label added');
-        assert.equal(addedLabels.indexOf('admin-ui') !== -1, true, 'admin-ui label added');
-        assert.equal(addedLabels.indexOf('sample-db') !== -1, true, 'sample-db label added');
+        assert.equal(addedLabels.indexOf('service-api') !== -1, true, 'service-api label added');
+        assert.equal(addedLabels.indexOf('admin-portal') !== -1, true, 'admin-portal label added');
+        assert.equal(addedLabels.indexOf('core-db') !== -1, true, 'core-db label added');
     });
 
     test('adds a label for each repo — enriched object format with name+reason+depends_on', function() {
         var addedLabels = [];
         var enriched = JSON.stringify([
-            { name: 'sample-db', reason: 'DB migration required.' },
-            { name: 'gens-igt', reason: 'New API endpoint.', depends_on: ['sample-db'] },
-            { name: 'lims-ui', reason: 'UI column update.', depends_on: ['gens-igt'] }
+            { name: 'core-db', reason: 'DB migration required.' },
+            { name: 'service-api', reason: 'New API endpoint.', depends_on: ['core-db'] },
+            { name: 'web-ui', reason: 'UI column update.', depends_on: ['service-api'] }
         ]);
         var module = makeLabelsModule(
             {
@@ -180,9 +180,9 @@ suite('writeSolutionAndLabels — repo label flow', function() {
         });
 
         assert.equal(result.success, true, 'action succeeds');
-        assert.equal(addedLabels.indexOf('sample-db') !== -1, true, 'sample-db label added');
-        assert.equal(addedLabels.indexOf('gens-igt') !== -1, true, 'gens-igt label added');
-        assert.equal(addedLabels.indexOf('lims-ui') !== -1, true, 'lims-ui label added');
+        assert.equal(addedLabels.indexOf('core-db') !== -1, true, 'core-db label added');
+        assert.equal(addedLabels.indexOf('service-api') !== -1, true, 'service-api label added');
+        assert.equal(addedLabels.indexOf('web-ui') !== -1, true, 'web-ui label added');
     });
 
     test('skips labels gracefully when affected_repos.json is missing', function() {
@@ -233,8 +233,8 @@ suite('writeSolutionAndLabels — repo label flow', function() {
             {
                 'outputs/response.md': 'h2. Solution Design\n\nFull solution text.',
                 'outputs/affected_repos.json': JSON.stringify([
-                    { name: 'sample-db', reason: 'DB migration' },
-                    { name: 'gens-igt', reason: 'API', depends_on: ['sample-db'] }
+                    { name: 'core-db', reason: 'DB migration' },
+                    { name: 'service-api', reason: 'API', depends_on: ['core-db'] }
                 ])
             },
             {
@@ -263,7 +263,7 @@ suite('writeSolutionAndLabels — repo label flow', function() {
             {
                 'outputs/response.md': 'h2. Solution Design\n\nFull solution text.',
                 'outputs/affected_repos.json': JSON.stringify([
-                    { name: 'sample-db', reason: 'DB migration' }
+                    { name: 'core-db', reason: 'DB migration' }
                 ])
             },
             {


### PR DESCRIPTION
Replaces real customer repo/org names (gens-igt, gens-sup, lims-ui, admin-ui, sample-db, ultraqc, genosity.com, GENSGENP-*) used in unit test fixtures with neutral placeholders (service-api, acme-org, web-ui, admin-portal, core-db, qa-tools, example.com, PROJ-*). Pure test-fixture rename, no behavior change — all affected suites re-run and pass (test_githubHelpers, test_resolveRepoFromTicket, test_writeSolutionAndLabels, test_createRepoTasks).