### PR TITLE
fix: use loadProjectConfig() in direct-to-base-branch actions

### DIFF
--- a/js/commitAndPushToBaseBranch.js
+++ b/js/commitAndPushToBaseBranch.js
@@ -67,9 +67,9 @@ function action(params) {
         return false;
     }
 
-    var config = configLoader.loadConfig(params);
+    var config = configLoader.loadProjectConfig(params.jobParams || params);
     _workingDir = config.workingDir || null;
-    var baseBranch = (config.targetRepository && config.targetRepository.baseBranch) || 'main';
+    var baseBranch = (config.git && config.git.baseBranch) || 'main';
     var opts = (config.customParams && config.customParams.directPush) || {};
 
     try {

--- a/js/preCliSyncBaseBranch.js
+++ b/js/preCliSyncBaseBranch.js
@@ -33,9 +33,9 @@ function cleanCommandOutput(output) {
 }
 
 function action(params) {
-    var config = configLoader.loadConfig(params);
+    var config = configLoader.loadProjectConfig(params.jobParams || params);
     _workingDir = config.workingDir || null;
-    var baseBranch = (config.targetRepository && config.targetRepository.baseBranch) || 'main';
+    var baseBranch = (config.git && config.git.baseBranch) || 'main';
 
     try {
         var out = cleanCommandOutput(runCmd({


### PR DESCRIPTION
Хотфикс к #344: `configLoader.loadConfig` не существует — экспортируется `loadProjectConfig(params.jobParams || params)`. Post-action падал с TypeError, изменения не пушились. Заодно `baseBranch` читается из `config.git.baseBranch` (куда маппится `customParams.targetRepository.baseBranch`).

Поймано на первом живом прогоне POC-агента.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>