### PR TITLE
fix(gitOps): use git reset --hard instead of git pull for existing local branches

### DIFF
--- a/js/common/gitOps.js
+++ b/js/common/gitOps.js
@@ -49,7 +49,12 @@ function _switchToBranch(branchName, cmd) {
 
     if (localBranchExists()) {
         cmd('git checkout ' + branchName);
-        cmd('git pull origin ' + branchName);
+        // Use reset --hard instead of pull: after a force-push (e.g. a rebase),
+        // local and remote branches diverge and 'git pull' fails with
+        // "Need to specify how to reconcile divergent branches".
+        // The remote is always the source of truth for an existing PR branch.
+        cmd(prHelper.buildOriginFetchCommand(branchName + ':' + branchName));
+        cmd('git reset --hard origin/' + branchName);
     } else {
         const remoteBranch = cleanCommandOutput(cmd('git ls-remote --heads origin ' + branchName) || '');
         if (remoteBranch.trim()) {

--- a/js/unit-tests/test_gitOps.js
+++ b/js/unit-tests/test_gitOps.js
@@ -162,5 +162,27 @@ suite('gitOps.checkoutPRBranch', function() {
         assert.equal(commands.indexOf('git rev-parse --abbrev-ref HEAD'), -1,
             'invariant check must be skipped entirely when baseBranch is not supplied');
     });
+
+    test('resets local branch to origin after force-push (divergent branches)', function() {
+        var commands = [];
+        var gitOps = loadGitOps({
+            cli_execute_command: function(args) {
+                commands.push(args.command);
+                if (args.command === 'git status --porcelain') return '\nCOMMAND_EXIT_CODE=0';
+                if (args.command === 'git branch --list "ai/TS-1268"') return '  ai/TS-1268\nCOMMAND_EXIT_CODE=0';
+                // git pull would fail here with divergent branches — reset --hard is used instead
+                if (args.command === 'git pull origin ai/TS-1268') {
+                    throw new Error('fatal: Need to specify how to reconcile divergent branches.');
+                }
+                return 'COMMAND_EXIT_CODE=0';
+            }
+        });
+
+        gitOps.checkoutPRBranch('ai/TS-1268');
+
+        assert.ok(commands.indexOf('git checkout ai/TS-1268') !== -1, 'local branch is checked out');
+        assert.equal(commands.indexOf('git pull origin ai/TS-1268'), -1, 'git pull must NOT be used (fails on divergent branches)');
+        assert.ok(commands.indexOf('git reset --hard origin/ai/TS-1268') !== -1, 'git reset --hard origin/<branch> is used to sync with remote');
+    });
 });
 


### PR DESCRIPTION
## Problem
`_switchToBranch` in `gitOps.js` used `git pull origin <branch>` when the branch already existed locally. After a force-push (e.g. a rebase of the PR branch), local and remote branches diverge and `git pull` fails with:

```
fatal: Need to specify how to reconcile divergent branches.
```

This caused `preCliReworkSetup.js` to abort with a branch checkout error, skipping the rework CLI agent entirely — no rework comments were posted to the MR.

## Fix
Replace `git pull origin <branch>` with an explicit fetch + `git reset --hard origin/<branch>`. The remote is always the source of truth for an existing PR branch in this context — the local branch should always be reset to match it, regardless of history divergence.

## Testing
- New test: `resets local branch to origin after force-push (divergent branches)` — verifies `git pull` is NOT called and `git reset --hard origin/<branch>` IS called when the local branch exists.
- All 7 existing + new tests pass: `dmtools run js/unit-tests/run_gitOps.json`