### PR TITLE
feat: opt-in multi-task-per-repo SA splitting agent

### DIFF
--- a/createRepoTasksMulti.json
+++ b/createRepoTasksMulti.json
@@ -1,0 +1,9 @@
+{
+  "name": "Teammate",
+  "params": {
+    "inputJql": "key = GENSGENP-52851",
+    "skipAIProcessing": true,
+    "postJSAction": "agents/js/createRepoTasksMulti.js",
+    "localExecution": true
+  }
+}

--- a/instructions/story_solution/affected_repos_multi_task_split.md
+++ b/instructions/story_solution/affected_repos_multi_task_split.md
@@ -1,0 +1,91 @@
+# Affected Repositories — Multi-Task Splitting (opt-in)
+
+This instruction extends the base `affected_repos_flow.md` output format. It is
+only included in SA agents that want to split the work inside a single
+repository into several independently trackable Sub-tasks (instead of exactly
+one Sub-task per repository). If this file is not in your `cliPrompts`, ignore
+it — keep emitting the plain per-repository schema.
+
+---
+
+## When to split a repository into multiple tasks
+
+Add a `tasks` array to a repository entry only when the work inside that one
+repository is naturally separable into pieces that can be **developed,
+reviewed, and tested independently** — for example:
+
+- A schema/migration change vs. the business logic that consumes it.
+- A backend API/entity change vs. a client-only follow-up in the same repo.
+- Two unrelated modules/packages within a monorepo-style repository that don't
+  share files and could be picked up by different developers in parallel.
+
+Do **not** split when:
+
+- The pieces are small and tightly coupled (same class/file, same PR anyway).
+- Splitting would only produce artificial "step 1 / step 2" tickets that must
+  always be worked by the same person in the same sitting — that's still one
+  task, just phrase the `reason` as a short ordered list instead.
+- There is genuinely only one repository‑scoped unit of work — most tickets
+  should still end up with a plain single-task-per-repo entry.
+
+When in doubt, prefer **not** splitting. Over-splitting creates Jira overhead
+(more tickets to triage, review, and close) without a real parallelization or
+tracking benefit.
+
+---
+
+## Schema
+
+A repository entry MAY add a `tasks` array. When present, it takes precedence
+over the top-level `reason` for Sub-task creation (the top-level `reason` is
+still shown in the Affected Repositories table as a one-line rollup summary).
+
+```json
+{
+  "name": "repo-a",
+  "reason": "One-line rollup summary shown in the table.",
+  "depends_on": ["repo-z"],
+  "tasks": [
+    {
+      "id": "schema",
+      "title": "Add Seq Plate schema migration",
+      "reason": "Flyway migration + entity for the new Seq Plate table.",
+      "depends_on": []
+    },
+    {
+      "id": "processor",
+      "title": "Implement AssignPoolsToWellsProcessor",
+      "reason": "Step processor consuming the new schema; depends on the migration landing first.",
+      "depends_on": ["schema"]
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `id` | ✅ (when `tasks` is used) | Short, unique-within-this-repo slug (kebab-case). Referenced by other tasks' `depends_on`. |
+| `title` | ✅ | Short Sub-task summary suffix — final Jira summary is `[repo-a] <title>`. |
+| `reason` | ✅ | One sentence: what this specific task changes and why. |
+| `depends_on` | ☐ | Array of prerequisite references (see below). Omit if none. |
+
+### `depends_on` reference forms (task-level, only inside a `tasks` array)
+
+- `"schema"` — another task's `id` **within the same repo**.
+- `"repo-z:some-id"` — a specific task in **another repo** (`repo:id`).
+- `"repo-z"` — a bare repo name — depends on **all** of that repo's tasks (or
+  its single implicit task if that repo has no `tasks` array). Same meaning as
+  the repo-level `depends_on` in the base schema.
+
+---
+
+## Rules
+
+- Every `id` must be unique within its repo's `tasks` array (not globally —
+  `gens-igt:schema` and `lims-ui:schema` can coexist).
+- Do not repeat information between a task's `reason` and its parent repo's
+  rollup `reason` — the rollup should read as a one-sentence summary of all
+  the repo's tasks combined, not a duplicate of the first task.
+- If a repository entry has no `tasks` array, it is still processed as exactly
+  one Sub-task, identical to the base (non-multi) flow — this keeps the schema
+  backward compatible with `affected_repos_flow.md`.

--- a/js/createRepoTasksMulti.js
+++ b/js/createRepoTasksMulti.js
@@ -1,0 +1,340 @@
+/**
+ * Create Repository Development Sub-tasks — Multi-Task Variant
+ *
+ * Like createRepoTasks.js, reads the {code:json|title=affected_repos} block from
+ * a story-solution (SA) ticket description and creates development Sub-tasks
+ * under the same parent as the SA ticket — but supports splitting a single
+ * repository's work into several independently trackable Sub-tasks via an
+ * optional `tasks` array on a repo entry (see
+ * instructions/story_solution/affected_repos_multi_task_split.md).
+ *
+ * Backward compatible: a repo entry with no `tasks` array still produces
+ * exactly one Sub-task, identical to createRepoTasks.js.
+ *
+ * Summary format:   [repo] <task title OR repo-level reason>
+ * Description:      Your scope only development for [repo] based on solution in
+ *                   [SA link] and parent acceptance criteria [parent link]
+ *
+ * Duplicate-safe: skips (repo, title) pairs that already have a matching
+ * Sub-task under the parent.
+ */
+
+function getJiraBaseUrl() {
+    try {
+        var url = java.lang.System.getenv('JIRA_BASE_PATH');
+        return url ? url.replace(/\/$/, '') : '';
+    } catch (e) {
+        return '';
+    }
+}
+
+function jiraLink(key, baseUrl) {
+    return '[' + key + '|' + baseUrl + '/browse/' + key + ']';
+}
+
+function parseAffectedRepos(description) {
+    if (!description) return [];
+    var startMarker = '{code:json|title=affected_repos}';
+    var endMarker = '{code}';
+    var startIdx = description.indexOf(startMarker);
+    if (startIdx === -1) {
+        console.warn('No {code:json|title=affected_repos} block found in description');
+        return [];
+    }
+    var jsonStart = startIdx + startMarker.length;
+    var endIdx = description.indexOf(endMarker, jsonStart);
+    if (endIdx === -1) {
+        console.warn('Closing {code} not found after affected_repos block');
+        return [];
+    }
+    var jsonStr = description.substring(jsonStart, endIdx).trim();
+    try {
+        var parsed = JSON.parse(jsonStr);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+        console.warn('Failed to parse affected_repos JSON:', e);
+        return [];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Flatten repo entries (with optional `tasks`) into a flat list of tasks,
+// each carrying a globally-unique key "repo:id" and resolved depends_on keys.
+// ---------------------------------------------------------------------------
+
+function flattenTasks(repos) {
+    var normalised = repos.map(function(r) {
+        return typeof r === 'string' ? { name: r } : r;
+    });
+
+    // repoName -> array of task keys ("repo:id"), used to expand bare-repo-name deps
+    var repoTaskKeys = {};
+    var flat = [];
+
+    normalised.forEach(function(repo) {
+        var repoName = repo.name;
+        if (!repoName) return;
+
+        if (Array.isArray(repo.tasks) && repo.tasks.length > 0) {
+            repoTaskKeys[repoName] = [];
+            repo.tasks.forEach(function(t) {
+                var id = t.id || t.title;
+                var key = repoName + ':' + id;
+                repoTaskKeys[repoName].push(key);
+                flat.push({
+                    key: key,
+                    repo: repoName,
+                    title: t.title || id,
+                    reason: t.reason || '',
+                    rawDependsOn: Array.isArray(t.depends_on) ? t.depends_on : [],
+                    repoLevelDependsOn: Array.isArray(repo.depends_on) ? repo.depends_on : []
+                });
+            });
+        } else {
+            // Implicit single task for this repo — identical to createRepoTasks.js behaviour
+            var implicitKey = repoName + ':' + repoName;
+            repoTaskKeys[repoName] = [implicitKey];
+            flat.push({
+                key: implicitKey,
+                repo: repoName,
+                title: repo.reason || repoName,
+                reason: repo.reason || '',
+                rawDependsOn: [],
+                repoLevelDependsOn: Array.isArray(repo.depends_on) ? repo.depends_on : []
+            });
+        }
+    });
+
+    // Resolve depends_on references into concrete task keys.
+    function resolveRef(ref, ownRepo) {
+        if (ref.indexOf(':') !== -1) {
+            // Already a fully-qualified "repo:id" reference
+            return repoTaskKeys[ref.split(':')[0]] && flat.some(function(f) { return f.key === ref; })
+                ? [ref] : [];
+        }
+        if (repoTaskKeys[ref]) {
+            // Bare repo name → depends on all of that repo's tasks
+            return repoTaskKeys[ref].slice();
+        }
+        // Bare task id within the same repo
+        var sameRepoKey = ownRepo + ':' + ref;
+        return flat.some(function(f) { return f.key === sameRepoKey; }) ? [sameRepoKey] : [];
+    }
+
+    flat.forEach(function(t) {
+        var resolved = {};
+        t.rawDependsOn.concat(t.repoLevelDependsOn).forEach(function(ref) {
+            resolveRef(ref, t.repo).forEach(function(k) {
+                if (k !== t.key) resolved[k] = true;
+            });
+        });
+        t.depends_on = Object.keys(resolved);
+    });
+
+    return flat;
+}
+
+// ---------------------------------------------------------------------------
+// Topological sort over the flattened task graph
+// ---------------------------------------------------------------------------
+
+function topologicalSortTasks(tasks) {
+    var byKey = {};
+    tasks.forEach(function(t) { byKey[t.key] = t; });
+
+    var sorted = [];
+    var visited = {};
+
+    function visit(key) {
+        if (visited[key]) return;
+        visited[key] = true;
+        var t = byKey[key];
+        if (t) {
+            t.depends_on.forEach(function(dep) { if (byKey[dep]) visit(dep); });
+            sorted.push(t);
+        }
+    }
+
+    tasks.forEach(function(t) { visit(t.key); });
+    return sorted;
+}
+
+function action(params) {
+    try {
+        var saKey = params.ticket && params.ticket.key;
+        if (!saKey) {
+            return { success: false, error: 'No ticket key in params' };
+        }
+
+        console.log('createRepoTasksMulti: processing SA ticket ' + saKey);
+
+        var customParams = params.customParams || (params.jobParams && params.jobParams.customParams) || {};
+        var blocksRelationship = customParams.blocksRelationship || 'Blocks';
+        var blockedStatus      = customParams.blockedStatus      || 'Blocked';
+        var ticketLabels       = customParams.labels             || ['development'];
+
+        var saTicket = jira_get_ticket({ key: saKey, fields: ['description', 'summary', 'parent'] });
+        var saFields = saTicket && saTicket.fields ? saTicket.fields : saTicket;
+        var description = saFields.description ? saFields.description.toString() : '';
+
+        var parentInfo = saFields.parent;
+        var parentKey = parentInfo && typeof parentInfo === 'object' ? parentInfo.key : null;
+        if (!parentKey) {
+            return { success: false, error: 'SA ticket ' + saKey + ' has no parent ticket' };
+        }
+        console.log('Parent ticket: ' + parentKey);
+
+        var parentTicket = jira_get_ticket({ key: parentKey, fields: ['summary'] });
+        var parentFields = parentTicket && parentTicket.fields ? parentTicket.fields : parentTicket;
+        var parentSummary = (parentFields.summary || parentKey).toString();
+
+        var repos = parseAffectedRepos(description);
+        if (repos.length === 0) {
+            return { success: false, error: 'No affected repos found in ' + saKey + ' — ensure writeSolutionAndLabels ran first' };
+        }
+
+        var tasks = topologicalSortTasks(flattenTasks(repos));
+        console.log('Flattened into ' + tasks.length + ' task(s) across ' +
+            repos.map(function(r) { return typeof r === 'string' ? r : r.name; }).join(', '));
+
+        var baseUrl = getJiraBaseUrl();
+        var projectKey = parentKey.split('-')[0];
+
+        // Load existing Sub-tasks under the parent to avoid duplicates.
+        // Dedup key is "[repo] title" (not just "[repo]") so multiple tasks
+        // in the same repo don't falsely collide.
+        var existingSummaries = [];
+        try {
+            var existing = jira_search_by_jql({
+                jql: 'parent = ' + parentKey + ' AND issuetype = Sub-task',
+                fields: ['summary']
+            });
+            if (Array.isArray(existing)) {
+                existing.forEach(function(t) {
+                    var s = t.fields && t.fields.summary ? t.fields.summary : (t.summary || '');
+                    existingSummaries.push(s);
+                });
+            }
+        } catch (e) {
+            console.warn('Could not fetch existing Sub-tasks (will create without dedup check):', e);
+        }
+
+        var created = [];
+        var skipped = [];
+        // task key ("repo:id") → created Jira key, for dependency linking
+        var taskKeyMap = {};
+
+        tasks.forEach(function(t) {
+            var summary = '[' + t.repo + '] ' + t.title;
+
+            var duplicate = existingSummaries.indexOf(summary) !== -1;
+            if (duplicate) {
+                console.log('Skipping "' + summary + '" — sub-task already exists');
+                skipped.push(summary);
+                return;
+            }
+
+            var saRef  = baseUrl ? jiraLink(saKey, baseUrl)     : saKey;
+            var parRef = baseUrl ? jiraLink(parentKey, baseUrl)  : parentKey;
+            var descBody = (t.reason ? t.reason + '\n\n' : '') +
+                       'Your scope only development for *' + t.repo +
+                       '* based on solution in ' + saRef +
+                       ' and parent acceptance criteria ' + parRef;
+
+            try {
+                var result = jira_create_ticket_with_parent({
+                    project: projectKey,
+                    issueType: 'Sub-task',
+                    summary: summary,
+                    description: descBody,
+                    parentKey: parentKey,
+                    labels: ticketLabels
+                });
+
+                var createdKey = null;
+                try {
+                    var parsed = typeof result === 'string' ? JSON.parse(result) : result;
+                    createdKey = parsed && (parsed.key || parsed.id) ? (parsed.key || parsed.id) : null;
+                } catch (e) { /* key extraction failed — non-critical */ }
+
+                console.log('Created Sub-task ' + (createdKey || '(key unavailable)') + ': ' + summary);
+                created.push({ taskKey: t.key, repo: t.repo, key: createdKey, summary: summary, depends_on: t.depends_on });
+                if (createdKey) taskKeyMap[t.key] = createdKey;
+
+            } catch (e) {
+                console.error('Failed to create Sub-task for ' + summary + ':', e);
+                created.push({ taskKey: t.key, repo: t.repo, key: null, summary: summary, error: e.toString(), depends_on: [] });
+            }
+        });
+
+        // Wire dependencies: blocker Blocks dependent + move dependent to Blocked status
+        created.forEach(function(c) {
+            if (!c.key || !Array.isArray(c.depends_on) || c.depends_on.length === 0) return;
+            var anyLinked = false;
+            c.depends_on.forEach(function(depKey) {
+                var blockerKey = taskKeyMap[depKey];
+                if (!blockerKey) {
+                    console.warn('Cannot resolve depends_on "' + depKey + '" for ' + c.key + ' — skipping link');
+                    return;
+                }
+                try {
+                    jira_link_issues({ sourceKey: blockerKey, anotherKey: c.key, relationship: blocksRelationship });
+                    console.log(blockerKey + ' ' + blocksRelationship + ' ' + c.key);
+                    anyLinked = true;
+                } catch (e) {
+                    console.warn('Failed to link ' + blockerKey + ' ' + blocksRelationship + ' ' + c.key + ':', e);
+                }
+            });
+            if (anyLinked) {
+                try {
+                    jira_move_to_status({ key: c.key, statusName: blockedStatus });
+                    console.log('Moved ' + c.key + ' to ' + blockedStatus);
+                } catch (e) {
+                    console.warn('Failed to move ' + c.key + ' to ' + blockedStatus + ':', e);
+                }
+            }
+        });
+
+        // Post summary comment on the SA ticket
+        if (created.length > 0 || skipped.length > 0) {
+            try {
+                var comment = 'h3. Development Sub-tasks\n\n';
+                created.forEach(function(c) {
+                    if (c.error) {
+                        comment += '* \u274c ' + c.summary + ': ' + c.error + '\n';
+                    } else {
+                        var ref = c.key && baseUrl ? jiraLink(c.key, baseUrl) : (c.key || c.summary);
+                        comment += '* \u2705 ' + ref + ' \u2014 ' + c.summary + '\n';
+                    }
+                });
+                if (skipped.length > 0) {
+                    comment += '\n_Skipped (already exist): ' + skipped.join(', ') + '_\n';
+                }
+                jira_post_comment({ key: saKey, comment: comment });
+            } catch (e) {
+                console.warn('Failed to post summary comment on ' + saKey + ':', e);
+            }
+        }
+
+        var successCount = created.filter(function(c) { return !c.error; }).length;
+        return {
+            success: true,
+            message: 'Created ' + successCount + ' Sub-task(s) under ' + parentKey + ', skipped ' + skipped.length,
+            created: successCount,
+            skipped: skipped.length
+        };
+
+    } catch (error) {
+        console.error('Error in createRepoTasksMulti:', error);
+        return { success: false, error: error.toString() };
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        action: action,
+        parseAffectedRepos: parseAffectedRepos,
+        flattenTasks: flattenTasks,
+        topologicalSortTasks: topologicalSortTasks
+    };
+}

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -71,7 +71,8 @@
         "js/unit-tests/test_preCliReworkSetup.js",
         "js/unit-tests/test_preCliDevelopmentSetup.js",
         "js/unit-tests/test_preCliKnowledgeUpdateSetup.js",
-        "js/unit-tests/test_pushKnowledgeUpdate.js"
+        "js/unit-tests/test_pushKnowledgeUpdate.js",
+        "js/unit-tests/test_createRepoTasksMulti.js"
       ]
     }
   }

--- a/js/unit-tests/run_createRepoTasksMulti.json
+++ b/js/unit-tests/run_createRepoTasksMulti.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_createRepoTasksMulti.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_createRepoTasksMulti.js
+++ b/js/unit-tests/test_createRepoTasksMulti.js
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for js/createRepoTasksMulti.js
+ */
+
+function makeModule(globals) {
+    var defaultGlobals = {
+        java: { lang: { System: { getenv: function() { return 'https://jiraeu.epam.com'; } } } },
+        jira_get_ticket: function() { return { fields: {} }; },
+        jira_search_by_jql: function() { return []; },
+        jira_create_ticket_with_parent: function() { return '{"key":"PROJ-2"}'; },
+        jira_link_issues: function() {},
+        jira_move_to_status: function() {},
+        jira_post_comment: function() {}
+    };
+    for (var k in (globals || {})) { defaultGlobals[k] = globals[k]; }
+
+    return loadModule(
+        'js/createRepoTasksMulti.js',
+        makeRequire({}),
+        defaultGlobals
+    );
+}
+
+// ---------------------------------------------------------------------------
+// flattenTasks
+// ---------------------------------------------------------------------------
+
+suite('createRepoTasksMulti — flattenTasks', function() {
+    test('repo with no tasks array produces one implicit task', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([{ name: 'repo-a', reason: 'Do the thing' }]);
+        assert.equal(flat.length, 1, 'one implicit task');
+        assert.equal(flat[0].repo, 'repo-a', 'repo name kept');
+        assert.equal(flat[0].title, 'Do the thing', 'reason used as title');
+        assert.deepEqual(flat[0].depends_on, [], 'no deps');
+    });
+
+    test('repo with tasks array produces one task per entry', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([{
+            name: 'gens-igt',
+            tasks: [
+                { id: 'schema', title: 'Add schema migration', reason: 'r1' },
+                { id: 'processor', title: 'Implement processor', reason: 'r2', depends_on: ['schema'] }
+            ]
+        }]);
+        assert.equal(flat.length, 2, 'two tasks');
+        assert.equal(flat[0].key, 'gens-igt:schema', 'first task key');
+        assert.equal(flat[1].key, 'gens-igt:processor', 'second task key');
+        assert.deepEqual(flat[1].depends_on, ['gens-igt:schema'], 'same-repo bare id resolved to qualified key');
+    });
+
+    test('bare repo-name dependency expands to all of that repo\'s task keys', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([
+            {
+                name: 'gens-igt',
+                tasks: [
+                    { id: 'schema', title: 'Schema' },
+                    { id: 'processor', title: 'Processor' }
+                ]
+            },
+            {
+                name: 'lims-ui',
+                depends_on: ['gens-igt']
+            }
+        ]);
+        var limsTask = flat.filter(function(t) { return t.repo === 'lims-ui'; })[0];
+        assert.equal(limsTask.depends_on.length, 2, 'depends on both gens-igt tasks');
+        assert.equal(limsTask.depends_on.indexOf('gens-igt:schema') !== -1, true, 'includes schema task');
+        assert.equal(limsTask.depends_on.indexOf('gens-igt:processor') !== -1, true, 'includes processor task');
+    });
+
+    test('fully-qualified "repo:id" cross-repo dependency resolves to exact task', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([
+            {
+                name: 'gens-igt',
+                tasks: [
+                    { id: 'schema', title: 'Schema' },
+                    { id: 'processor', title: 'Processor' }
+                ]
+            },
+            {
+                name: 'lims-ui',
+                tasks: [
+                    { id: 'view', title: 'View', depends_on: ['gens-igt:processor'] }
+                ]
+            }
+        ]);
+        var viewTask = flat.filter(function(t) { return t.key === 'lims-ui:view'; })[0];
+        assert.deepEqual(viewTask.depends_on, ['gens-igt:processor'], 'exact cross-repo task dependency resolved');
+    });
+
+    test('unresolvable dependency reference is silently dropped, not fatal', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([
+            { name: 'repo-a', tasks: [{ id: 't1', title: 'T1', depends_on: ['nonexistent'] }] }
+        ]);
+        assert.deepEqual(flat[0].depends_on, [], 'unresolved ref dropped');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// topologicalSortTasks
+// ---------------------------------------------------------------------------
+
+suite('createRepoTasksMulti — topologicalSortTasks', function() {
+    test('orders prerequisite tasks before dependents', function() {
+        var mod = makeModule();
+        var flat = mod.flattenTasks([{
+            name: 'gens-igt',
+            tasks: [
+                { id: 'processor', title: 'Processor', depends_on: ['schema'] },
+                { id: 'schema', title: 'Schema' }
+            ]
+        }]);
+        var sorted = mod.topologicalSortTasks(flat);
+        var keys = sorted.map(function(t) { return t.key; });
+        assert.equal(keys.indexOf('gens-igt:schema') < keys.indexOf('gens-igt:processor'), true, 'schema before processor');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseAffectedRepos (shared logic with createRepoTasks.js)
+// ---------------------------------------------------------------------------
+
+suite('createRepoTasksMulti — parseAffectedRepos', function() {
+    test('extracts JSON array from {code:json|title=affected_repos} block', function() {
+        var mod = makeModule();
+        var desc = '{code:json|title=affected_repos}\n[{"name":"repo-a"}]\n{code}';
+        var repos = mod.parseAffectedRepos(desc);
+        assert.equal(repos.length, 1, 'one repo');
+    });
+
+    test('returns empty array when marker absent', function() {
+        var mod = makeModule();
+        assert.equal(mod.parseAffectedRepos('nothing here').length, 0, 'empty array');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// action — end to end
+// ---------------------------------------------------------------------------
+
+suite('createRepoTasksMulti — action', function() {
+    var reposJson = JSON.stringify([
+        {
+            name: 'gens-igt',
+            reason: 'Schema + processor',
+            tasks: [
+                { id: 'schema', title: 'Add schema migration', reason: 'Flyway migration' },
+                { id: 'processor', title: 'Implement processor', reason: 'Consumes schema', depends_on: ['schema'] }
+            ]
+        },
+        {
+            name: 'lims-ui',
+            reason: 'New view',
+            depends_on: ['gens-igt']
+        }
+    ]);
+    var description = 'Solution text\n\n{code:json|title=affected_repos}\n' + reposJson + '\n{code}\n\n----';
+
+    test('creates one Sub-task per flattened task, not per repo', function() {
+        var created = [];
+        var ticketCounter = 200;
+        var mod = makeModule({
+            jira_get_ticket: function(opts) {
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
+                }
+                return { fields: { summary: 'Build PacBio Seq Run Prep' } };
+            },
+            jira_search_by_jql: function() { return []; },
+            jira_create_ticket_with_parent: function(opts) {
+                ticketCounter++;
+                created.push(opts);
+                return '{"key":"PROJ-' + ticketCounter + '"}';
+            },
+            jira_link_issues: function() {},
+            jira_move_to_status: function() {},
+            jira_post_comment: function() {}
+        });
+
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
+
+        assert.equal(result.success, true, 'succeeds');
+        assert.equal(created.length, 3, 'three sub-tasks: schema, processor, lims-ui view');
+        assert.equal(created[0].summary, '[gens-igt] Add schema migration', 'first task summary');
+        assert.equal(created[1].summary, '[gens-igt] Implement processor', 'second task summary');
+        assert.equal(created[2].summary, '[lims-ui] New view', 'implicit single-task repo summary');
+    });
+
+    test('links cross-task dependencies (same repo and cross repo) and moves dependents to Blocked', function() {
+        var links = [];
+        var moved = [];
+        var ticketCounter = 300;
+        var mod = makeModule({
+            jira_get_ticket: function(opts) {
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
+                }
+                return { fields: { summary: 'Story' } };
+            },
+            jira_search_by_jql: function() { return []; },
+            jira_create_ticket_with_parent: function() {
+                ticketCounter++;
+                return '{"key":"PROJ-' + ticketCounter + '"}';
+            },
+            jira_link_issues: function(opts) { links.push(opts); },
+            jira_move_to_status: function(opts) { moved.push(opts); },
+            jira_post_comment: function() {}
+        });
+
+        mod.action({ ticket: { key: 'PROJ-100' } });
+
+        // schema(301) blocks processor(302); both schema+processor block lims-ui view(303)
+        assert.equal(links.length, 3, 'three Blocks links (1 intra-repo + 2 cross-repo)');
+        assert.equal(moved.length, 2, 'processor and lims-ui view moved to Blocked');
+    });
+
+    test('repo entry without tasks array still creates exactly one Sub-task (backward compatible)', function() {
+        var created = [];
+        var flatDescription = 'Solution\n\n{code:json|title=affected_repos}\n' +
+            JSON.stringify([{ name: 'core-db', reason: 'DB migration' }]) + '\n{code}';
+        var mod = makeModule({
+            jira_get_ticket: function(opts) {
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: flatDescription, parent: { key: 'PROJ-50' } } };
+                }
+                return { fields: { summary: 'Story' } };
+            },
+            jira_search_by_jql: function() { return []; },
+            jira_create_ticket_with_parent: function(opts) { created.push(opts); return '{"key":"PROJ-401"}'; },
+            jira_post_comment: function() {}
+        });
+
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
+        assert.equal(result.success, true, 'succeeds');
+        assert.equal(created.length, 1, 'exactly one sub-task');
+        assert.equal(created[0].summary, '[core-db] DB migration', 'summary uses repo-level reason as title');
+    });
+
+    test('skips (repo, title) pairs that already exist as Sub-tasks', function() {
+        var created = [];
+        var ticketCounter = 500;
+        var mod = makeModule({
+            jira_get_ticket: function(opts) {
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: description, parent: { key: 'PROJ-50' } } };
+                }
+                return { fields: { summary: 'Story' } };
+            },
+            jira_search_by_jql: function() {
+                return [{ fields: { summary: '[gens-igt] Add schema migration' } }]; // already exists
+            },
+            jira_create_ticket_with_parent: function(opts) {
+                ticketCounter++;
+                created.push(opts);
+                return '{"key":"PROJ-' + ticketCounter + '"}';
+            },
+            jira_post_comment: function() {}
+        });
+
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
+        assert.equal(result.success, true, 'succeeds');
+        assert.equal(created.length, 2, 'schema task skipped, other two created');
+        assert.equal(result.skipped, 1, 'one skipped');
+    });
+
+    test('returns error when SA ticket has no parent', function() {
+        var mod = makeModule({
+            jira_get_ticket: function() {
+                return { fields: { description: description, parent: null } };
+            }
+        });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
+        assert.equal(result.success, false, 'fails without parent');
+    });
+
+    test('returns error when no affected_repos block in description', function() {
+        var mod = makeModule({
+            jira_get_ticket: function(opts) {
+                if (opts.key === 'PROJ-100') {
+                    return { fields: { description: 'no repos here', parent: { key: 'PROJ-50' } } };
+                }
+                return { fields: { summary: 'Story' } };
+            }
+        });
+        var result = mod.action({ ticket: { key: 'PROJ-100' } });
+        assert.equal(result.success, false, 'fails without repos block');
+    });
+
+    test('module.exports is guarded with typeof for postJSAction compatibility', function() {
+        var code = file_read({ path: 'js/createRepoTasksMulti.js' });
+        var hasGuard = code.indexOf('typeof module') !== -1 && code.indexOf('module.exports') !== -1;
+        assert.equal(hasGuard, true, 'module.exports must be inside typeof module guard');
+    });
+});

--- a/story_solution_e2e_multi.json
+++ b/story_solution_e2e_multi.json
@@ -1,0 +1,15 @@
+{
+  "name": "Teammate",
+  "parent": {
+    "path": "story_solution_e2e.json",
+    "merge": ["params.cliPrompts"]
+  },
+  "params": {
+    "metadata": {
+      "contextId": "story_solution_e2e_multi"
+    },
+    "cliPrompts": [
+      "./agents/instructions/story_solution/affected_repos_multi_task_split.md"
+    ]
+  }
+}


### PR DESCRIPTION
## Problem
The existing SA (Solution Analysis) flow (`affected_repos.json` → `createRepoTasks.js`) creates exactly **one** Jira Sub-task per affected repo. Feedback from real usage: sometimes a single repo's work should be split into several independently-trackable Sub-tasks (e.g. schema migration vs. processor implementation vs. API endpoint), not lumped into one ticket.

## Approach
Fully additive, opt-in new agent — existing agent/scripts are **untouched**:
- `instructions/story_solution/affected_repos_multi_task_split.md` — new instruction, teaches the SA-writing AI an optional `tasks[]` array per repo entry in `affected_repos.json`, with guidance on when splitting makes sense and the three `depends_on` reference forms (bare task id = same-repo, `repo:id` = cross-repo, bare repo name = depends on all of that repo's tasks).
- `story_solution_e2e_multi.json` — new SA job config, layers the instruction on top of the existing `story_solution_e2e.json` via `parent`+`merge`.
- `js/createRepoTasksMulti.js` — new standalone module (does not modify `createRepoTasks.js`) that flattens repo+tasks JSON into a task graph, topologically sorts it, creates one Sub-task per flattened task, and wires `Blocks`/`Blocked` dependencies at task granularity. Dedup uses exact `"[repo] title"` match (vs. the original's repo-name-substring match) since substring dedup would false-positive once a repo has multiple tasks. Backward compatible: a repo entry without `tasks[]` behaves identically to today.
- `createRepoTasksMulti.json` — job config wiring the new module.
- `js/unit-tests/test_createRepoTasksMulti.js` (15 tests) + `run_createRepoTasksMulti.json`, registered in `run_all.json`.

## Testing
`dmtools run js/unit-tests/run_all.json` — 734 passed (was 719 before this PR), 4 pre-existing unrelated failures in `gitOps`/`pullRequest` tests confirmed present on `main` before this change (verified via `git stash`).