### PR TITLE
fix(git): keep generated .codegraph index out of branch setup and auto-commits

### DIFF
--- a/js/developBugAndCreatePR.js
+++ b/js/developBugAndCreatePR.js
@@ -214,7 +214,7 @@ function action(params) {
             } catch (cleanupErr) {
                 console.warn('Could not remove tracked Copilot session cache before checking status:', cleanupErr);
             }
-            cli_execute_command({ command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"' });
+            cli_execute_command({ command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**" ":!.codegraph" ":!.codegraph/**"' });
             const rawStatus = cli_execute_command({ command: 'git status --porcelain' }) || '';
             const statusLines = rawStatus.split('\n').filter(function(l) {
                 return l.trim() &&

--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -215,7 +215,7 @@ function performGitOperations(branchName, commitMessage, baseBranch, config, cus
         // Stage all changes
         console.log('Staging changes...');
         runCmd({
-            command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"'
+            command: 'git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**" ":!.codegraph" ":!.codegraph/**"'
         });
 
         // Check if there are changes to commit

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -127,6 +127,36 @@ function alignBranchWithBase(ticketKey, branchName, baseBranch) {
     console.warn('Keeping divergent branch ' + branchName + '; conflict guidance written for the agent.');
 }
 
+// ── Generated index guard (.codegraph) ──────────────────────────────────────
+// `codegraph init/sync` (CI setup step) stages .codegraph/ into the git index.
+// If an older run auto-committed that generated index onto the target branch,
+// `git checkout <branch>` fails with "Your local changes ... would be
+// overwritten". Move the index aside for the duration of branch setup and
+// restore it afterwards; if the checked-out branch still tracks .codegraph,
+// untrack it so the next auto-commit removes it (self-healing).
+function stashGeneratedIndex() {
+    try { runCmd({ command: 'git rm -r --cached --ignore-unmatch .codegraph' }); } catch (e) {}
+    try {
+        runCmd({ command: 'if [ -d .codegraph ]; then rm -rf .codegraph.branch-setup-bak && mv .codegraph .codegraph.branch-setup-bak; fi' });
+    } catch (e) {
+        console.warn('Could not move .codegraph aside before branch setup:', e);
+    }
+}
+
+function restoreGeneratedIndex() {
+    try { runCmd({ command: 'git rm -r --cached --ignore-unmatch .codegraph' }); } catch (e) {}
+    try {
+        runCmd({ command: 'if [ -f .gitignore ] && ! grep -qxF ".codegraph/" .gitignore; then printf "\\n# CodeGraph generated index - regenerated per-run, must never be committed\\n.codegraph/\\n" >> .gitignore; fi' });
+    } catch (e) {
+        console.warn('Could not add .codegraph/ to .gitignore:', e);
+    }
+    try {
+        runCmd({ command: 'if [ -d .codegraph.branch-setup-bak ]; then rm -rf .codegraph && mv .codegraph.branch-setup-bak .codegraph; fi' });
+    } catch (e) {
+        console.warn('Could not restore .codegraph after branch setup:', e);
+    }
+}
+
 function checkoutBranch(ticketKey, config, ticket, customParams) {
     ticket = ticket || { key: ticketKey, fields: {} };
     customParams = customParams || {};
@@ -139,6 +169,8 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
     var branchName = configLoader.resolveBranchName(config, ticket, 'development');
     var rebaseBase = configLoader.resolvePRTargetBranch(config, ticket);
     console.log('Setting up branch:', branchName);
+
+    stashGeneratedIndex();
 
     try {
         runCmd({ command: 'git config user.name "' + config.git.authorName + '"' });
@@ -161,6 +193,7 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
         console.warn('Error checking local branches:', e);
     }
 
+    try {
     if (localBranches.trim()) {
         console.log('Branch exists locally, aligning with base:', branchName);
         runCmd({ command: 'git checkout ' + branchName });
@@ -241,6 +274,9 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
     }
 
     console.log('Branch ready:', branchName);
+    } finally {
+        restoreGeneratedIndex();
+    }
 }
 
 function postSetupErrorToJira(ticketKey, stage, errorMessage) {

--- a/js/pushReworkChanges.js
+++ b/js/pushReworkChanges.js
@@ -210,7 +210,7 @@ function commitAndPush(ticketKey, config, customParams) {
         console.warn('Could not remove tracked Copilot session cache before staging:', cleanupErr);
     }
 
-    cmd('git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"');
+    cmd('git add . -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**" ":!.codegraph" ":!.codegraph/**"');
 
     const status = prHelper.readStagedDiffStat(cmd, workingDir);
 

--- a/js/timerAutoCommitAndSave.js
+++ b/js/timerAutoCommitAndSave.js
@@ -112,7 +112,7 @@ function autoCommitAndPush(customParams, ticketKey) {
 
     try {
         cli_execute_command({
-            command: 'git add -A -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**"',
+            command: 'git add -A -- ":!.dmtools/copilot-sessions" ":!.dmtools/copilot-sessions/**" ":!.codegraph" ":!.codegraph/**"',
             workingDirectory: workingDir
         });
     } catch (e) {

--- a/js/unit-tests/test_developBugAndCreatePR.js
+++ b/js/unit-tests/test_developBugAndCreatePR.js
@@ -109,7 +109,10 @@ suite('developBugAndCreatePR', function() {
         assert.equal(result.path, 'interrupted');
         assert.notOk(
             loaded.commands.some(function(c) {
-                return c.indexOf('.agent-bin') !== -1 || c.indexOf('.codegraph') !== -1;
+                // Pathspec exclusions (":!.codegraph") are staging guards, not cleanup —
+                // strip them before checking for actual artifact management commands.
+                var stripped = c.split('":!.codegraph/**"').join('').split('":!.codegraph"').join('');
+                return stripped.indexOf('.agent-bin') !== -1 || stripped.indexOf('.codegraph') !== -1;
             }),
             'CodeGraph setup/cleanup belongs to setup scripts, not JS post-actions'
         );

--- a/js/unit-tests/test_preCliDevelopmentSetup.js
+++ b/js/unit-tests/test_preCliDevelopmentSetup.js
@@ -192,3 +192,97 @@ suite('preCliDevelopmentSetup.checkoutBranch — two-branch mode feature branch 
     });
 
 });
+
+suite('preCliDevelopmentSetup.checkoutBranch — generated .codegraph index guard', function() {
+
+    var STASH_RM_CMD = 'git rm -r --cached --ignore-unmatch .codegraph';
+    var STASH_MV_CMD = 'if [ -d .codegraph ]; then rm -rf .codegraph.branch-setup-bak && mv .codegraph .codegraph.branch-setup-bak; fi';
+    var RESTORE_MV_CMD = 'if [ -d .codegraph.branch-setup-bak ]; then rm -rf .codegraph && mv .codegraph.branch-setup-bak .codegraph; fi';
+
+    function loadForGuard(calls, responses) {
+        var config = makeConfig({ git: { featureBranch: { enabled: false } } });
+        var configLoaderStub = makeConfigLoaderStub({ development: 'ai/PROJ-1' }, 'master', null, []);
+        return {
+            mod: loadPreCliDevelopmentSetup(configLoaderStub, {
+                cli_execute_command: makeCliMock(calls, responses)
+            }),
+            config: config
+        };
+    }
+
+    test('stashes .codegraph before any checkout and restores it afterwards', function() {
+        var calls = [];
+        var ctx = loadForGuard(calls, {});
+
+        ctx.mod.checkoutBranch('PROJ-1', ctx.config, TICKET, {});
+
+        var stashRmIdx = calls.indexOf(STASH_RM_CMD);
+        var stashMvIdx = calls.indexOf(STASH_MV_CMD);
+        var checkoutIdx = calls.indexOf('git checkout master');
+        var restoreMvIdx = calls.lastIndexOf(RESTORE_MV_CMD);
+
+        assert.ok(stashRmIdx !== -1, 'unstages .codegraph before branch setup');
+        assert.ok(stashMvIdx !== -1, 'moves .codegraph aside before branch setup');
+        assert.ok(restoreMvIdx !== -1, 'restores .codegraph after branch setup');
+        assert.ok(stashMvIdx < checkoutIdx, 'stash happens before checkout');
+        assert.ok(restoreMvIdx > calls.lastIndexOf('git checkout -b ai/PROJ-1'), 'restore happens after checkout');
+    });
+
+    test('restores .codegraph even when checkout fails', function() {
+        var calls = [];
+        var responses = {};
+        var ctx = loadForGuard(calls, responses);
+        // Existing local branch → plain checkout, which we make fail (dirty .codegraph scenario).
+        responses['git branch --list "ai/PROJ-1"'] = 'ai/PROJ-1';
+        var failingCalls = [];
+        var configLoaderStub = makeConfigLoaderStub({ development: 'ai/PROJ-1' }, 'master', null, []);
+        var mod = loadPreCliDevelopmentSetup(configLoaderStub, {
+            cli_execute_command: function(opts) {
+                var command = opts && opts.command;
+                failingCalls.push(command);
+                if (command === 'git checkout ai/PROJ-1') {
+                    throw new Error('error: Your local changes to .codegraph/codegraph.db would be overwritten');
+                }
+                if (responses && Object.prototype.hasOwnProperty.call(responses, command)) {
+                    return responses[command];
+                }
+                return '';
+            }
+        });
+
+        var threw = false;
+        try {
+            mod.checkoutBranch('PROJ-1', makeConfig({ git: { featureBranch: { enabled: false } } }), TICKET, {});
+        } catch (e) {
+            threw = true;
+        }
+
+        assert.ok(threw, 'checkout failure propagates');
+        assert.ok(failingCalls.indexOf(RESTORE_MV_CMD) !== -1, 'restore runs even on checkout failure');
+        // stash rm + restore rm = at least two untrack calls
+        var rmCount = failingCalls.filter(function(c) { return c === STASH_RM_CMD; }).length;
+        assert.ok(rmCount >= 2, 'restore untracks .codegraph on the (attempted) branch');
+    });
+
+    test('guard commands run inside config.workingDir when set', function() {
+        var calls = [];
+        var dirs = [];
+        var configLoaderStub = makeConfigLoaderStub({ development: 'ai/PROJ-1' }, 'master', null, []);
+        var mod = loadPreCliDevelopmentSetup(configLoaderStub, {
+            cli_execute_command: function(opts) {
+                calls.push(opts && opts.command);
+                dirs.push(opts && opts.workingDirectory);
+                return '';
+            },
+            file_write: function() {}
+        });
+        var config = makeConfig({ git: { featureBranch: { enabled: false } }, workingDir: 'dependencies/target-repo' });
+
+        mod.checkoutBranch('PROJ-1', config, TICKET, {});
+
+        var stashMvIdx = calls.indexOf(STASH_MV_CMD);
+        assert.ok(stashMvIdx !== -1, 'stash command ran');
+        assert.equal(dirs[stashMvIdx], 'dependencies/target-repo', 'stash runs in the dependency working dir');
+    });
+
+});


### PR DESCRIPTION
## Problem

`codegraph init/sync` (CI setup step) stages `.codegraph/` into the dependency repo's git index. Auto-commit post-actions (`git add -A`) then sweep the generated index (40+ MB `codegraph.db`) into the ticket branch. Every subsequent run for the same ticket fails at branch setup:

```
git checkout bug/MAPC-8068
error: Your local changes to the following files would be overwritten by checkout:
	.codegraph/codegraph.db
```

The existing fallback (`git checkout -B <branch> origin/<branch>`) fails the same way, so development stops before code generation.

## Fix

- **`checkoutBranch` (preCliDevelopmentSetup.js)**: move `.codegraph` aside for the duration of branch setup and restore it in `finally`. After checkout, untrack `.codegraph` on the branch and ensure it is in `.gitignore` — branches already poisoned by older runs self-heal on the next auto-commit.
- **Auto-commit staging** (`timerAutoCommitAndSave.js`, `developBugAndCreatePR.js`, `developTicketAndCreatePR.js`, `pushReworkChanges.js`): exclude `.codegraph` via pathspec alongside the existing `copilot-sessions` exclusion.

No project-specific content — `.codegraph` handling matches the existing generic setup scripts (`setup/codegraph.sh`, `setup/_common.sh`).

## Tests

- 3 new unit tests for the checkout guard (stash-before-checkout, restore-on-failure, workingDir propagation)
- Updated `test_developBugAndCreatePR.js` to allow `:!.codegraph` pathspec exclusions (staging guard, not artifact cleanup)
- `run_all.json`: 722 passed, 4 failed — the 4 failures pre-exist on `main` (verified by stashing)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>