### PR TITLE
fix: report Claude Code token usage

### DIFF
--- a/scripts/providers/claude.sh
+++ b/scripts/providers/claude.sh
@@ -88,6 +88,28 @@ run_claude_code() {
   set -e
 
   record_codegraph_usage "${claude_code_log}"
+
+  # Claude Code's stream-json output carries aggregate usage in the final
+  # result.modelUsage object. Normalize it to the same provider-neutral JSON
+  # schema used by the Jira token-usage comment helper. Reporting is strictly
+  # best-effort and must never replace the Claude process exit code.
+  local provider_script_dir usage_name usage_file usage_exit_code manifest_exit_code
+  provider_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  usage_name="${AI_AGENT_USAGE_NAME:-claude-code}"
+  usage_file="outputs/${usage_name}_usage.json"
+  rm -f "${usage_file}" 2>/dev/null || true
+  usage_exit_code=0
+  python3 "${provider_script_dir}/claude_usage.py" "${claude_code_log}" "${usage_file}" || usage_exit_code=$?
+  if [ "${usage_exit_code}" -eq 0 ]; then
+    manifest_exit_code=0
+    record_usage_file "${usage_file}" || manifest_exit_code=$?
+    if [ "${manifest_exit_code}" -ne 0 ]; then
+      echo "⚠️  Claude token usage was extracted but could not be added to the manifest (exit ${manifest_exit_code}); continuing with agent exit ${claude_code_exit_code}."
+    fi
+  else
+    echo "⚠️  Claude token usage could not be recorded (extractor exit ${usage_exit_code}); continuing with agent exit ${claude_code_exit_code}."
+  fi
+
   # Save session ID for the next run to resume from.
   local saved_session_id
   saved_session_id="$(grep -o '"session_id":"[^"]*"' "${claude_code_log}" 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')"

--- a/scripts/providers/claude_usage.py
+++ b/scripts/providers/claude_usage.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Extract normalized token usage from a Claude Code stream-JSON transcript."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class UsageNotFoundError(ValueError):
+    """Raised when a transcript has no aggregate Claude usage result."""
+
+
+def _number(value: Any) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return value
+
+
+def find_last_usage_result(lines: list[str]) -> dict[str, Any]:
+    """Return the last result event that contains a non-empty modelUsage map."""
+    result: dict[str, Any] | None = None
+    for line in lines:
+        try:
+            candidate = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(candidate, dict) or candidate.get("type") != "result":
+            continue
+        model_usage = candidate.get("modelUsage")
+        if isinstance(model_usage, dict) and model_usage:
+            result = candidate
+
+    if result is None:
+        raise UsageNotFoundError("no result event with modelUsage was found")
+    return result
+
+
+def normalize_usage(result: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Claude's per-model aggregate into the provider-neutral schema."""
+    model_usage = result["modelUsage"]
+    models = sorted(str(model) for model in model_usage)
+
+    input_other = 0
+    input_cache_read = 0
+    input_cache_creation = 0
+    output = 0
+    model_cost = 0
+
+    for usage in model_usage.values():
+        if not isinstance(usage, dict):
+            continue
+        input_other += _number(usage.get("inputTokens"))
+        input_cache_read += _number(usage.get("cacheReadInputTokens"))
+        input_cache_creation += _number(usage.get("cacheCreationInputTokens"))
+        output += _number(usage.get("outputTokens"))
+        model_cost += _number(usage.get("costUSD"))
+
+    total_input = input_other + input_cache_read + input_cache_creation
+    total_tokens = total_input + output
+    reported_cost = result.get("total_cost_usd")
+    cost_usd = _number(reported_cost) if isinstance(reported_cost, (int, float)) else model_cost
+
+    return {
+        "provider": "claude-code",
+        "models": models,
+        "input_other": input_other,
+        "input_cache_read": input_cache_read,
+        "input_cache_creation": input_cache_creation,
+        "output": output,
+        "total_input": total_input,
+        "total_tokens": total_tokens,
+        "cost_usd": cost_usd,
+    }
+
+
+def extract_usage(transcript_path: Path) -> dict[str, Any]:
+    with transcript_path.open("r", encoding="utf-8") as transcript:
+        return normalize_usage(find_last_usage_result(list(transcript)))
+
+
+def write_usage(output_path: Path, usage: dict[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as output:
+        json.dump(usage, output, indent=2)
+        output.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("transcript", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        usage = extract_usage(args.transcript)
+    except (OSError, UsageNotFoundError) as error:
+        print(f"Claude token usage unavailable: {error}", file=sys.stderr)
+        return 2
+
+    write_usage(args.output, usage)
+    print("=== Claude Code Token Usage Summary ===")
+    print(f"  Model(s): {', '.join(usage['models'])}")
+    print(f"  Input (other):          {usage['input_other']:,}")
+    print(f"  Input (cache read):     {usage['input_cache_read']:,}")
+    print(f"  Input (cache creation): {usage['input_cache_creation']:,}")
+    print(f"  Output:                 {usage['output']:,}")
+    print(f"  Total input:            {usage['total_input']:,}")
+    print(f"  Total tokens:           {usage['total_tokens']:,}")
+    print(f"  Cost (USD):             {usage['cost_usd']}")
+    print(f"  Written to:             {args.output}")
+    print("=======================================")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/providers/tests/test_claude_provider.sh
+++ b/scripts/providers/tests/test_claude_provider.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+PROVIDERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+source "${PROVIDERS_DIR}/_common.sh"
+source "${PROVIDERS_DIR}/claude.sh"
+
+run_provider_case() {
+  local case_name="$1"
+  local fake_exit_code="$2"
+  local fake_output="$3"
+  local expected_artifacts="$4"
+  local case_dir="${TEST_ROOT}/${case_name}"
+  local fake_bin="${case_dir}/bin"
+  mkdir -p "${fake_bin}" "${case_dir}/outputs"
+
+  printf '#!/bin/bash\nprintf "%%s\\n" "$FAKE_CLAUDE_OUTPUT"\nexit "$FAKE_CLAUDE_EXIT_CODE"\n' > "${fake_bin}/claude"
+  chmod +x "${fake_bin}/claude"
+
+  (
+    cd "${case_dir}"
+    export PATH="${fake_bin}:${PATH}"
+    export FAKE_CLAUDE_OUTPUT="${fake_output}"
+    export FAKE_CLAUDE_EXIT_CODE="${fake_exit_code}"
+    export CLAUDE_CODE_API_KEY="test-key"
+    export CLAUDE_CODE_BASE_URL="https://example.com"
+    export AI_AGENT_USAGE_NAME="story_development"
+    export DMTOOLS_CLI_LOG_DIR="${case_dir}/logs"
+    PROMPT_ARG="test prompt"
+    PROMPT="test prompt"
+    PROMPT_BYTES=11
+    PASS_ARGS=()
+
+    if [ "${expected_artifacts}" = "usage-only" ]; then
+      record_usage_file() { return 23; }
+    fi
+
+    actual_exit_code=0
+    run_claude_code >/dev/null 2>&1 || actual_exit_code=$?
+
+    if [ "${actual_exit_code}" -ne "${fake_exit_code}" ]; then
+      echo "Expected provider exit ${fake_exit_code}, got ${actual_exit_code}" >&2
+      exit 1
+    fi
+
+    if [ "${expected_artifacts}" = "usage-and-manifest" ]; then
+      test -f outputs/story_development_usage.json
+      test -f outputs/token_usage_files.json
+      grep -q 'outputs/story_development_usage.json' outputs/token_usage_files.json
+    elif [ "${expected_artifacts}" = "usage-only" ]; then
+      test -f outputs/story_development_usage.json
+      test ! -e outputs/token_usage_files.json
+    else
+      test ! -e outputs/story_development_usage.json
+      test ! -e outputs/token_usage_files.json
+    fi
+  )
+}
+
+VALID_RESULT='{"type":"result","total_cost_usd":0.25,"modelUsage":{"example-model":{"inputTokens":2,"outputTokens":3,"cacheReadInputTokens":5,"cacheCreationInputTokens":7,"costUSD":0.25}}}'
+run_provider_case "usage-on-failure" 7 "${VALID_RESULT}" usage-and-manifest
+run_provider_case "manifest-failure" 11 "${VALID_RESULT}" usage-only
+run_provider_case "missing-usage" 9 '{"type":"result","modelUsage":{}}' none
+
+echo "Claude provider integration tests passed"

--- a/scripts/providers/tests/test_claude_usage.py
+++ b/scripts/providers/tests/test_claude_usage.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "claude_usage.py"
+SPEC = importlib.util.spec_from_file_location("claude_usage", MODULE_PATH)
+claude_usage = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(claude_usage)
+
+
+def result_event(model_usage, total_cost=None):
+    event = {"type": "result", "modelUsage": model_usage}
+    if total_cost is not None:
+        event["total_cost_usd"] = total_cost
+    return json.dumps(event)
+
+
+class ClaudeUsageTest(unittest.TestCase):
+    def test_normalizes_single_model_usage(self):
+        result = claude_usage.find_last_usage_result(
+            [
+                json.dumps({"type": "assistant", "usage": {"input_tokens": 7}}),
+                result_event(
+                    {
+                        "example-model": {
+                            "inputTokens": 13,
+                            "outputTokens": 7,
+                            "cacheReadInputTokens": 31,
+                            "cacheCreationInputTokens": 5,
+                            "costUSD": 0.12,
+                        }
+                    },
+                    0.109,
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            claude_usage.normalize_usage(result),
+            {
+                "provider": "claude-code",
+                "models": ["example-model"],
+                "input_other": 13,
+                "input_cache_read": 31,
+                "input_cache_creation": 5,
+                "output": 7,
+                "total_input": 49,
+                "total_tokens": 56,
+                "cost_usd": 0.109,
+            },
+        )
+
+    def test_aggregates_multiple_models_and_falls_back_to_model_cost(self):
+        result = json.loads(
+            result_event(
+                {
+                    "model-b": {
+                        "inputTokens": 4,
+                        "outputTokens": 2,
+                        "cacheReadInputTokens": 6,
+                        "costUSD": 0.2,
+                    },
+                    "model-a": {
+                        "inputTokens": 3,
+                        "outputTokens": 1,
+                        "cacheCreationInputTokens": 5,
+                        "costUSD": 0.1,
+                    },
+                }
+            )
+        )
+
+        usage = claude_usage.normalize_usage(result)
+
+        self.assertEqual(usage["models"], ["model-a", "model-b"])
+        self.assertEqual(usage["input_other"], 7)
+        self.assertEqual(usage["input_cache_read"], 6)
+        self.assertEqual(usage["input_cache_creation"], 5)
+        self.assertEqual(usage["output"], 3)
+        self.assertEqual(usage["total_tokens"], 21)
+        self.assertAlmostEqual(usage["cost_usd"], 0.3)
+
+    def test_uses_last_valid_result_and_ignores_malformed_lines(self):
+        first = result_event({"old-model": {"inputTokens": 1}})
+        last = result_event({"new-model": {"inputTokens": 9}})
+
+        result = claude_usage.find_last_usage_result(
+            [first, "not-json", json.dumps({"type": "result"}), last]
+        )
+
+        self.assertIn("new-model", result["modelUsage"])
+
+    def test_missing_optional_fields_default_to_zero(self):
+        result = json.loads(result_event({"example-model": {}}))
+
+        usage = claude_usage.normalize_usage(result)
+
+        self.assertEqual(usage["total_tokens"], 0)
+        self.assertEqual(usage["cost_usd"], 0)
+
+    def test_no_usable_result_raises(self):
+        with self.assertRaises(claude_usage.UsageNotFoundError):
+            claude_usage.find_last_usage_result(
+                ["bad-json", json.dumps({"type": "result", "modelUsage": {}})]
+            )
+
+    def test_extract_and_write_usage_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            transcript = root / "transcript.jsonl"
+            output = root / "outputs" / "story_development_usage.json"
+            transcript.write_text(
+                result_event({"example-model": {"inputTokens": 2, "outputTokens": 3}})
+                + "\n",
+                encoding="utf-8",
+            )
+
+            claude_usage.write_usage(output, claude_usage.extract_usage(transcript))
+
+            self.assertEqual(json.loads(output.read_text(encoding="utf-8"))["total_tokens"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add token-usage reporting for the Claude Code provider so existing post-actions can publish usage summaries to Jira.

Claude already exposes aggregate usage in the final stream-JSON `result.modelUsage`, but the provider did not convert it into the usage artifact consumed by `tokenUsageComment.js`.

## Changes

- Parse the last valid Claude `result.modelUsage` event.
- Normalize input, cached input, output, total tokens, models, and USD cost.
- Write `outputs/<agent>_usage.json`.
- Register the artifact in `outputs/token_usage_files.json`.
- Keep reporting best-effort so extraction or manifest failures never change Claude’s exit status.
- Add unit and provider integration tests covering malformed output, multiple models, missing usage, failed Claude runs, and manifest failures.

## Example output

```json
{
  "provider": "claude-code",
  "models": ["example-model"],
  "input_other": 13,
  "input_cache_read": 31,
  "input_cache_creation": 5,
  "output": 7,
  "total_input": 49,
  "total_tokens": 56,
  "cost_usd": 0.109
}
```

## Verification

- Claude usage parser: 6 tests passed
- Provider integration tests: passed
- Full agent unit-test suite: 748 passed, 0 failed
- Shell syntax and diff checks: passed