### PR TITLE
fix(tokenUsageComment): avoid bridge JSON-array misparse of bracketed comments

### DIFF
--- a/js/common/tokenUsageComment.js
+++ b/js/common/tokenUsageComment.js
@@ -76,6 +76,30 @@ function formatJiraMention(notifierId) {
     return '[~accountid:' + id + ']';
 }
 
+/**
+ * Work around a bug in the DMTools GraalJS bridge (JobJavaScriptBridge):
+ * any string tool argument that starts with "[" and ends with "]" gets
+ * speculatively parsed as a JSON array. org.json's lenient tokenizer can
+ * "succeed" on a leading fragment (e.g. an unquoted bareword) and silently
+ * discard everything after the first matching "]", corrupting the rest of
+ * the string before it reaches the tool. See IstiN/dmtools-agents#360.
+ *
+ * Our comment format ("[label]: {...}\nInitiator: [~accountid:...]") is
+ * exactly this shape: it starts with "[" (the label) and ends with "]"
+ * (the mention). Appending a trailing period breaks the pattern without
+ * changing the meaningful content.
+ */
+function avoidBridgeArrayMisparse(str) {
+    if (typeof str !== 'string') {
+        return str;
+    }
+    var trimmed = str.trim();
+    if (trimmed.length > 2 && trimmed.charAt(0) === '[' && trimmed.charAt(trimmed.length - 1) === ']') {
+        return str + '.';
+    }
+    return str;
+}
+
 function formatUsageComment(filePath, data, initiator) {
     var fileName = fileNameFromPath(filePath);
     // Strip the _usage suffix so the comment label matches the agent name
@@ -92,7 +116,7 @@ function formatUsageComment(filePath, data, initiator) {
     if (mention) {
         comment += '\nInitiator: ' + mention;
     }
-    return comment;
+    return avoidBridgeArrayMisparse(comment);
 }
 
 /**
@@ -145,6 +169,7 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         postTokenUsageComments: postTokenUsageComments,
         findUsageFiles: findUsageFiles,
-        formatUsageComment: formatUsageComment
+        formatUsageComment: formatUsageComment,
+        avoidBridgeArrayMisparse: avoidBridgeArrayMisparse
     };
 }

--- a/js/unit-tests/test_tokenUsageComment.js
+++ b/js/unit-tests/test_tokenUsageComment.js
@@ -49,6 +49,34 @@ suite('tokenUsageComment', function() {
         assert.contains(comment, 'Initiator: [~accountid:abc]');
     });
 
+    // Regression test for IstiN/dmtools-agents#360: a comment that starts with
+    // "[label]" and ends with "[~accountid:...]" is exactly the shape the
+    // DMTools GraalJS bridge mis-parses as a JSON array, silently truncating
+    // the whole comment. The trailing-period guard must break that shape.
+    test('formatUsageComment appends a guard period when the comment would end with the mention bracket', function() {
+        var mod = loadTokenUsageComment({});
+        var comment = mod.formatUsageComment('outputs/claude-code_usage.json', { provider: 'claude-code' }, '712020:d28c649e-58fe-40e2-8d4f-ca1def1444a7');
+        assert.ok(comment.charAt(0) === '[', 'comment should still start with the [label] prefix');
+        assert.notOk(comment.charAt(comment.length - 1) === ']', 'comment must not end with "]" (would trigger the bridge bug)');
+        assert.ok(comment.charAt(comment.length - 1) === '.', 'comment should end with the guard period');
+        assert.contains(comment, 'Initiator: [~accountid:712020:d28c649e-58fe-40e2-8d4f-ca1def1444a7]');
+    });
+
+    test('formatUsageComment does not add a guard period when there is no initiator mention', function() {
+        var mod = loadTokenUsageComment({});
+        var comment = mod.formatUsageComment('outputs/claude-code_usage.json', { provider: 'claude-code' });
+        assert.notContains(comment, 'Initiator:');
+        assert.ok(comment.charAt(comment.length - 1) === '}', 'comment should end with the JSON payload unchanged');
+    });
+
+    test('avoidBridgeArrayMisparse appends a period only when the string starts with [ and ends with ]', function() {
+        var mod = loadTokenUsageComment({});
+        assert.equal(mod.avoidBridgeArrayMisparse('[claude-code]: {"a":1}\nInitiator: [~accountid:1]'), '[claude-code]: {"a":1}\nInitiator: [~accountid:1].');
+        assert.equal(mod.avoidBridgeArrayMisparse('[claude-code]: {"a":1}'), '[claude-code]: {"a":1}');
+        assert.equal(mod.avoidBridgeArrayMisparse('plain text'), 'plain text');
+        assert.equal(mod.avoidBridgeArrayMisparse('[]'), '[]');
+    });
+
     test('postTokenUsageComments posts a Jira comment for each usage file', function() {
         var posted = [];
         var mod = loadTokenUsageComment({


### PR DESCRIPTION
## Problem

Fixes #360.

`JobJavaScriptBridge.executeToolFromJS` in the DMTools GraalJS bridge speculatively parses any string tool argument that `startsWith("[") && endsWith("]")` as a JSON array. org.json's lenient tokenizer can "succeed" on just a leading fragment (e.g. an unquoted bareword), silently discarding everything after the first matching `]` before the value reaches the target MCP tool.

Our token usage comment format built in `formatUsageComment()`:

```
[label]: {...usage json...}
Initiator: [~accountid:<id>]
```

matches this shape exactly — it starts with `[` (the label prefix) and ends with `]` (the mention's closing bracket). As a result, `jira_post_comment` received a corrupted value like `["claude-code"]` instead of the real usage data + initiator mention, and this went completely unnoticed (no exception, the tool call still "succeeded").

## Fix

Add `avoidBridgeArrayMisparse()` to `js/common/tokenUsageComment.js`, applied at the end of `formatUsageComment()`. It appends a trailing period whenever the final comment string would otherwise both start with `[` and end with `]`, breaking the bridge's misparse heuristic without changing the meaningful content — the `[~accountid:...]` mention syntax is preserved so Jira still renders it as a real user mention.

This is a workaround scoped to our own code; the actual bug lives in the DMTools bridge engine itself and is out of scope for this repo (tracked in #360).

## Testing

- Extended `js/unit-tests/test_tokenUsageComment.js`:
  - New regression test reproducing the exact reported shape (label + initiator id without `~`), asserting the guarded comment no longer ends with `]` and gains a trailing `.` instead, while still containing the full mention text.
  - New test confirming no guard is applied when there's no initiator mention (comment unchanged, still ends with `}`).
  - New unit tests for `avoidBridgeArrayMisparse()` directly.
- Ran locally:
  ```bash
  node agents/js/unit-tests/node_testRunner.js js/unit-tests/test_tokenUsageComment.js
  ```
  Result: `✅ PASS — 9 passed, 0 failed`.
- Existing tests for this file continue to pass unchanged.
