### PR TITLE
fix(preCliDevelopmentSetup): fetch baseBranch from origin before git checkout

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -267,6 +267,10 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
                 console.log('Two-branch mode: dev branch will be created from feature branch:', featureBranchName);
             }
             console.log('Creating new branch from', branchBase + ':', branchName);
+            // Explicitly fetch the base branch so origin/<branchBase> is available locally.
+            // git fetch origin --prune (done earlier) may not populate it in a shallow clone
+            // (e.g. cloned with --depth 1 --branch main, so only refs/heads/main exists locally).
+            runCmd({ command: prHelper.buildOriginFetchCommand(branchBase) });
             runCmd({ command: 'git checkout ' + branchBase });
             runCmd({ command: 'git pull origin ' + branchBase });
             runCmd({ command: 'git checkout -b ' + branchName });

--- a/js/unit-tests/test_preCliDevelopmentSetup.js
+++ b/js/unit-tests/test_preCliDevelopmentSetup.js
@@ -286,3 +286,65 @@ suite('preCliDevelopmentSetup.checkoutBranch — generated .codegraph index guar
     });
 
 });
+
+suite('preCliDevelopmentSetup.checkoutBranch — base branch fetch before checkout', function() {
+
+    test('fetches baseBranch from origin before git checkout when creating a new branch', function() {
+        var calls = [];
+        var configLoaderStub = makeConfigLoaderStub({ development: 'ai/PROJ-1' }, 'master', null, []);
+        var mod = loadPreCliDevelopmentSetup(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, {})
+        });
+        var config = makeConfig({ git: { featureBranch: { enabled: false } } });
+
+        mod.checkoutBranch('PROJ-1', config, TICKET, {});
+
+        var fetchIdx = -1;
+        var checkoutIdx = -1;
+        for (var i = 0; i < calls.length; i++) {
+            if (calls[i] && calls[i].indexOf('fetch origin') !== -1 && calls[i].indexOf('master') !== -1) {
+                fetchIdx = i;
+            }
+            if (calls[i] === 'git checkout master') {
+                checkoutIdx = i;
+            }
+        }
+        assert.ok(fetchIdx !== -1, 'git fetch origin master must run before checkout');
+        assert.ok(checkoutIdx !== -1, 'git checkout master must run');
+        assert.ok(fetchIdx < checkoutIdx, 'fetch must come before checkout (fetchIdx=' + fetchIdx + ', checkoutIdx=' + checkoutIdx + ')');
+    });
+
+    test('fetches two-branch feature base before git checkout when creating a new branch', function() {
+        var calls = [];
+        var hookLoadCalls = [];
+        var configLoaderStub = makeConfigLoaderStub(
+            { development: 'ai/PROJ-1', feature: 'release/rc_mobile_proj-1' },
+            'master',
+            null,
+            hookLoadCalls
+        );
+        var mod = loadPreCliDevelopmentSetup(configLoaderStub, {
+            cli_execute_command: makeCliMock(calls, {})
+        });
+        var config = makeConfig(); // featureBranch.enabled = true by default
+
+        mod.checkoutBranch('PROJ-1', config, TICKET, {});
+
+        // In two-branch mode the dev branch is created from the feature branch,
+        // so the fetch must target the feature branch name, not the raw baseBranch.
+        var fetchIdx = -1;
+        var checkoutIdx = -1;
+        for (var i = 0; i < calls.length; i++) {
+            if (calls[i] && calls[i].indexOf('fetch origin') !== -1 && calls[i].indexOf('release/rc_mobile_proj-1') !== -1) {
+                fetchIdx = i;
+            }
+            if (calls[i] === 'git checkout release/rc_mobile_proj-1') {
+                checkoutIdx = i;
+            }
+        }
+        assert.ok(fetchIdx !== -1, 'git fetch origin release/rc_mobile_proj-1 must run before checkout');
+        assert.ok(checkoutIdx !== -1, 'git checkout release/rc_mobile_proj-1 must run');
+        assert.ok(fetchIdx < checkoutIdx, 'fetch must come before checkout');
+    });
+
+});


### PR DESCRIPTION
## Problem
When the development agent creates a new ticket branch, `preCliDevelopmentSetup.js` runs `git checkout <baseBranch>` directly after the generic `git fetch origin --prune`. In a shallow clone (`--depth 1 --branch main`, the `checkout.sh` default), only `refs/heads/main` exists locally — other branches are not checkoutable even after the generic fetch.

This caused `git checkout develop/3.9.0` to fail with `pathspec did not match any file(s) known to git`, silently leaving the agent on `main` instead of the correct base branch. The agent then wrote code on the wrong base and had to self-heal via a later merge, producing a dirty commit history.

## Fix
Run an explicit targeted fetch (`git fetch origin <branchBase>`) immediately before `git checkout <branchBase>` so the remote-tracking ref is always available, regardless of clone depth or fetch strategy.

## Testing
Two new unit tests added to `js/unit-tests/test_preCliDevelopmentSetup.js`:
- Single-branch mode: verifies `git fetch origin master` runs before `git checkout master`
- Two-branch mode: verifies `git fetch origin <featureBranch>` runs before `git checkout <featureBranch>`

`dmtools run js/unit-tests/run_preCliDevelopmentSetup.json` — 9 passed, 0 failed.