### PR TITLE
feat: poc_development_redirect config

### DIFF
--- a/poc_development_redirect.json
+++ b/poc_development_redirect.json
@@ -1,0 +1,15 @@
+{
+  "name": "Teammate",
+  "parent": {
+    "path": "story_development_redirect.json",
+    "merge": []
+  },
+  "params": {
+    "metadata": {
+      "contextId": "poc_development_redirect"
+    },
+    "customParams": {
+      "targetAgentName": "poc_development.json"
+    }
+  }
+}


### PR DESCRIPTION
Redirect-конфиг для POC-разработки по образцу `pr_rework_redirect.json`: из `[repo]`-тега в summary тикета делегирует в `repo-agents/<repo>/poc_development.json` потребителя.

Generic, без продуктовой специфики — вся она в конфиге потребителя.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>