### PR TITLE
fix: ensure origin/<baseBranch> tracking ref exists for non-main base branches

### DIFF
--- a/js/common/gitOps.js
+++ b/js/common/gitOps.js
@@ -143,6 +143,14 @@ function checkoutPRBranch(branchName, workingDir, baseBranch) {
 
     // 4. Hard invariant: never report success while parked on the base branch.
     if (baseBranch) {
+        // Make sure origin/<baseBranch> tracking ref exists before anything
+        // downstream (detectMergeConflicts, getPRDiff, syncBranchWithBase)
+        // relies on it — a plain `fetch --prune` above only refreshes refs
+        // already tracked per the remote's configured refspec, which is
+        // insufficient for a base branch never explicitly fetched before
+        // (e.g. a fixVersion-derived "develop/3.9.0" in a shallow CI clone).
+        prHelper.ensureRemoteBranchRef(cmd, workingDir, baseBranch);
+
         var current = cleanCommandOutput(cmd('git rev-parse --abbrev-ref HEAD') || '').trim();
         if (current === baseBranch) {
             console.warn('⚠️ Still on base branch "' + baseBranch + '" after checkout — recreating ' + branchName + ' from origin/' + baseBranch);
@@ -159,6 +167,13 @@ function getPRDiff(baseBranch, headBranch, workingDir) {
     var cmd = function(command) { return cli_execute_command(Object.assign({}, cmdOpts, { command: command })); };
     try {
         console.log('Generating diff between', baseBranch, 'and', headBranch, workingDir ? '(in ' + workingDir + ')' : '');
+
+        // Make sure origin/<baseBranch> tracking ref exists, in case this is
+        // called standalone (without a preceding checkoutPRBranch in the same
+        // working dir) against a base branch never fetched with an explicit
+        // refspec before.
+        var baseBranchName = baseBranch.indexOf('origin/') === 0 ? baseBranch.slice('origin/'.length) : baseBranch;
+        prHelper.ensureRemoteBranchRef(cmd, workingDir, baseBranchName);
 
         // Unshallow if needed so there is a full merge base available
         try {
@@ -228,6 +243,11 @@ function detectMergeConflicts(baseBranch, inputFolder, workingDir) {
     var cmd = function(command) { return cli_execute_command(Object.assign({}, cmdOpts, { command: command })); };
     try {
         console.log('Checking for merge conflicts with origin/' + baseBranch + (workingDir ? ' in ' + workingDir : '') + '...');
+
+        // See getPRDiff/checkoutPRBranch — ensure the tracking ref exists in
+        // case this is the first git command in the working dir to reference
+        // origin/<baseBranch>.
+        prHelper.ensureRemoteBranchRef(cmd, workingDir, baseBranch);
 
         try {
             var isShallow = cleanCommandOutput(cmd('git rev-parse --is-shallow-repository') || 'false');

--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -180,6 +180,41 @@ function buildOriginFetchCommand(refSpec) {
     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
 }
 
+/**
+ * Ensures `refs/remotes/origin/<branchName>` exists and is up to date.
+ *
+ * `git fetch origin <branchName>` (no destination refspec) only updates
+ * FETCH_HEAD — it never creates/updates the `origin/<branchName>` tracking
+ * ref. That "worked" for base branch "main" only because long-lived cached
+ * checkouts (e.g. CI dependency caches) already had `origin/main` from an
+ * earlier full clone or wildcard fetch. Any other base branch (e.g. a
+ * fixVersion-derived "develop/3.9.0") that was never explicitly fetched with
+ * a destination refspec into that cache genuinely has no local tracking ref,
+ * so every later git command that reads `origin/<branchName>` (merge-base,
+ * merge, diff) fails with "unknown revision or path not in the working
+ * tree" — even though the branch exists on the remote.
+ *
+ * Uses an explicit refspec (`+refs/heads/<b>:refs/remotes/origin/<b>`) so the
+ * tracking ref is created/updated regardless of the remote's configured
+ * fetch refspec (e.g. a shallow/single-branch clone in CI).
+ *
+ * @returns {boolean} true if the fetch succeeded (ref should now exist)
+ */
+function ensureRemoteBranchRef(runCommand, workingDir, branchName) {
+    if (!branchName || !isSafeRefName(branchName)) return false;
+
+    try {
+        runCommand(
+            'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName,
+            workingDir
+        );
+        return true;
+    } catch (e) {
+        console.warn('Could not fetch explicit ref for origin/' + branchName + ':', e.message || e);
+        return false;
+    }
+}
+
 function readTrackedStatus(runCommand, workingDir) {
     return cleanCommandOutput(
         runCommand('git status --porcelain --ignore-submodules=dirty', workingDir) || ''
@@ -290,7 +325,7 @@ function syncBranchWithBase(options) {
 
     try {
         console.log('Synchronizing ' + branchName + ' with origin/' + baseBranch + ' before publishing...');
-        runCommand(buildOriginFetchCommand(baseBranch), workingDir);
+        ensureRemoteBranchRef(runCommand, workingDir, baseBranch);
 
         var upToDate = branchContainsBase(runCommand, workingDir, baseBranch);
         if (upToDate) {
@@ -338,9 +373,14 @@ function syncBranchWithBase(options) {
         var message = error && error.message ? error.message : String(error);
         if (conflictFiles.length > 0) {
             message = 'Merge conflict while syncing with origin/' + baseBranch + ': ' + conflictFiles.join(', ');
-        } else if (autoResolve.error) {
+        } else if (autoResolve.error && autoResolve.error !== 'No conflicted files detected') {
+            // A specific auto-resolve failure (unresolved conflicts, commit failure)
+            // is more actionable than the original git error — surface it.
             message = autoResolve.error;
         }
+        // Otherwise autoResolve found zero conflict markers, meaning `error` was
+        // never a real merge conflict (e.g. a missing origin/<baseBranch> ref) —
+        // keep the original git error instead of the misleading generic message.
         console.warn('Could not synchronize branch with base:', message);
         return {
             success: false,
@@ -457,6 +497,7 @@ module.exports = {
     sanitizeTitle: sanitizeTitle,
     sanitizeCommitMessage: sanitizeCommitMessage,
     buildOriginFetchCommand: buildOriginFetchCommand,
+    ensureRemoteBranchRef: ensureRemoteBranchRef,
     readTrackedStatus: readTrackedStatus,
     readStagedDiffStat: readStagedDiffStat,
     syncBranchWithBase: syncBranchWithBase,

--- a/js/test/git_remote_tracking_ref.test.js
+++ b/js/test/git_remote_tracking_ref.test.js
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the origin/<baseBranch> remote-tracking-ref fix.
+ *
+ * Regression coverage for a real production failure: a `pr_rework` run
+ * targeting a fixVersion-derived base branch (`develop/3.9.0`, not `main`)
+ * failed with `fatal: ambiguous argument 'origin/develop/3.9.0': unknown
+ * revision or path not in the working tree` inside syncBranchWithBase,
+ * detectMergeConflicts and getPRDiff — because `git fetch origin
+ * <baseBranch>` (no destination refspec) only updates FETCH_HEAD, never
+ * `refs/remotes/origin/<baseBranch>`. It "worked" for `main` only because a
+ * long-lived cached checkout already had `origin/main` from an earlier full
+ * clone.
+ *
+ * Runs with plain Node.js. Mocks `cli_execute_command` so no real git/network
+ * calls are made; assertions check that the explicit-refspec fetch
+ * (`+refs/heads/<b>:refs/remotes/origin/<b>`) is issued for a non-main base
+ * branch before any command that reads `origin/<baseBranch>`.
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+const AGENT_JS_DIR = path.resolve(__dirname, '..');
+
+const BASE_BRANCH = 'develop/3.9.0';
+
+// ---- fake git state ---------------------------------------------------------
+// Simulates a cached checkout where origin/develop/3.9.0 does NOT exist yet
+// (unlike origin/main, which "just works" from earlier runs).
+let remoteRefFetched = false;
+const executedCommands = [];
+
+function resetGitState() {
+    remoteRefFetched = false;
+    executedCommands.length = 0;
+}
+
+const EXPLICIT_REFSPEC_FETCH =
+    'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + BASE_BRANCH + ':refs/remotes/origin/' + BASE_BRANCH;
+
+global.cli_execute_command = function(opts) {
+    const command = (opts && opts.command) || '';
+    executedCommands.push(command);
+
+    if (command === EXPLICIT_REFSPEC_FETCH) {
+        remoteRefFetched = true;
+        return '';
+    }
+
+    // Any command referencing origin/<baseBranch> before the explicit-refspec
+    // fetch happened simulates the real "unknown revision" failure.
+    if (command.indexOf('origin/' + BASE_BRANCH) !== -1 && !remoteRefFetched) {
+        throw new Error("fatal: ambiguous argument 'origin/" + BASE_BRANCH + "': unknown revision or path not in the working tree.");
+    }
+
+    if (command.indexOf('git rev-parse --is-shallow-repository') === 0) return 'false';
+    if (command.indexOf('git rev-parse --abbrev-ref HEAD') === 0) return 'feature/ticket-123';
+    if (command.indexOf('git status --porcelain') === 0) return '';
+    if (command.indexOf('git status --short') === 0) return '';
+    if (command.indexOf('git branch --list') === 0) return 'feature/ticket-123';
+    if (command.indexOf('git ls-remote --heads origin') === 0) return 'abc123\trefs/heads/feature/ticket-123';
+    if (command.indexOf('git checkout') === 0) return '';
+    if (command.indexOf('git pull') === 0) return '';
+    if (command.indexOf('git config') === 0) return '';
+    if (command.indexOf('git rev-parse origin/' + BASE_BRANCH) === 0) return 'abc123deadbeef\n';
+    if (command.indexOf('git merge-base') === 0) return 'abc123deadbeef\n';
+    if (command.indexOf('git diff') === 0) return 'diff --git a/x b/x\n';
+
+    return '';
+};
+global.file_read = function() { return ''; };
+global.file_write = function() { return true; };
+global.file_delete = function() { return true; };
+
+// ---- tests -------------------------------------------------------------------
+function test(name, fn) {
+    resetGitState();
+    try {
+        fn();
+        console.log('  ✅', name);
+    } catch (e) {
+        console.error('  ❌', name);
+        throw e;
+    }
+}
+
+function runTests() {
+    console.log('Running git_remote_tracking_ref tests...');
+
+    const prHelper = require(path.join(AGENT_JS_DIR, 'common', 'pullRequest.js'));
+    const gitOps = require(path.join(AGENT_JS_DIR, 'common', 'gitOps.js'));
+
+    test('ensureRemoteBranchRef issues explicit-refspec fetch for a non-main branch', () => {
+        const runCommand = function(cmd, wd) {
+            return global.cli_execute_command({ command: cmd, workingDirectory: wd });
+        };
+        const ok = prHelper.ensureRemoteBranchRef(runCommand, null, BASE_BRANCH);
+        assert.strictEqual(ok, true, 'should report success');
+        assert.ok(remoteRefFetched, 'explicit refspec fetch should have run');
+    });
+
+    test('syncBranchWithBase resolves origin/<baseBranch> after ensureRemoteBranchRef (no "unknown revision" failure)', () => {
+        const result = prHelper.syncBranchWithBase({
+            branchName: 'feature/ticket-123',
+            baseBranch: BASE_BRANCH,
+            runCommand: function(cmd, wd) {
+                return global.cli_execute_command({ command: cmd, workingDirectory: wd });
+            }
+        });
+        assert.ok(remoteRefFetched, 'should have fetched the explicit ref before rev-parsing origin/<baseBranch>');
+        assert.strictEqual(result.success, true, 'sync should succeed: ' + (result.error || ''));
+    });
+
+    test('syncBranchWithBase surfaces the original git error instead of a misleading "No conflicted files detected" message', () => {
+        // Simulate a genuine unresolved failure unrelated to a missing ref
+        // (e.g. merge throws for some other reason) with zero conflict markers
+        // in git status --short — resolveMergeConflicts finds nothing to fix,
+        // and previously this replaced the real error with a generic message.
+        // Force branchContainsBase to report "not up to date" (different SHAs)
+        // so syncBranchWithBase proceeds all the way to the merge attempt.
+        const runCommand = function(cmd) {
+            if (cmd.indexOf('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/') === 0) {
+                remoteRefFetched = true;
+                return '';
+            }
+            if (cmd.indexOf('git rev-parse origin/' + BASE_BRANCH) === 0) return 'base-sha\n';
+            if (cmd.indexOf('git merge-base origin/' + BASE_BRANCH + ' HEAD') === 0) return 'different-sha\n';
+            if (cmd.indexOf('git status --porcelain') === 0) return '';
+            if (cmd.indexOf('git merge --no-edit origin/') === 0) {
+                throw new Error('fatal: something unexpected happened during merge');
+            }
+            if (cmd.indexOf('git status --short') === 0) return '';
+            if (cmd.indexOf('git merge --abort') === 0) return '';
+            return '';
+        };
+        const result = prHelper.syncBranchWithBase({
+            branchName: 'feature/ticket-123',
+            baseBranch: BASE_BRANCH,
+            runCommand: runCommand
+        });
+        assert.strictEqual(result.success, false);
+        assert.ok(
+            result.error.indexOf('something unexpected happened during merge') !== -1,
+            'should preserve the original error, got: ' + result.error
+        );
+    });
+
+    test('getPRDiff ensures origin/<baseBranch> ref before diffing a non-main base branch', () => {
+        const diff = gitOps.getPRDiff(BASE_BRANCH, 'feature/ticket-123', null);
+        assert.ok(remoteRefFetched, 'should have fetched the explicit ref before diffing');
+        assert.ok(diff && diff.length > 0, 'should return a non-empty diff');
+    });
+
+    test('detectMergeConflicts ensures origin/<baseBranch> ref before merging a non-main base branch', () => {
+        const conflicts = gitOps.detectMergeConflicts(BASE_BRANCH, 'input/TICKET-123', null);
+        assert.ok(remoteRefFetched, 'should have fetched the explicit ref before merging');
+        assert.deepStrictEqual(conflicts, [], 'should report no conflicts on a clean merge');
+    });
+
+    test('checkoutPRBranch ensures origin/<baseBranch> ref exists as soon as the branch is known', () => {
+        gitOps.checkoutPRBranch('feature/ticket-123', null, BASE_BRANCH);
+        assert.ok(remoteRefFetched, 'should have fetched the explicit ref during checkout');
+    });
+
+    console.log('✅ All git_remote_tracking_ref tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Problem

`git fetch origin <baseBranch>` (no destination refspec) only updates `FETCH_HEAD`, never `refs/remotes/origin/<baseBranch>`. This "worked" for `baseBranch = "main"` only because long-lived cached CI checkouts already had `origin/main` from an earlier full clone / wildcard fetch. Any other base branch (e.g. a fixVersion-derived `develop/3.9.0` that was never explicitly fetched with a destination refspec into that cache) genuinely has no local tracking ref, so every later command referencing `origin/<baseBranch>` fails with `unknown revision or path not in the working tree` — even though the branch exists on the remote.

This caused a real production `pr_rework` run against a non-main base branch to fail inside `pushReworkChanges.js`'s `commitAndPush() -> syncBranchWithBase()`, silently dropping all review-thread replies, the PR comment, and the tracker status update — even though the CLI coding agent had already made and pushed a real fix.

## Fix

- Add `ensureRemoteBranchRef(runCommand, workingDir, branchName)` in `js/common/pullRequest.js`, using the explicit-refspec pattern (`+refs/heads/<b>:refs/remotes/origin/<b>`) already proven correct in `fetchAdditionalHistoryForMergeBase`, and export it.
- Call it in `syncBranchWithBase` (replacing the FETCH_HEAD-only fetch), `detectMergeConflicts`, `getPRDiff`, and `checkoutPRBranch` (`js/common/gitOps.js`) before any of them reference `origin/<baseBranch>`.
- Preserve the original git error in `syncBranchWithBase`'s catch block instead of always falling back to the misleading `"No conflicted files detected"` message when `resolveMergeConflicts` finds zero conflict markers (also true for a missing-ref failure, not just a real merge conflict).

## Tests

Adds `js/test/git_remote_tracking_ref.test.js` — regression coverage that fails against the unpatched code (proving the bug) and passes with the fix, covering `ensureRemoteBranchRef`, `syncBranchWithBase`, `getPRDiff`, `detectMergeConflicts`, and `checkoutPRBranch` for a non-main base branch.

```
node js/test/git_remote_tracking_ref.test.js
```