### PR TITLE
fix(autoStart): dispatch workflows against the AI repo's own ref

### DIFF
--- a/js/common/autoStart.js
+++ b/js/common/autoStart.js
@@ -243,10 +243,15 @@ function triggerConfiguredWorkflowForTicket(options) {
     var config = options.config || {};
     var configFile = options.configFile;
     var workflowFile = options.workflowFile || 'ai-teammate.yml';
-    // Default to the target repo's actual default branch (config.git.baseBranch, e.g. 'master')
-    // rather than assuming 'main' — dispatching a workflow_dispatch against a non-existent ref
-    // fails with "No ref found for: <ref>" (HTTP 422) and silently breaks auto-chaining.
-    var ref = options.ref || (config.git && config.git.baseBranch) || 'main';
+    // The dispatch targets the AI repo (customParams.aiRepository), which may differ
+    // from the target repo — then the target's baseBranch may not exist there
+    // ("No ref found for: <ref>", HTTP 422). Precedence: explicit options.ref →
+    // aiRepository.ref/branch → target repo's baseBranch → 'main'.
+    var aiRepoCfgForRef = customParams.aiRepository;
+    var ref = options.ref
+        || (aiRepoCfgForRef && (aiRepoCfgForRef.ref || aiRepoCfgForRef.branch))
+        || (config.git && config.git.baseBranch)
+        || 'main';
     var label = options.label || configFile || workflowFile;
     if (!ticketKey || !configFile) {
         console.warn('autoStart: missing ticketKey or configFile — skipping');
@@ -375,7 +380,11 @@ function triggerSmIfIdle(options) {
     }
 
     try {
-        var ref = (config.git && config.git.baseBranch) || 'main';
+        // Same ref precedence as triggerConfiguredWorkflowForTicket: the dispatch goes
+        // to the AI repo, whose default branch may differ from the target repo's.
+        var ref = (aiRepoCfg && (aiRepoCfg.ref || aiRepoCfg.branch))
+            || (config.git && config.git.baseBranch)
+            || 'main';
         scm.triggerWorkflow(aiOwner, aiRepo, smWorkflowFile, '{}', ref);
         console.log('✅ SM fallback: system idle — triggered ' + smWorkflowFile);
         return true;

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -467,3 +467,105 @@ suite('triggerSmIfIdle', function() {
     });
 
 });
+
+suite('autoStart — AI-repo dispatch ref (aiRepository.ref)', function() {
+
+    test('workflow dispatch uses aiRepository.ref over target baseBranch', function() {
+        var triggeredPayload = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredPayload = { owner: owner, repo: repo, ref: ref };
+            }
+        });
+
+        // Target repo's baseBranch ('develop') does not exist in the AI repo —
+        // dispatching there must use the AI repo's own ref.
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'target-repo' }, git: { baseBranch: 'develop' } },
+            customParams: {
+                aiRepository: { owner: 'IstiN', repo: 'ai-repo', ref: 'main' }
+            },
+            configFile: 'agents/pr_review.json'
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggeredPayload.repo, 'ai-repo');
+        assert.equal(triggeredPayload.ref, 'main', 'should dispatch against aiRepository.ref, not the target baseBranch');
+    });
+
+    test('workflow dispatch accepts aiRepository.branch as alias', function() {
+        var triggeredPayload = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredPayload = { ref: ref };
+            }
+        });
+
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'target-repo' }, git: { baseBranch: 'develop' } },
+            customParams: {
+                aiRepository: { owner: 'IstiN', repo: 'ai-repo', branch: 'main' }
+            },
+            configFile: 'agents/pr_review.json'
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggeredPayload.ref, 'main');
+    });
+
+    test('workflow dispatch falls back to target baseBranch when aiRepository has no ref', function() {
+        var triggeredPayload = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredPayload = { ref: ref };
+            }
+        });
+
+        var result = autoStart.triggerConfiguredWorkflowForTicket({
+            ticketKey: 'TS-90',
+            config: { repository: { owner: 'IstiN', repo: 'trackstate' }, git: { baseBranch: 'master' } },
+            customParams: {
+                aiRepository: { owner: 'IstiN', repo: 'trackstate' }
+            },
+            configFile: 'agents/pr_review.json'
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggeredPayload.ref, 'master', 'same-repo setups keep dispatching against baseBranch');
+    });
+
+    test('SM fallback uses aiRepository.ref over target baseBranch', function() {
+        var triggeredWorkflow = null;
+        var autoStart = loadAutoStartHelper({
+            github_list_workflow_runs: function() {
+                return JSON.stringify({ workflow_runs: [] });
+            },
+            github_trigger_workflow: function(owner, repo, workflowFile, payload, ref) {
+                triggeredWorkflow = { ref: ref };
+            }
+        });
+
+        var result = autoStart.triggerSmIfIdle({
+            config: { repository: { owner: 'IstiN', repo: 'target-repo' }, git: { baseBranch: 'develop' } },
+            customParams: {
+                smFallback: true,
+                aiRepository: { owner: 'IstiN', repo: 'ai-repo', ref: 'main' }
+            }
+        });
+
+        assert.equal(result, true);
+        assert.equal(triggeredWorkflow.ref, 'main', 'SM fallback should dispatch against aiRepository.ref');
+    });
+
+});


### PR DESCRIPTION
## Problem

`triggerConfiguredWorkflowForTicket` / `triggerSmIfIdle` dispatch `workflow_dispatch` to the **AI repo** (`customParams.aiRepository`), but the ref defaulted to the **target repo's** `config.git.baseBranch`. When the two repos differ (orchestrator repo + product repo), the target's baseBranch may not exist in the AI repo — GitHub rejects the dispatch:

```
POST /repos/<ai-repo>/actions/workflows/ai-teammate.yml/dispatches
422: {"message":"No ref found for: develop"}
```

…and auto-chaining silently breaks: development finishes, PR opens, ticket moves to In Review — but `pr_review` never starts.

## Fix

Ref precedence is now:

`options.ref` → `aiRepository.ref` / `aiRepository.branch` → target `config.git.baseBranch` → `'main'`

Applied to both dispatch sites (`triggerConfiguredWorkflowForTicket`, `triggerSmIfIdle`). Same-repo setups (no `aiRepository.ref`) keep the existing baseBranch behavior.

## Tests

4 new unit tests in `test_autoStart.js`: `aiRepository.ref` wins over target baseBranch, `branch` alias, fallback to baseBranch when no AI-repo ref, SM fallback honors `aiRepository.ref`. Suite: 20/20 pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>