### PR TITLE
fix: preserve sibling params.ticket for baseBranch/snapshotBranch resolvers

### DIFF
--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -303,6 +303,31 @@ function loadHookFn(path, hookName) {
  * @param {Object} params - Agent params (jobParams or top-level params)
  * @returns {Object} Merged configuration
  */
+/**
+ * Build the params object to pass into loadProjectConfig() when the caller needs
+ * ticket-aware resolvers (baseBranchResolverFnPath / snapshotBranchResolverFnPath).
+ *
+ * Background: in the real Teammate execution path, preJSAction/postJSAction params
+ * have `jobParams` and `ticket` as *sibling* top-level keys (see JavaScriptExecutor.
+ * withJobContext in dm.ai — parameters.put("jobParams", ...); parameters.put("ticket", ...)).
+ * Most call sites use `params.jobParams || params` to read customParams/configPath,
+ * which silently drops the sibling `params.ticket` since it's never nested inside
+ * jobParams in that mode. Any resolver keyed off params.ticket (fixVersion-based
+ * branch resolution, etc.) would then never fire. This helper re-attaches the
+ * ticket without mutating the original params/jobParams objects.
+ *
+ * @param {Object} params - Full action params (may have .jobParams and/or .ticket)
+ * @returns {Object} params object safe to pass into loadProjectConfig()
+ */
+function paramsForConfigLoad(params) {
+    var base = (params && params.jobParams) || params || {};
+    var ticket = (base && base.ticket) || (params && params.ticket);
+    if (ticket && base.ticket !== ticket) {
+        base = Object.assign({}, base, { ticket: ticket });
+    }
+    return base;
+}
+
 function loadProjectConfig(params) {
     var customParams = (params && params.customParams) || {};
     var loaded = null;
@@ -688,6 +713,7 @@ function resolveInstructions(agentName, defaultInstructions, config, agentCliPro
 module.exports = {
     DEFAULTS: DEFAULTS,
     loadProjectConfig: loadProjectConfig,
+    paramsForConfigLoad: paramsForConfigLoad,
     mergeProjectConfig: mergeProjectConfig,
     deepMerge: deepMerge,
     formatTemplate: formatTemplate,

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -601,7 +601,10 @@ function action(params) {
         // - Teammate workflow: params.ticket exists directly
         // - Standalone dmtools (JSRunner): params.jobParams.ticket
         const actualParams = params.ticket ? params : (params.jobParams || params);
-        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        // paramsForConfigLoad re-attaches params.ticket (sibling of jobParams in the
+        // real Teammate execution path) so baseBranchResolverFnPath can key off the
+        // ticket's fixVersion — see configLoader.js for details.
+        var config = configLoader.loadProjectConfig(configLoader.paramsForConfigLoad(params));
         _workingDir = config.workingDir || null;
         _scm = configLoader.createScm(config);
 

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -263,7 +263,10 @@ function action(params) {
         // - Teammate workflow: params.inputFolderPath exists directly
         // - Standalone dmtools (JSRunner): params.jobParams.inputFolderPath
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
-        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        // paramsForConfigLoad re-attaches params.ticket (sibling of jobParams in the
+        // real Teammate execution path) so baseBranchResolverFnPath/snapshotBranchResolverFnPath
+        // can key off the ticket's fixVersion — see configLoader.js for details.
+        var config = configLoader.loadProjectConfig(configLoader.paramsForConfigLoad(params));
         var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         var statuses = resolveStatuses(customParams);
 

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -77,7 +77,10 @@ function action(params) {
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
         var inputFolder = actualParams.inputFolderPath;
         var ticketKey = inputFolder.split('/').pop();
-        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        // paramsForConfigLoad re-attaches params.ticket (sibling of jobParams in the
+        // real Teammate execution path) so baseBranchResolverFnPath can key off the
+        // ticket's fixVersion — see configLoader.js for details.
+        var config = configLoader.loadProjectConfig(configLoader.paramsForConfigLoad(params));
         var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         var scm = configLoader.createScm(config);
 

--- a/js/preCliSnapshotSetup.js
+++ b/js/preCliSnapshotSetup.js
@@ -126,7 +126,10 @@ function action(params) {
         }
 
         // 2. Resolve config. snapshotBranch is filled by snapshotBranchResolverFnPath if configured.
-        var config = configLoader.loadProjectConfig(params.jobParams || params);
+        // paramsForConfigLoad re-attaches params.ticket (sibling of jobParams in the
+        // real Teammate execution path) so snapshotBranchResolverFnPath can key off the
+        // ticket's fixVersion — see configLoader.js for details.
+        var config = configLoader.loadProjectConfig(configLoader.paramsForConfigLoad(params));
         var snapshotBranch = config.git && config.git.snapshotBranch;
         if (!snapshotBranch) {
             console.log('preCliSnapshotSetup: no snapshotBranch configured — nothing to do');

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -441,6 +441,82 @@ suite('configLoader.loadProjectConfig', function() {
         assert.equal(config.git.baseBranch, 'main', 'falls back to defaults on parse error');
     });
 
+    // ── paramsForConfigLoad ─────────────────────────────────────────────────
+    // Regression coverage for the bug where baseBranchResolverFnPath/
+    // snapshotBranchResolverFnPath silently never fired in production: real
+    // Teammate execution passes preJSAction/postJSAction params as sibling
+    // top-level keys { jobParams, ticket, response } (see JavaScriptExecutor.
+    // withJobContext in dm.ai), but every call site read `params.jobParams ||
+    // params` to reach customParams/configPath, which discarded the sibling
+    // `params.ticket`.
+
+    test('paramsForConfigLoad re-attaches sibling params.ticket onto jobParams (real Teammate shape)', function() {
+        var cl = makeLoader({});
+        var ticket = { key: 'PROJ-1', fields: { fixVersions: [{ name: '3.9.0' }] } };
+        var result = cl.paramsForConfigLoad({
+            jobParams: { customParams: { targetRepository: { repo: 'example-repo' } } },
+            ticket: ticket,
+            response: 'some response'
+        });
+        assert.equal(result.ticket, ticket, 'ticket carried over onto the jobParams-derived object');
+        assert.equal(result.customParams.targetRepository.repo, 'example-repo', 'jobParams.customParams preserved');
+    });
+
+    test('paramsForConfigLoad does not mutate the original jobParams object', function() {
+        var cl = makeLoader({});
+        var jobParams = { customParams: {} };
+        var ticket = { key: 'PROJ-1' };
+        cl.paramsForConfigLoad({ jobParams: jobParams, ticket: ticket });
+        assert.equal(jobParams.ticket, undefined, 'original jobParams left untouched');
+    });
+
+    test('paramsForConfigLoad leaves jobParams.ticket alone when already present (standalone/JSRunner shape)', function() {
+        var cl = makeLoader({});
+        var innerTicket = { key: 'PROJ-2' };
+        var outerTicket = { key: 'PROJ-3' };
+        var result = cl.paramsForConfigLoad({
+            jobParams: { ticket: innerTicket, customParams: {} },
+            ticket: outerTicket
+        });
+        assert.equal(result.ticket, innerTicket, 'jobParams.ticket wins when already set');
+    });
+
+    test('paramsForConfigLoad falls back to params itself when no jobParams present', function() {
+        var cl = makeLoader({});
+        var ticket = { key: 'PROJ-4' };
+        var result = cl.paramsForConfigLoad({ ticket: ticket, customParams: {} });
+        assert.equal(result.ticket, ticket);
+    });
+
+    test('end-to-end: baseBranchResolverFnPath now fires from the real Teammate params shape', function() {
+        var cl = makeLoader({
+            '.dmtools/config.js':
+                'module.exports = { git: { baseBranchResolverFnPath: "./.dmtools/resolver.js", baseBranchByFixVersionPattern: "develop/{version}" } };',
+            './.dmtools/resolver.js':
+                'module.exports = function(ticket, candidateBaseBranch, config) { ' +
+                '  var targetRepo = config.customParams && config.customParams.targetRepository; ' +
+                '  if (!targetRepo || targetRepo.repo !== "example-repo") return candidateBaseBranch; ' +
+                '  var versions = ticket && ticket.fields && ticket.fields.fixVersions; ' +
+                '  if (versions && versions.length > 0) return "develop/" + versions[0].name; ' +
+                '  return candidateBaseBranch; ' +
+                '};'
+        });
+        // Simulate the real Teammate shape: jobParams and ticket as siblings —
+        // this is exactly what preCliDevelopmentSetup/developTicketAndCreatePR/
+        // preCliReworkSetup/preCliSnapshotSetup receive in production.
+        var realShapeParams = {
+            jobParams: {
+                customParams: {
+                    targetRepository: { owner: 'acme-corp', repo: 'example-repo', baseBranch: 'main' }
+                }
+            },
+            ticket: { key: 'PROJ-5', fields: { fixVersions: [{ name: '3.9.0' }] } }
+        };
+        var config = cl.loadProjectConfig(cl.paramsForConfigLoad(realShapeParams));
+        assert.equal(config.git.baseBranch, 'develop/3.9.0',
+            'resolver must fire even though ticket only exists as a sibling of jobParams');
+    });
+
 });
 
 // ── resolveConfluenceUrls ─────────────────────────────────────────────────────

--- a/js/unit-tests/test_preCliSnapshotSetup.js
+++ b/js/unit-tests/test_preCliSnapshotSetup.js
@@ -19,6 +19,9 @@ function loadPreCliSnapshotSetup(configLoaderStub, mocks) {
 
 function makeConfigLoaderStub(snapshotBranch) {
     return {
+        paramsForConfigLoad: function(params) {
+            return (params && params.jobParams) || params || {};
+        },
         loadProjectConfig: function() {
             return {
                 git: {


### PR DESCRIPTION
## Bug

Real production MR `gens-sup/develop/admin-ui!690` (ticket GENSGENP-53010) opened against `main` instead of the expected `develop/3.9.0`, despite the ticket's fixVersion being correctly set and the versioned-develop-base-branch-resolver logic being correctly configured.

## Root cause

`dm.ai`'s `AbstractJob`/`JavaScriptExecutor.withJobContext(jobParams, ticket, response)` always passes pre/post-action params as **sibling top-level keys**: `{ jobParams, ticket, response }`.

Every call site that needs `baseBranchResolverFnPath`/`snapshotBranchResolverFnPath` called `configLoader.loadProjectConfig(params.jobParams || params)`. Since `params.jobParams` is always truthy in production, this always evaluated to `params.jobParams` alone — silently discarding the sibling `params.ticket`. `loadProjectConfig`'s ticket-aware resolver logic is gated behind `if (baseBranchResolverPath && params && params.ticket)`, so this guard never passed in real runs, and resolution silently fell back to whatever `customParams.targetRepository.baseBranch` was hardcoded (`"main"` for admin-ui).

Existing unit tests didn't catch this because they call `loadProjectConfig` directly with a flat `{ ticket, customParams }` shape, bypassing the jobParams-unwrapping bug entirely.

## Fix

- Added `configLoader.paramsForConfigLoad(params)` — re-attaches the sibling `params.ticket` onto the jobParams-derived object without mutating originals. Handles both shapes:
  - Real Teammate: `{ jobParams, ticket }` (siblings) → ticket gets attached
  - Standalone/JSRunner: `{ jobParams: { ticket } }` (nested) → left untouched
- Updated the 4 call sites that depend on ticket-aware resolvers to use it: `preCliDevelopmentSetup.js`, `developTicketAndCreatePR.js`, `preCliReworkSetup.js`, `preCliSnapshotSetup.js`.
- Added 5 regression tests in `test_configLoader.js`, including an end-to-end test proving `baseBranchResolverFnPath` now fires from the real Teammate params shape.
- Fixed `test_preCliSnapshotSetup.js`'s configLoader stub to include the new method.

## Testing

- `run_configLoader.json`: 85/85 passed
- Full suite (`run_all.json`): 722/722 passed
- Verified no gens-specific references introduced (per project convention).
