### PR TITLE
fix: update stale test refs after ensureRemoteBranchRef introduction

### DIFF
--- a/js/unit-tests/test_gitOps.js
+++ b/js/unit-tests/test_gitOps.js
@@ -17,6 +17,18 @@ function loadGitOps(mocks) {
             './pullRequest.js': {
                 buildOriginFetchCommand: function(refSpec) {
                     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                },
+                ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                    if (!branchName) return false;
+                    try {
+                        runCommand(
+                            'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName,
+                            workingDir
+                        );
+                        return true;
+                    } catch (e) {
+                        return false;
+                    }
                 }
             }
         }),

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -143,7 +143,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.success, true);
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
-            { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
+            { command: 'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/main:refs/remotes/origin/main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
             { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
@@ -170,7 +170,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.success, true);
         assert.equal(result.updated, false);
         assert.deepEqual(commands, [
-            'git -c fetch.recurseSubmodules=no fetch origin release',
+            'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/release:refs/remotes/origin/release',
             'git rev-parse origin/release',
             'git merge-base origin/release HEAD'
         ]);
@@ -196,7 +196,7 @@ suite('pullRequest helper', function() {
         assert.equal(result.success, true);
         assert.equal(result.updated, true);
         assert.deepEqual(commands, [
-            { command: 'git -c fetch.recurseSubmodules=no fetch origin main', workingDirectory: 'repo' },
+            { command: 'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/main:refs/remotes/origin/main', workingDirectory: 'repo' },
             { command: 'git rev-parse origin/main', workingDirectory: 'repo' },
             { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },
             { command: 'git merge-base origin/main HEAD', workingDirectory: 'repo' },


### PR DESCRIPTION
Commit ee4758e introduced ensureRemoteBranchRef() which changed the fetch format from bare-branch to explicit refspecs (+refs/heads/<b>:refs/remotes/origin/<b>). The unit tests were not updated to match:

## Changes

### test_gitOps.js
The ./pullRequest.js mock in loadGitOps() was missing ensureRemoteBranchRef, causing 'not a function' TypeError in checkoutPRBranch tests that pass a baseBranch argument.

**Fix:** Added ensureRemoteBranchRef to the mock, matching the real implementation's contract from pullRequest.js.

### test_pullRequestHelper.js
3 syncBranchWithBase tests asserted the old bare-branch fetch format:
- fetch origin main → fetch origin +refs/heads/main:refs/remotes/origin/main (2 occurrences)
- fetch origin release → fetch origin +refs/heads/release:refs/remotes/origin/release

**Fix:** Updated the 3 expected command strings to use the refspec format.

## Why the source code is correct

git fetch origin <branch> only updates FETCH_HEAD and never creates refs/remotes/origin/<branch>, so any non-main base branch (e.g. develop/3.9.0) silently fails downstream merge-base/merge/diff calls. The ensureRemoteBranchRef helper deliberately uses explicit refspecs to fix this — the tests were stale expectations, not bugs in the source.

## Verification

Ran the full test suite (698 tests) under the Dart QuickJS runtime:

    698 passed, 0 failed