### PR TITLE
feat: generic direct-to-base-branch workflow actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,21 @@ var fileReadMock = function(opts) {
 
 ## Conventions
 
-### No project-specific content
-This repo must not contain customer names, ticket keys, repo paths, branch names, or technology rules that belong to a single project. Project context goes in the target repo's `.dmtools/config.js`.
+### No project-specific content — STRICT RULE
+
+**This is a public, product-agnostic repository. NEVER commit anything company- or customer-specific here.** Violations are a fireable offense and require history rewrite.
+
+Forbidden anywhere in this repo (code, comments, prompts, instructions, tests, docs, commit messages):
+
+- Company, customer, or product names
+- Internal hostnames, URLs, IPs, Jira/Confluence links, real ticket keys
+- Internal label/branch/repo naming conventions tied to one organization
+- File paths pointing to internal repos, internal registry URLs
+- Sample data copied from real internal systems
+
+Everything here must be **generic and configurable**: names like `example.com`, `PROJ-123`, `acme`; behavior driven by `customParams` / `.dmtools/config.js` in the consuming repo. Project context goes in the target repo's `.dmtools/config.js` or the corporate orchestrator repo — never here.
+
+**Before every commit**: re-read your diff and check it against this list.
 
 ### Agent config structure
 - `metadata.contextId` identifies the workflow (used for config composition lookups).

--- a/js/commitAndPushToBaseBranch.js
+++ b/js/commitAndPushToBaseBranch.js
@@ -17,7 +17,7 @@
  *
  * Configuration (customParams.directPush):
  *   - commitMessage:    e.g. "Update {ticketKey} artifacts"
- *   - gateCommand:      e.g. "npm run build" (optional)
+ *   - gateCommand:      e.g. "npm run build" (optional, supports {ticketKey})
  *   - resultUrlTemplate: e.g. "https://example.com/{ticketKey}/" (optional)
  *   - successComment:   comment posted on success (optional)
  *   - noChangesComment: comment posted when nothing changed (optional)
@@ -83,8 +83,9 @@ function action(params) {
         }
 
         if (opts.gateCommand) {
+            var gateCmd = opts.gateCommand.split('{ticketKey}').join(ticketKey);
             try {
-                var gateOut = cleanCommandOutput(runCmd({ command: opts.gateCommand + ' 2>&1 | tail -20' }));
+                var gateOut = cleanCommandOutput(runCmd({ command: gateCmd + ' 2>&1 | tail -20' }));
                 console.log('commitAndPushToBaseBranch: gate passed. ' + gateOut);
             } catch (gateError) {
                 console.error('commitAndPushToBaseBranch: gate failed, not pushing:', gateError.toString());

--- a/js/commitAndPushToBaseBranch.js
+++ b/js/commitAndPushToBaseBranch.js
@@ -1,0 +1,116 @@
+/**
+ * Commit and Push To Base Branch Action
+ *
+ * Generic postJSAction for direct-to-main iteration loops (no branch, no PR).
+ * Useful for content/artifact repos where the deliverable is deployed
+ * automatically from the default branch (e.g. static-site pipelines) and the
+ * agent should publish immediately.
+ *
+ * Steps:
+ * 1. If the working tree is clean — post an optional "no changes" comment and finish.
+ * 2. Optional pre-push gate command (customParams.directPush.gateCommand) run in
+ *    workingDir; when it fails, nothing is pushed and the output is commented.
+ * 3. git add -A, commit, pull --rebase, push to baseBranch.
+ * 4. Optional Jira comment with customParams.directPush.successComment
+ *    (supports {ticketKey} and {url} placeholders; url comes from
+ *    customParams.directPush.resultUrlTemplate, also with {ticketKey}).
+ *
+ * Configuration (customParams.directPush):
+ *   - commitMessage:    e.g. "Update {ticketKey} artifacts"
+ *   - gateCommand:      e.g. "npm run build" (optional)
+ *   - resultUrlTemplate: e.g. "https://example.com/{ticketKey}/" (optional)
+ *   - successComment:   comment posted on success (optional)
+ *   - noChangesComment: comment posted when nothing changed (optional)
+ */
+
+const { extractTicketKey } = require('./common/jiraHelpers.js');
+var configLoader = require('./configLoader.js');
+
+var _workingDir = null;
+function runCmd(args) {
+    if (_workingDir) args.workingDirectory = _workingDir;
+    return cli_execute_command(args);
+}
+
+function cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function (line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function render(template, ticketKey) {
+    var url = '';
+    if (template && template.resultUrlTemplate) {
+        url = template.resultUrlTemplate.split('{ticketKey}').join(ticketKey);
+    }
+    return (template && template.text ? template.text : '')
+        .split('{ticketKey}').join(ticketKey)
+        .split('{url}').join(url);
+}
+
+function postComment(ticketKey, message) {
+    try {
+        jira_post_comment(ticketKey, message);
+    } catch (e) {
+        console.warn('commitAndPushToBaseBranch: comment failed:', e.toString());
+    }
+}
+
+function action(params) {
+    var ticketKey = extractTicketKey(params) || (params.ticket && params.ticket.key);
+    if (!ticketKey) {
+        console.error('commitAndPushToBaseBranch: could not determine ticket key');
+        return false;
+    }
+
+    var config = configLoader.loadConfig(params);
+    _workingDir = config.workingDir || null;
+    var baseBranch = (config.targetRepository && config.targetRepository.baseBranch) || 'main';
+    var opts = (config.customParams && config.customParams.directPush) || {};
+
+    try {
+        var status = cleanCommandOutput(runCmd({ command: 'git status --porcelain' }));
+        if (!status) {
+            console.log('commitAndPushToBaseBranch: no changes to commit');
+            if (opts.noChangesComment) {
+                postComment(ticketKey, render({ text: opts.noChangesComment, resultUrlTemplate: opts.resultUrlTemplate }, ticketKey));
+            }
+            return true;
+        }
+
+        if (opts.gateCommand) {
+            try {
+                var gateOut = cleanCommandOutput(runCmd({ command: opts.gateCommand + ' 2>&1 | tail -20' }));
+                console.log('commitAndPushToBaseBranch: gate passed. ' + gateOut);
+            } catch (gateError) {
+                console.error('commitAndPushToBaseBranch: gate failed, not pushing:', gateError.toString());
+                postComment(ticketKey, 'Pre-push gate failed, changes NOT pushed:\n\n```\n' + gateError.toString().slice(-1500) + '\n```');
+                return false;
+            }
+        }
+
+        var message = (opts.commitMessage || 'Update {ticketKey} artifacts').split('{ticketKey}').join(ticketKey);
+        runCmd({ command: 'git add -A' });
+        runCmd({ command: 'git commit -m "' + message.replace(/"/g, '\\"') + '" --no-verify' });
+        runCmd({ command: 'git pull --rebase origin ' + baseBranch });
+        runCmd({ command: 'git push origin HEAD:' + baseBranch });
+        console.log('commitAndPushToBaseBranch: pushed to ' + baseBranch);
+
+        if (opts.successComment) {
+            postComment(ticketKey, render({ text: opts.successComment, resultUrlTemplate: opts.resultUrlTemplate }, ticketKey));
+        }
+        return true;
+    } catch (e) {
+        console.error('commitAndPushToBaseBranch failed:', e.toString());
+        postComment(ticketKey, 'Push to ' + baseBranch + ' failed: ' + e.toString().slice(0, 1000));
+        return false;
+    }
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { action: action };
+}

--- a/js/preCliSyncBaseBranch.js
+++ b/js/preCliSyncBaseBranch.js
@@ -1,0 +1,54 @@
+/**
+ * Pre-CLI Sync Base Branch Action
+ *
+ * Generic preCliJSAction for workflows that iterate directly on the target
+ * repository's default branch (no feature branches, no PRs) — e.g. content
+ * generation or documentation repos where every run should build on top of
+ * the latest state.
+ *
+ * Ensures the working copy (customParams.targetRepository.workingDir) is on
+ * the configured baseBranch and fast-forwarded to origin.
+ *
+ * Configuration (customParams.targetRepository):
+ *   - baseBranch: branch to sync (default "main")
+ *   - workingDir: checkout directory (from targetRepository.workingDir)
+ */
+
+var configLoader = require('./configLoader.js');
+
+var _workingDir = null;
+function runCmd(args) {
+    if (_workingDir) args.workingDirectory = _workingDir;
+    return cli_execute_command(args);
+}
+
+function cleanCommandOutput(output) {
+    if (!output) return '';
+    return output.split('\n').filter(function (line) {
+        return line.indexOf('Script started') === -1 &&
+               line.indexOf('Script done') === -1 &&
+               line.indexOf('COMMAND=') === -1 &&
+               line.indexOf('COMMAND_EXIT_CODE=') === -1;
+    }).join('\n').trim();
+}
+
+function action(params) {
+    var config = configLoader.loadConfig(params);
+    _workingDir = config.workingDir || null;
+    var baseBranch = (config.targetRepository && config.targetRepository.baseBranch) || 'main';
+
+    try {
+        var out = cleanCommandOutput(runCmd({
+            command: 'git checkout ' + baseBranch + ' && git pull --ff-only origin ' + baseBranch
+        }));
+        console.log('preCliSyncBaseBranch: on ' + baseBranch + ', up to date. ' + out);
+        return true;
+    } catch (e) {
+        console.error('preCliSyncBaseBranch: failed to sync ' + baseBranch + ':', e.toString());
+        return false;
+    }
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { action: action };
+}


### PR DESCRIPTION
## Что

Переиспользуемые строительные блоки для workflow, которые итерируют прямо на default-ветке целевого репо (без feature-веток и PR) — например, контент/артефакт-репозитории с автодеплоем из main:

- **js/preCliSyncBaseBranch.js** (preCliJSAction) — синкает рабочую копию на baseBranch (fast-forward only)
- **js/commitAndPushToBaseBranch.js** (postJSAction) — опциональный pre-push gate (любая команда), commit, rebase, push в baseBranch, опциональные комментарии в трекер. Всё конфигурируется через `customParams.directPush`:
  - `commitMessage` (плейсхолдер `{ticketKey}`)
  - `gateCommand` (например `npm run build`)
  - `resultUrlTemplate` (плейсхолдер `{ticketKey}`)
  - `successComment` / `noChangesComment` (плейсхолдеры `{ticketKey}`, `{url}`)

Вся продуктовая специфика живёт в корпоративном оркестраторе (конфиг потребителя), здесь — только generic механизм.

Также: правило «No project-specific content» в AGENTS.md расширено до явного strict-правила со списком запрещённого и pre-commit чеклистом.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>