### PR TITLE
docs: require cross-repo verification note for shared enum/id literals in API Contracts

### DIFF
--- a/instructions/enhancement/solution_design_formatting_rules.md
+++ b/instructions/enhancement/solution_design_formatting_rules.md
@@ -31,6 +31,7 @@ The block below is a **structural template / example only**. The tags such as `<
 <bold>API Contracts:</bold>
 <bullet> <code>POST /api/example</code>: [request payload shape] → [response shape].
 <bullet> <code>GET /api/example/{id}</code>: [purpose and return shape].
+<bullet> [If a new/changed enum or literal id value is introduced here and another repository will hardcode it verbatim: call out here that the consuming repo's implementation MUST verify the exact literal against the actual merged source of truth (not just this design doc) before its change merges, and should cover it with a test that fails if the source value ever drifts — not one that only mocks the id locally.]
 
 <bold>AC Coverage:</bold>
 The Acceptance Criteria are defined in the BA ticket (<link>BA-TICKET|https://jira.example.com/browse/BA-TICKET</link>) and are the single source of truth.


### PR DESCRIPTION
When a solution design introduces a new/changed enum or literal id value that another repository will hardcode verbatim, the API Contracts section must now call out that the consuming repo needs to verify the exact literal against the actual merged source of truth (not just the design doc text, which can go stale after a later rename) and cover it with a test that would catch drift, not one that only mocks the id locally.

Motivated by a real incident: a backend enum value was renamed during code review, but a dependent frontend implementation built from the same design doc never picked up the rename and shipped with the stale literal — no test caught it because the frontend test only mocked the (now wrong) id.