### PR TITLE
feat(knowledge): knowledgeRepoDir for separate memory-repo checkouts

### DIFF
--- a/js/preCliKnowledgeUpdateSetup.js
+++ b/js/preCliKnowledgeUpdateSetup.js
@@ -24,6 +24,14 @@
  * (e.g. baseBranchResolverFnPath, snapshotBranchResolverFnPath) — a project
  * that hasn't opted in must never fail or produce noise.
  *
+ * customParams.knowledgeRepoDir (also optional) names a SEPARATE
+ * knowledge-hosting repository checked out inside the workspace (e.g. a shared
+ * memory repo cloned under dependencies/ via .dmtools/repositories.json). When
+ * set, the agent-facing target path becomes <knowledgeRepoDir>/<knowledgeDir>
+ * and the pushKnowledgeUpdate post-action scopes all git commands to that
+ * repository via `git -C`, so knowledge branches are pushed to the memory
+ * repo's origin — never to the outer working repo.
+ *
  * When knowledgeDir IS configured, one of three input modes is used (checked
  * in this order):
  *
@@ -61,6 +69,18 @@ function writeNoOpMarker(inputFolder, reason) {
             '\n\nDo NOT read or modify any knowledge/ directory this run. Stop after ' +
             'confirming this file says so; do not attempt to find one yourself.\n'
     });
+}
+
+/**
+ * Path the CLI agent should read/write, relative to its working directory.
+ * When customParams.knowledgeRepoDir names a separate knowledge-hosting repo
+ * checked out inside the workspace (e.g. a shared memory repo under
+ * dependencies/ from .dmtools/repositories.json), the agent-facing path is
+ * <knowledgeRepoDir>/<knowledgeDir>; the post-action scopes git to that repo.
+ */
+function agentKnowledgePath(customParams) {
+    var repoDir = customParams.knowledgeRepoDir;
+    return repoDir ? repoDir + '/' + customParams.knowledgeDir : customParams.knowledgeDir;
 }
 
 function writeTaskMarker(inputFolder, knowledgeDir, prDetails) {
@@ -191,16 +211,19 @@ function action(params) {
         }
 
         var prDetailsForContext = resolved.prDetails || {};
+        var agentPath = agentKnowledgePath(customParams);
         gh.writePRContext(inputFolder, prDetailsForContext, resolved.diffText, resolved.discussionsMarkdown, resolved.discussionsRaw);
-        writeTaskMarker(inputFolder, knowledgeDir, resolved.prDetails);
+        writeTaskMarker(inputFolder, agentPath, resolved.prDetails);
 
-        console.log('✅ Knowledge update setup complete — target:', knowledgeDir);
+        console.log('✅ Knowledge update setup complete — target:', agentPath);
 
         return {
             success: true,
             prNumber: prDetailsForContext.number || null,
             prUrl: prDetailsForContext.html_url || null,
-            knowledgeDir: knowledgeDir
+            knowledgeDir: knowledgeDir,
+            knowledgeRepoDir: customParams.knowledgeRepoDir || null,
+            agentKnowledgePath: agentPath
         };
 
     } catch (error) {
@@ -210,5 +233,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, writeNoOpMarker, resolvePrContext };
+    module.exports = { action, writeNoOpMarker, resolvePrContext, agentKnowledgePath };
 }

--- a/js/pushKnowledgeUpdate.js
+++ b/js/pushKnowledgeUpdate.js
@@ -38,6 +38,23 @@ function branchSlugFor(customParams) {
     return 'update-' + ts;
 }
 
+/**
+ * Builds a git command scoped to the knowledge-hosting repository.
+ *
+ * By default (no customParams.knowledgeRepoDir) the knowledge base lives in the
+ * current working repository and plain `git <args>` is used — the original
+ * single-repo behavior. When the knowledge base lives in a SEPARATE repository
+ * checked out inside the workspace (e.g. a shared memory repo cloned under
+ * dependencies/ via .dmtools/repositories.json), customParams.knowledgeRepoDir
+ * points at that checkout and every git command is scoped to it via `git -C`,
+ * so branch/commit/push hit the memory repo's origin and never touch the outer
+ * working repo. knowledgeDir stays relative to that repo root.
+ */
+function gitCommand(customParams, args) {
+    var repoDir = customParams.knowledgeRepoDir;
+    return repoDir ? 'git -C "' + repoDir + '" ' + args : 'git ' + args;
+}
+
 function action(params) {
     try {
         var actualParams = params.inputFolderPath ? params : (params.jobParams || params);
@@ -50,7 +67,7 @@ function action(params) {
             return { success: true, skipped: true };
         }
 
-        var status = cleanOutput(cli_execute_command({ command: 'git status --porcelain -- "' + knowledgeDir + '"' }));
+        var status = cleanOutput(cli_execute_command({ command: gitCommand(customParams, 'status --porcelain -- "' + knowledgeDir + '"') }));
         if (!status) {
             console.log('pushKnowledgeUpdate: no changes under', knowledgeDir, '— nothing to push.');
             return { success: true, skipped: true };
@@ -58,8 +75,8 @@ function action(params) {
 
         console.log('pushKnowledgeUpdate: detected changes under', knowledgeDir, ':\n' + status);
 
-        cli_execute_command({ command: 'git config user.name "' + GIT_CONFIG.AUTHOR_NAME + '"' });
-        cli_execute_command({ command: 'git config user.email "' + GIT_CONFIG.AUTHOR_EMAIL + '"' });
+        cli_execute_command({ command: gitCommand(customParams, 'config user.name "' + GIT_CONFIG.AUTHOR_NAME + '"') });
+        cli_execute_command({ command: gitCommand(customParams, 'config user.email "' + GIT_CONFIG.AUTHOR_EMAIL + '"') });
 
         var slug = branchSlugFor(customParams);
         var branchName = 'knowledge/' + slug + '-review-lessons';
@@ -67,15 +84,17 @@ function action(params) {
             ? 'knowledge(pr-' + customParams.prNumber + '): distill review lessons from merged PR'
             : 'knowledge: distill review lessons';
 
-        cli_execute_command({ command: 'git checkout -b "' + branchName + '"' });
-        cli_execute_command({ command: 'git add -- "' + knowledgeDir + '"' });
-        cli_execute_command({ command: 'git commit -m "' + commitSubject + '"' });
+        cli_execute_command({ command: gitCommand(customParams, 'checkout -b "' + branchName + '"') });
+        cli_execute_command({ command: gitCommand(customParams, 'add -- "' + knowledgeDir + '"') });
+        cli_execute_command({ command: gitCommand(customParams, 'commit -m "' + commitSubject + '"') });
 
-        var pushOutput = cleanOutput(cli_execute_command({ command: 'git push -u origin "' + branchName + '"' }));
+        var pushOutput = cleanOutput(cli_execute_command({ command: gitCommand(customParams, 'push -u origin "' + branchName + '"') }));
         console.log('pushKnowledgeUpdate: pushed branch', branchName);
         console.log(pushOutput);
 
-        return { success: true, branchName: branchName, knowledgeDir: knowledgeDir };
+        var result = { success: true, branchName: branchName, knowledgeDir: knowledgeDir };
+        if (customParams.knowledgeRepoDir) result.knowledgeRepoDir = customParams.knowledgeRepoDir;
+        return result;
 
     } catch (error) {
         console.error('❌ Error in pushKnowledgeUpdate:', error);
@@ -84,5 +103,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action };
+    module.exports = { action, gitCommand };
 }

--- a/js/unit-tests/test_preCliKnowledgeUpdateSetup.js
+++ b/js/unit-tests/test_preCliKnowledgeUpdateSetup.js
@@ -301,3 +301,48 @@ suite('preCliKnowledgeUpdateSetup — no usable material at all', function() {
         assert.equal(result.reason, 'no diff or discussions available');
     });
 });
+
+suite('preCliKnowledgeUpdateSetup — knowledgeRepoDir (separate memory repo checkout)', function() {
+
+    test('task marker points the agent at <knowledgeRepoDir>/<knowledgeDir>', function() {
+        var tracker = makeWriteTracker();
+        var scm = { getDiffText: function() { return 'diff --git a/x b/x'; } };
+        var gh = makeGhStub({
+            getPRDetails: function() { return { number: 42, html_url: 'https://example.com/pr/42', title: 'x', state: 'merged' }; },
+            fetchDiscussionsAndRawData: function() { return { markdown: '## Thread', rawThreads: null }; },
+            writePRContext: function() {}
+        });
+
+        var mod = loadPreCliKnowledgeUpdateSetup(gh, scm, { file_write: tracker.file_write });
+
+        var result = mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: {
+                knowledgeDir: 'platform-core',
+                knowledgeRepoDir: 'dependencies/acme-review-memory',
+                prNumber: '42'
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.knowledgeDir, 'platform-core');
+        assert.equal(result.knowledgeRepoDir, 'dependencies/acme-review-memory');
+        assert.equal(result.agentKnowledgePath, 'dependencies/acme-review-memory/platform-core');
+
+        var marker = tracker.find('input/pr_knowledge_update/knowledge_task.md');
+        assert.ok(marker);
+        assert.contains(marker.content, 'dependencies/acme-review-memory/platform-core');
+    });
+
+    test('agentKnowledgePath falls back to plain knowledgeDir when knowledgeRepoDir is unset', function() {
+        var mod = loadPreCliKnowledgeUpdateSetup(makeGhStub(), {}, {});
+        assert.equal(
+            mod.agentKnowledgePath({ knowledgeDir: 'platform-core' }),
+            'platform-core'
+        );
+        assert.equal(
+            mod.agentKnowledgePath({ knowledgeDir: 'platform-core', knowledgeRepoDir: 'dependencies/memory' }),
+            'dependencies/memory/platform-core'
+        );
+    });
+});

--- a/js/unit-tests/test_pushKnowledgeUpdate.js
+++ b/js/unit-tests/test_pushKnowledgeUpdate.js
@@ -149,3 +149,81 @@ suite('pushKnowledgeUpdate — commits and pushes changes', function() {
         assert.equal(addCalls[0], 'git add -- "knowledge"');
     });
 });
+
+suite('pushKnowledgeUpdate — knowledgeRepoDir (separate memory repo checkout)', function() {
+
+    function loadWithStatus(statusOutput) {
+        var cliCalls = [];
+        var mod = loadModule(
+            'js/pushKnowledgeUpdate.js',
+            makeRequire({
+                './configLoader.js': { loadProjectConfig: function() { return {}; } },
+                './config.js': configModule,
+                'config': configModule
+            }),
+            {
+                cli_execute_command: function(opts) {
+                    cliCalls.push(opts.command);
+                    if (opts.command.indexOf('status --porcelain') !== -1) return statusOutput;
+                    return '';
+                }
+            }
+        );
+        return { mod: mod, cliCalls: cliCalls };
+    }
+
+    test('scopes every git command to knowledgeRepoDir via git -C', function() {
+        var loaded = loadWithStatus(' M platform-core/heuristics/foo.md\n');
+
+        var result = loaded.mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: {
+                knowledgeDir: 'platform-core',
+                knowledgeRepoDir: 'dependencies/acme-review-memory',
+                prNumber: '42'
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.knowledgeRepoDir, 'dependencies/acme-review-memory');
+
+        loaded.cliCalls.forEach(function(cmd) {
+            assert.ok(cmd.indexOf('git -C "dependencies/acme-review-memory"') === 0,
+                'every git command must be scoped to the memory repo, got: ' + cmd);
+        });
+
+        var addCall = loaded.cliCalls.filter(function(c) { return c.indexOf('add --') !== -1; })[0];
+        assert.ok(addCall.indexOf('add -- "platform-core"') !== -1,
+            'git add must use the knowledgeDir relative to the memory repo root');
+    });
+
+    test('status check with knowledgeRepoDir still no-ops cleanly when nothing changed', function() {
+        var loaded = loadWithStatus('');
+
+        var result = loaded.mod.action({
+            inputFolderPath: 'input/pr_knowledge_update',
+            customParams: {
+                knowledgeDir: 'platform-core',
+                knowledgeRepoDir: 'dependencies/acme-review-memory',
+                prNumber: '42'
+            }
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.skipped, true);
+        assert.equal(loaded.cliCalls.length, 1);
+        assert.contains(loaded.cliCalls[0], 'git -C "dependencies/acme-review-memory" status --porcelain');
+    });
+
+    test('gitCommand leaves commands unscoped when knowledgeRepoDir is unset', function() {
+        var loaded = loadWithStatus('');
+        assert.equal(
+            loaded.mod.gitCommand({ knowledgeDir: 'X' }, 'status'),
+            'git status'
+        );
+        assert.equal(
+            loaded.mod.gitCommand({ knowledgeDir: 'X', knowledgeRepoDir: 'deps/mem' }, 'status'),
+            'git -C "deps/mem" status'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to #336. Lets a consuming repo host its review-knowledge base in a **separate repository** checked out inside the workspace (e.g. a shared `acme-review-memory` repo cloned under `dependencies/` via `.dmtools/repositories.json`), instead of the working repo itself.

## Changes

- `customParams.knowledgeRepoDir` (optional) names that checkout.
- `js/preCliKnowledgeUpdateSetup.js`: the agent-facing target path in `knowledge_task.md` becomes `<knowledgeRepoDir>/<knowledgeDir>`; the action result exposes `knowledgeDir`, `knowledgeRepoDir`, and the joined `agentKnowledgePath`.
- `js/pushKnowledgeUpdate.js`: every git command is scoped via `git -C <knowledgeRepoDir>` (status / config / checkout -b / add / commit / push), so the knowledge branch is pushed to the memory repo's origin and the outer working repo is never touched. `git add` still stages only `knowledgeDir`, relative to the memory repo root.

Backward compatible: without `knowledgeRepoDir` the behavior is byte-identical to before (plain `git` in cwd).

## Verification

- `run_preCliKnowledgeUpdateSetup.json` (both knowledge suites): **19 passed, 0 failed** (+5 new tests).
- `run_all.json`: 724 passed, 4 failed — the 4 failures (`gitOps.checkoutPRBranch`, `pullRequest` helper refspec expectations) reproduce identically on clean `origin/main` (719 passed, 4 failed) and are unrelated.