### PR TITLE
fix: avoid shell metacharacters in direct-to-base-branch actions

### DIFF
--- a/js/commitAndPushToBaseBranch.js
+++ b/js/commitAndPushToBaseBranch.js
@@ -17,7 +17,10 @@
  *
  * Configuration (customParams.directPush):
  *   - commitMessage:    e.g. "Update {ticketKey} artifacts"
- *   - gateCommand:      e.g. "npm run build" (optional, supports {ticketKey})
+ *   - gateCommand:      e.g. "bash scripts/gate.sh {ticketKey}" (optional,
+ *                       supports {ticketKey}). Must be a SINGLE plain command —
+ *                       the executor rejects shell metacharacters
+ *                       (&&, ||, |, ;, >, <). Wrap logic in a script file.
  *   - resultUrlTemplate: e.g. "https://example.com/{ticketKey}/" (optional)
  *   - successComment:   comment posted on success (optional)
  *   - noChangesComment: comment posted when nothing changed (optional)
@@ -83,9 +86,13 @@ function action(params) {
         }
 
         if (opts.gateCommand) {
+            // NOTE: cli_execute_command rejects shell metacharacters
+            // (&&, ||, |, ;, >, <, ...). gateCommand must be a single plain
+            // invocation — wrap any logic into a script in the target repo
+            // (e.g. "bash scripts/gate.sh {ticketKey}").
             var gateCmd = opts.gateCommand.split('{ticketKey}').join(ticketKey);
             try {
-                var gateOut = cleanCommandOutput(runCmd({ command: gateCmd + ' 2>&1 | tail -20' }));
+                var gateOut = cleanCommandOutput(runCmd({ command: gateCmd }));
                 console.log('commitAndPushToBaseBranch: gate passed. ' + gateOut);
             } catch (gateError) {
                 console.error('commitAndPushToBaseBranch: gate failed, not pushing:', gateError.toString());

--- a/js/preCliSyncBaseBranch.js
+++ b/js/preCliSyncBaseBranch.js
@@ -9,6 +9,10 @@
  * Ensures the working copy (customParams.targetRepository.workingDir) is on
  * the configured baseBranch and fast-forwarded to origin.
  *
+ * Shell-safety: cli_execute_command rejects shell metacharacters
+ * (&&, ||, |, ;, >, <, backticks, $(...), ${...}) — every command here is a
+ * single plain invocation. Never chain commands in this file.
+ *
  * Configuration (customParams.targetRepository):
  *   - baseBranch: branch to sync (default "main")
  *   - workingDir: checkout directory (from targetRepository.workingDir)
@@ -38,9 +42,10 @@ function action(params) {
     var baseBranch = (config.git && config.git.baseBranch) || 'main';
 
     try {
-        var out = cleanCommandOutput(runCmd({
-            command: 'git checkout ' + baseBranch + ' && git pull --ff-only origin ' + baseBranch
-        }));
+        // NOTE: cli_execute_command rejects shell metacharacters (&&, |, ;, ...).
+        // Each git invocation must be a separate call.
+        cleanCommandOutput(runCmd({ command: 'git checkout ' + baseBranch }));
+        var out = cleanCommandOutput(runCmd({ command: 'git pull --ff-only origin ' + baseBranch }));
         console.log('preCliSyncBaseBranch: on ' + baseBranch + ', up to date. ' + out);
         return true;
     } catch (e) {


### PR DESCRIPTION
cli_execute_command валидирует команды и отклоняет shell-метасимволы (`&&`, `||`, `|`, `;`, `>`, `<`, backticks, ``). Прошлая версия чейнила git-команды через `&&` и добавляла `| tail` к gate — preCli падал на валидации и абортил весь прогон до старта CLI-агента.

- preCliSyncBaseBranch: отдельные вызовы git checkout / git pull
- commitAndPushToBaseBranch: gateCommand выполняется as-is (задокументировано: одна простая команда, логику заворачивать в скрипт-файл репо)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>