### PR TITLE
fix(gitOps): use explicit remote-tracking refspec in fetch before reset --hard

### DIFF
--- a/js/common/gitOps.js
+++ b/js/common/gitOps.js
@@ -53,7 +53,10 @@ function _switchToBranch(branchName, cmd) {
         // local and remote branches diverge and 'git pull' fails with
         // "Need to specify how to reconcile divergent branches".
         // The remote is always the source of truth for an existing PR branch.
-        cmd(prHelper.buildOriginFetchCommand(branchName + ':' + branchName));
+        // NOTE: fetch with explicit remote-tracking refspec (+refs/heads/<b>:refs/remotes/origin/<b>)
+        // — a plain '<branch>:<branch>' refspec would try to update the local branch ref
+        // and fails when HEAD is currently on that branch ("Refusing to fetch into current branch").
+        cmd(prHelper.buildOriginFetchCommand('+refs/heads/' + branchName + ':refs/remotes/origin/' + branchName));
         cmd('git reset --hard origin/' + branchName);
     } else {
         const remoteBranch = cleanCommandOutput(cmd('git ls-remote --heads origin ' + branchName) || '');

--- a/js/unit-tests/test_gitOps.js
+++ b/js/unit-tests/test_gitOps.js
@@ -183,6 +183,12 @@ suite('gitOps.checkoutPRBranch', function() {
         assert.ok(commands.indexOf('git checkout ai/TS-1268') !== -1, 'local branch is checked out');
         assert.equal(commands.indexOf('git pull origin ai/TS-1268'), -1, 'git pull must NOT be used (fails on divergent branches)');
         assert.ok(commands.indexOf('git reset --hard origin/ai/TS-1268') !== -1, 'git reset --hard origin/<branch> is used to sync with remote');
+        // Fetch must use explicit remote-tracking refspec — a plain '<branch>:<branch>' refspec
+        // fails when HEAD is on that branch ("Refusing to fetch into current branch").
+        var hasCorrectFetch = commands.some(function(c) {
+            return c && c.indexOf('fetch origin') !== -1 && c.indexOf('+refs/heads/ai/TS-1268:refs/remotes/origin/ai/TS-1268') !== -1;
+        });
+        assert.ok(hasCorrectFetch, 'fetch must use +refs/heads/<b>:refs/remotes/origin/<b> refspec');
     });
 });
 


### PR DESCRIPTION
## Problem
PR #357 fixed divergent branches by replacing `git pull` with `git fetch + git reset --hard`. But the fetch used `buildOriginFetchCommand(branchName + ':' + branchName)` which produces:

```
git fetch origin <branch>:<branch>
```

This refspec tries to update the **local branch ref** — and git refuses with:

```
fatal: Refusing to fetch into current branch refs/heads/<branch> of non-bare repository
```

because HEAD is already on that branch (we just did `git checkout <branch>` on the preceding line).

## Fix
Use the explicit remote-tracking refspec instead:

```
git fetch origin +refs/heads/<branch>:refs/remotes/origin/<branch>
```

This updates `origin/<branch>` (the remote-tracking ref) rather than the local branch ref, making it safe to call while HEAD is on that branch. `git reset --hard origin/<branch>` then works correctly.

## Testing
- Added assertion to the existing divergent-branches test verifying the correct refspec is used.
- All 7 tests pass: `dmtools run js/unit-tests/run_gitOps.json`