### PR TITLE
fix: report Copilot CLI token usage (cost tracking)

### DIFF
--- a/scripts/providers/copilot.sh
+++ b/scripts/providers/copilot.sh
@@ -163,6 +163,16 @@ run_copilot() {
     return 0
   }
 
+  # COPILOT_HOME is cached and restored across CI runs, and the same session is
+  # resumed for a given ticket/group, so the session store can already contain
+  # usage rows from previous runs. Snapshot the highest row id now and report
+  # only what this run adds.
+  local copilot_usage_baseline_id=0
+  copilot_usage_baseline_id="$(python3 "${script_dir}/copilot_usage.py" --baseline 2>/dev/null || echo 0)"
+  case "${copilot_usage_baseline_id}" in
+    ''|*[!0-9]*) copilot_usage_baseline_id=0 ;;
+  esac
+
   local max_attempts="${COPILOT_RATE_LIMIT_RETRIES:-2}"
   local retry_delay="${COPILOT_RATE_LIMIT_RETRY_DELAY_SECONDS:-90}"
   local attempt=1
@@ -225,7 +235,51 @@ run_copilot() {
   echo "Full transcript(s) saved to:"
   printf '  %s\n' "${copilot_log_files[@]}"
 
+  report_copilot_usage "${exit_code}" "${copilot_usage_baseline_id}" "${copilot_log_files[@]}"
+
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="
   return $exit_code
+}
+
+# Normalize the Copilot CLI's token usage into the same provider-neutral JSON
+# schema the Jira token-usage comment helper consumes, and register it in the
+# outputs manifest. Reporting is strictly best-effort and must never replace
+# the Copilot process exit code.
+report_copilot_usage() {
+  local agent_exit_code="$1"
+  local baseline_id="$2"
+  shift 2
+
+  local provider_script_dir usage_name usage_file usage_exit_code manifest_exit_code
+  provider_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  usage_name="${AI_AGENT_USAGE_NAME:-copilot}"
+  usage_file="outputs/${usage_name}_usage.json"
+  rm -f "${usage_file}" 2>/dev/null || true
+
+  local usage_args=(--output "${usage_file}" --since-id "${baseline_id}")
+  if [ -n "${COPILOT_SESSION_ID:-}" ]; then
+    usage_args+=(--session-id "${COPILOT_SESSION_ID}")
+  fi
+  local log_file
+  for log_file in "$@"; do
+    if [ -n "${log_file}" ]; then
+      usage_args+=(--transcript "${log_file}")
+    fi
+  done
+
+  echo ""
+  usage_exit_code=0
+  python3 "${provider_script_dir}/copilot_usage.py" "${usage_args[@]}" || usage_exit_code=$?
+  if [ "${usage_exit_code}" -eq 0 ]; then
+    manifest_exit_code=0
+    record_usage_file "${usage_file}" || manifest_exit_code=$?
+    if [ "${manifest_exit_code}" -ne 0 ]; then
+      echo "⚠️  Copilot token usage was extracted but could not be added to the manifest (exit ${manifest_exit_code}); continuing with agent exit ${agent_exit_code}."
+    fi
+  else
+    echo "⚠️  Copilot token usage could not be recorded (extractor exit ${usage_exit_code}); continuing with agent exit ${agent_exit_code}."
+  fi
+
+  return 0
 }

--- a/scripts/providers/copilot_usage.py
+++ b/scripts/providers/copilot_usage.py
@@ -125,7 +125,11 @@ def _connect_readonly(store: Path) -> tuple[sqlite3.Connection, str | None]:
     """Open the store without mutating it.
 
     A live WAL sidecar cannot always be replayed through a read-only handle, so
-    fall back to reading a private copy of the database and its sidecars.
+    fall back to reading a private copy of the database and its sidecars. If
+    the copy or the connection to it fails partway through, the temp directory
+    is removed before the error propagates so failed attempts (e.g. permission
+    errors, a torn copy of a database being actively written) don't leak
+    directories on disk.
     """
     try:
         connection = sqlite3.connect(f"file:{store}?mode=ro", uri=True)
@@ -135,13 +139,17 @@ def _connect_readonly(store: Path) -> tuple[sqlite3.Connection, str | None]:
         pass
 
     temp_dir = tempfile.mkdtemp(prefix="copilot-usage-")
-    copy = Path(temp_dir) / store.name
-    shutil.copyfile(store, copy)
-    for suffix in ("-wal", "-shm"):
-        sidecar = Path(str(store) + suffix)
-        if sidecar.exists():
-            shutil.copyfile(sidecar, Path(str(copy) + suffix))
-    return sqlite3.connect(f"file:{copy}?mode=ro", uri=True), temp_dir
+    try:
+        copy = Path(temp_dir) / store.name
+        shutil.copyfile(store, copy)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(str(store) + suffix)
+            if sidecar.exists():
+                shutil.copyfile(sidecar, Path(str(copy) + suffix))
+        return sqlite3.connect(f"file:{copy}?mode=ro", uri=True), temp_dir
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
 
 
 def max_usage_event_id(home: str | None = None) -> int:
@@ -169,26 +177,45 @@ def read_store_rows(
     home: str | None = None,
     since_id: int = 0,
 ) -> list[dict[str, Any]]:
-    """Read usage rows for the given sessions that were written after since_id."""
-    if not session_ids:
-        return []
+    """Read usage rows written after since_id.
+
+    Rows are scoped to session_ids when any were resolved. If none were (the
+    CLI can crash or time out before printing its `--resume=<uuid>` line, or
+    an older CLI without `--session-id` support may pick its own random
+    session id that we never observe), fall back to every row newer than
+    since_id so the run's exact usage still gets reported instead of silently
+    dropping to nothing. That fallback only fires when since_id is a real,
+    non-zero baseline — with since_id == 0 it would return the store's entire
+    history rather than just this run's rows.
+    """
     store = resolve_store_path(home)
     if store is None:
         return []
 
-    placeholders = ",".join("?" for _ in session_ids)
-    query = (
-        "SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
-        "reasoning_tokens, total_nano_aiu, duration_ms FROM assistant_usage_events "
-        f"WHERE lower(session_id) IN ({placeholders}) AND id > ?"
-    )
+    if session_ids:
+        placeholders = ",".join("?" for _ in session_ids)
+        query = (
+            "SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
+            "reasoning_tokens, total_nano_aiu, duration_ms FROM assistant_usage_events "
+            f"WHERE lower(session_id) IN ({placeholders}) AND id > ?"
+        )
+        params: tuple[Any, ...] = (*session_ids, since_id)
+    elif since_id > 0:
+        query = (
+            "SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
+            "reasoning_tokens, total_nano_aiu, duration_ms FROM assistant_usage_events "
+            "WHERE id > ?"
+        )
+        params = (since_id,)
+    else:
+        return []
 
     connection = None
     temp_dir = None
     try:
         connection, temp_dir = _connect_readonly(store)
         connection.row_factory = sqlite3.Row
-        rows = connection.execute(query, (*session_ids, since_id)).fetchall()
+        rows = connection.execute(query, params).fetchall()
     except (sqlite3.Error, OSError):
         return []
     finally:
@@ -200,7 +227,7 @@ def read_store_rows(
     return [dict(row) for row in rows]
 
 
-def normalize_store_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+def normalize_store_rows(rows: list[dict[str, Any]], scoped: bool = True) -> dict[str, Any]:
     """Aggregate raw session-store rows into the provider-neutral schema."""
     if not rows:
         raise UsageNotFoundError("no usage rows were found in the Copilot session store")
@@ -229,7 +256,7 @@ def normalize_store_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
     # Copilot reports input_tokens as the grand total, cached segments included.
     input_other = max(0, total_input - input_cache_read - input_cache_creation)
 
-    return build_usage(
+    usage = build_usage(
         models=sorted(models),
         usage_records=len(rows),
         input_other=input_other,
@@ -241,6 +268,14 @@ def normalize_store_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
         duration_ms=duration_ms,
         source="session-store",
     )
+    if not scoped:
+        # No session id could be resolved for this run; these rows are every
+        # new row in the store rather than rows we could tie to a specific
+        # Copilot session. Flag it so a concurrently-writing process sharing
+        # the same COPILOT_HOME is visible in the output instead of silently
+        # blended in.
+        usage["scoped"] = False
+    return usage
 
 
 def parse_transcript_footer(text: str) -> dict[str, Any] | None:
@@ -388,7 +423,7 @@ def extract_usage(
 
     rows = read_store_rows(resolved, home=home, since_id=since_id)
     if rows:
-        return normalize_store_rows(rows)
+        return normalize_store_rows(rows, scoped=bool(resolved))
     return normalize_transcript_footers(transcripts)
 
 
@@ -416,6 +451,9 @@ def print_usage_summary(usage: dict[str, Any], output_path: Path) -> None:
     print(f"  Source:                 {usage['source']}")
     if usage.get("approximate"):
         print("  Note:                   values are rounded by the Copilot CLI summary")
+    if usage.get("scoped") is False:
+        print("  Note:                   no session id was resolved; totals cover every new")
+        print("                          store row since baseline, not just this run's session")
     print(f"  Written to:             {output_path}")
     print("===================================")
 

--- a/scripts/providers/copilot_usage.py
+++ b/scripts/providers/copilot_usage.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Extract normalized token usage for a GitHub Copilot CLI run.
+
+Two sources are supported, in order of preference:
+
+1. ``$COPILOT_HOME/session-store.db`` — the Copilot CLI session store. Its
+   ``assistant_usage_events`` table holds one exact row per model request
+   (tokens plus billed nano AIU), which is the only lossless source.
+2. The transcript footer printed by the CLI (``Tokens  ↑ 1.8m (1.7m cached,
+   70.3k written) • ↓ 6.3k (1.0k reasoning)`` / ``AI Credits 58.8``). Those
+   numbers are rounded to three significant digits, so results derived from
+   them are flagged ``approximate``.
+
+The output matches the provider-neutral schema consumed by the Jira token
+usage comment helper (js/common/tokenUsageComment.js).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+STORE_FILE_NAME = "session-store.db"
+NANO_AIU_PER_CREDIT = 1_000_000_000
+
+# "Resume     copilot --resume=5970236a-c0cb-46b0-85da-db6898163d11"
+_RESUME_PATTERN = re.compile(
+    r"--resume[=\s]+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+_NUMBER = r"[0-9][0-9.,]*\s*[kmb]?"
+_TOKENS_PATTERN = re.compile(
+    r"Tokens\s+[\u2191^]\s*(" + _NUMBER + r")\s*(\([^)]*\))?"
+    r"(?:[^\u2193]*[\u2193v]\s*(" + _NUMBER + r")\s*(\([^)]*\))?)?",
+    re.IGNORECASE,
+)
+_CACHED_PATTERN = re.compile(r"(" + _NUMBER + r")\s*cached", re.IGNORECASE)
+_WRITTEN_PATTERN = re.compile(r"(" + _NUMBER + r")\s*written", re.IGNORECASE)
+_REASONING_PATTERN = re.compile(r"(" + _NUMBER + r")\s*reasoning", re.IGNORECASE)
+_CREDITS_PATTERN = re.compile(r"AI\s+Credits\s+([0-9][0-9.,]*\s*[kmb]?)", re.IGNORECASE)
+
+
+class UsageNotFoundError(ValueError):
+    """Raised when neither the session store nor a transcript yields usage."""
+
+
+def _number(value: Any) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return value
+
+
+def parse_scaled_number(raw: str | None) -> int:
+    """Parse Copilot's abbreviated counters ("1.8m", "70.3k", "976")."""
+    if not raw:
+        return 0
+    text = str(raw).strip().lower().replace(",", "").replace(" ", "")
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([kmb])?", text)
+    if not match:
+        return 0
+    value = float(match.group(1))
+    value *= {"": 1, "k": 1_000, "m": 1_000_000, "b": 1_000_000_000}[match.group(2) or ""]
+    return int(round(value))
+
+
+def parse_float(raw: str | None) -> float:
+    if not raw:
+        return 0.0
+    text = str(raw).strip().lower().replace(",", "").replace(" ", "")
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([kmb])?", text)
+    if not match:
+        return 0.0
+    value = float(match.group(1))
+    return value * {"": 1, "k": 1_000, "m": 1_000_000, "b": 1_000_000_000}[match.group(2) or ""]
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def find_session_ids(texts: Iterable[str]) -> list[str]:
+    """Collect Copilot session ids from transcripts, preserving first-seen order."""
+    ordered: list[str] = []
+    for text in texts:
+        for match in _RESUME_PATTERN.finditer(text or ""):
+            session_id = match.group(1).lower()
+            if session_id not in ordered:
+                ordered.append(session_id)
+    return ordered
+
+
+def resolve_store_path(home: str | None = None) -> Path | None:
+    """Locate the Copilot session store.
+
+    An explicit ``home`` is authoritative; otherwise fall back to
+    ``$COPILOT_HOME`` and then the default ``~/.copilot`` used by local runs.
+    """
+    if home:
+        candidates = [Path(home)]
+    else:
+        candidates = []
+        env_home = os.environ.get("COPILOT_HOME")
+        if env_home:
+            candidates.append(Path(env_home))
+        candidates.append(Path.home() / ".copilot")
+
+    for candidate in candidates:
+        store = candidate if candidate.name == STORE_FILE_NAME else candidate / STORE_FILE_NAME
+        if store.is_file():
+            return store
+    return None
+
+
+def _connect_readonly(store: Path) -> tuple[sqlite3.Connection, str | None]:
+    """Open the store without mutating it.
+
+    A live WAL sidecar cannot always be replayed through a read-only handle, so
+    fall back to reading a private copy of the database and its sidecars.
+    """
+    try:
+        connection = sqlite3.connect(f"file:{store}?mode=ro", uri=True)
+        connection.execute("SELECT 1 FROM assistant_usage_events LIMIT 1").fetchall()
+        return connection, None
+    except sqlite3.Error:
+        pass
+
+    temp_dir = tempfile.mkdtemp(prefix="copilot-usage-")
+    copy = Path(temp_dir) / store.name
+    shutil.copyfile(store, copy)
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(str(store) + suffix)
+        if sidecar.exists():
+            shutil.copyfile(sidecar, Path(str(copy) + suffix))
+    return sqlite3.connect(f"file:{copy}?mode=ro", uri=True), temp_dir
+
+
+def max_usage_event_id(home: str | None = None) -> int:
+    """Return the highest usage row id currently in the store, or 0."""
+    store = resolve_store_path(home)
+    if store is None:
+        return 0
+    connection = None
+    temp_dir = None
+    try:
+        connection, temp_dir = _connect_readonly(store)
+        row = connection.execute("SELECT MAX(id) FROM assistant_usage_events").fetchone()
+    except (sqlite3.Error, OSError):
+        return 0
+    finally:
+        if connection is not None:
+            connection.close()
+        if temp_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def read_store_rows(
+    session_ids: list[str],
+    home: str | None = None,
+    since_id: int = 0,
+) -> list[dict[str, Any]]:
+    """Read usage rows for the given sessions that were written after since_id."""
+    if not session_ids:
+        return []
+    store = resolve_store_path(home)
+    if store is None:
+        return []
+
+    placeholders = ",".join("?" for _ in session_ids)
+    query = (
+        "SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
+        "reasoning_tokens, total_nano_aiu, duration_ms FROM assistant_usage_events "
+        f"WHERE lower(session_id) IN ({placeholders}) AND id > ?"
+    )
+
+    connection = None
+    temp_dir = None
+    try:
+        connection, temp_dir = _connect_readonly(store)
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(query, (*session_ids, since_id)).fetchall()
+    except (sqlite3.Error, OSError):
+        return []
+    finally:
+        if connection is not None:
+            connection.close()
+        if temp_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return [dict(row) for row in rows]
+
+
+def normalize_store_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate raw session-store rows into the provider-neutral schema."""
+    if not rows:
+        raise UsageNotFoundError("no usage rows were found in the Copilot session store")
+
+    models: set[str] = set()
+    total_input = 0
+    input_cache_read = 0
+    input_cache_creation = 0
+    output = 0
+    reasoning = 0
+    nano_aiu = 0
+    duration_ms = 0
+
+    for row in rows:
+        model = row.get("model")
+        if model:
+            models.add(str(model))
+        total_input += _number(row.get("input_tokens"))
+        input_cache_read += _number(row.get("cache_read_tokens"))
+        input_cache_creation += _number(row.get("cache_write_tokens"))
+        output += _number(row.get("output_tokens"))
+        reasoning += _number(row.get("reasoning_tokens"))
+        nano_aiu += _number(row.get("total_nano_aiu"))
+        duration_ms += _number(row.get("duration_ms"))
+
+    # Copilot reports input_tokens as the grand total, cached segments included.
+    input_other = max(0, total_input - input_cache_read - input_cache_creation)
+
+    return build_usage(
+        models=sorted(models),
+        usage_records=len(rows),
+        input_other=input_other,
+        input_cache_read=input_cache_read,
+        input_cache_creation=input_cache_creation,
+        output=output,
+        reasoning=reasoning,
+        ai_credits=nano_aiu / NANO_AIU_PER_CREDIT,
+        duration_ms=duration_ms,
+        source="session-store",
+    )
+
+
+def parse_transcript_footer(text: str) -> dict[str, Any] | None:
+    """Parse the last usage footer block printed in a transcript."""
+    tokens_match = None
+    for tokens_match in _TOKENS_PATTERN.finditer(text or ""):
+        pass
+    if tokens_match is None:
+        return None
+
+    input_total = parse_scaled_number(tokens_match.group(1))
+    input_detail = tokens_match.group(2) or ""
+    output_total = parse_scaled_number(tokens_match.group(3))
+    output_detail = tokens_match.group(4) or ""
+
+    cached = _CACHED_PATTERN.search(input_detail)
+    written = _WRITTEN_PATTERN.search(input_detail)
+    reasoning = _REASONING_PATTERN.search(output_detail)
+
+    credits_match = None
+    for credits_match in _CREDITS_PATTERN.finditer(text or ""):
+        pass
+
+    return {
+        "total_input": input_total,
+        "input_cache_read": parse_scaled_number(cached.group(1)) if cached else 0,
+        "input_cache_creation": parse_scaled_number(written.group(1)) if written else 0,
+        "output": output_total,
+        "reasoning": parse_scaled_number(reasoning.group(1)) if reasoning else 0,
+        "ai_credits": parse_float(credits_match.group(1)) if credits_match else 0.0,
+    }
+
+
+def normalize_transcript_footers(transcripts: list[tuple[str, str]]) -> dict[str, Any]:
+    """Aggregate footers across attempts, keeping one footer per Copilot session.
+
+    Retries that resume the same session print a cumulative footer, so only the
+    last footer of each session is counted; independent sessions are summed.
+    """
+    per_session: dict[str, dict[str, Any]] = {}
+    for name, text in transcripts:
+        footer = parse_transcript_footer(text)
+        if footer is None:
+            continue
+        session_ids = find_session_ids([text])
+        per_session[session_ids[-1] if session_ids else f"transcript:{name}"] = footer
+
+    if not per_session:
+        raise UsageNotFoundError("no Copilot usage footer was found in the transcript(s)")
+
+    total_input = 0
+    input_cache_read = 0
+    input_cache_creation = 0
+    output = 0
+    reasoning = 0
+    ai_credits = 0.0
+    for footer in per_session.values():
+        total_input += footer["total_input"]
+        input_cache_read += footer["input_cache_read"]
+        input_cache_creation += footer["input_cache_creation"]
+        output += footer["output"]
+        reasoning += footer["reasoning"]
+        ai_credits += footer["ai_credits"]
+
+    input_other = max(0, total_input - input_cache_read - input_cache_creation)
+
+    usage = build_usage(
+        models=[],
+        usage_records=len(per_session),
+        input_other=input_other,
+        input_cache_read=input_cache_read,
+        input_cache_creation=input_cache_creation,
+        output=output,
+        reasoning=reasoning,
+        ai_credits=ai_credits,
+        duration_ms=0,
+        source="transcript-summary",
+    )
+    usage["approximate"] = True
+    return usage
+
+
+def build_usage(
+    *,
+    models: list[str],
+    usage_records: int,
+    input_other: int,
+    input_cache_read: int,
+    input_cache_creation: int,
+    output: int,
+    reasoning: int,
+    ai_credits: float,
+    duration_ms: int,
+    source: str,
+) -> dict[str, Any]:
+    total_input = input_other + input_cache_read + input_cache_creation
+    usage: dict[str, Any] = {
+        "provider": "copilot",
+        "models": models,
+        "usage_records": usage_records,
+        "input_other": input_other,
+        "input_cache_read": input_cache_read,
+        "input_cache_creation": input_cache_creation,
+        "output": output,
+        "reasoning": reasoning,
+        "total_input": total_input,
+        "total_tokens": total_input + output,
+        "ai_credits": round(ai_credits, 6),
+        "duration_ms": duration_ms,
+        "source": source,
+    }
+    cost_usd = usd_cost(usage["ai_credits"])
+    if cost_usd is not None:
+        usage["cost_usd"] = cost_usd
+    return usage
+
+
+def usd_cost(ai_credits: float) -> float | None:
+    """Convert AI credits to USD when COPILOT_USD_PER_CREDIT is configured."""
+    raw = os.environ.get("COPILOT_USD_PER_CREDIT", "").strip()
+    if not raw:
+        return None
+    try:
+        rate = float(raw)
+    except ValueError:
+        return None
+    if rate <= 0:
+        return None
+    return round(ai_credits * rate, 6)
+
+
+def extract_usage(
+    transcript_paths: list[Path],
+    home: str | None = None,
+    since_id: int = 0,
+    session_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    transcripts = [(str(path), read_text(path)) for path in transcript_paths]
+
+    resolved = list(session_ids or [])
+    for session_id in find_session_ids(text for _, text in transcripts):
+        if session_id not in resolved:
+            resolved.append(session_id)
+    resolved = [session_id.lower() for session_id in resolved if session_id]
+
+    rows = read_store_rows(resolved, home=home, since_id=since_id)
+    if rows:
+        return normalize_store_rows(rows)
+    return normalize_transcript_footers(transcripts)
+
+
+def write_usage(output_path: Path, usage: dict[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as output:
+        json.dump(usage, output, indent=2)
+        output.write("\n")
+
+
+def print_usage_summary(usage: dict[str, Any], output_path: Path) -> None:
+    print("=== Copilot Token Usage Summary ===")
+    print(f"  Model(s):               {', '.join(usage['models']) or 'unknown'}")
+    print(f"  Usage records:          {usage['usage_records']:,}")
+    print(f"  Input (other):          {usage['input_other']:,}")
+    print(f"  Input (cache read):     {usage['input_cache_read']:,}")
+    print(f"  Input (cache creation): {usage['input_cache_creation']:,}")
+    print(f"  Output:                 {usage['output']:,}")
+    print(f"  Output (reasoning):     {usage['reasoning']:,}")
+    print(f"  Total input:            {usage['total_input']:,}")
+    print(f"  Total tokens:           {usage['total_tokens']:,}")
+    print(f"  AI credits:             {usage['ai_credits']}")
+    if "cost_usd" in usage:
+        print(f"  Cost (USD):             {usage['cost_usd']}")
+    print(f"  Source:                 {usage['source']}")
+    if usage.get("approximate"):
+        print("  Note:                   values are rounded by the Copilot CLI summary")
+    print(f"  Written to:             {output_path}")
+    print("===================================")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--transcript", type=Path, action="append", default=[])
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--home", default=None)
+    parser.add_argument("--session-id", action="append", default=[])
+    parser.add_argument("--since-id", type=int, default=0)
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="print the current highest usage row id and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.baseline:
+        print(max_usage_event_id(args.home))
+        return 0
+
+    if args.output is None:
+        parser.error("--output is required unless --baseline is used")
+
+    try:
+        usage = extract_usage(
+            args.transcript,
+            home=args.home,
+            since_id=args.since_id,
+            session_ids=args.session_id,
+        )
+    except (OSError, UsageNotFoundError) as error:
+        print(f"Copilot token usage unavailable: {error}", file=sys.stderr)
+        return 2
+
+    write_usage(args.output, usage)
+    print_usage_summary(usage, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/providers/tests/test_copilot_provider.sh
+++ b/scripts/providers/tests/test_copilot_provider.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -euo pipefail
+
+PROVIDERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+source "${PROVIDERS_DIR}/_common.sh"
+source "${PROVIDERS_DIR}/copilot.sh"
+
+SESSION_ID="5970236a-c0cb-46b0-85da-db6898163d11"
+
+# Seeds the Copilot session store the same way the real CLI does: schema on
+# first use, then one usage row per model request.
+write_store_seeder() {
+  cat > "$1" << 'PYEOF'
+import sqlite3
+import sys
+
+store, session_id, input_tokens, output_tokens, nano_aiu = sys.argv[1:6]
+connection = sqlite3.connect(store)
+connection.execute(
+    "CREATE TABLE IF NOT EXISTS assistant_usage_events ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, model TEXT NOT NULL, "
+    "input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, "
+    "cache_write_tokens INTEGER, reasoning_tokens INTEGER, total_nano_aiu INTEGER, "
+    "duration_ms INTEGER)"
+)
+connection.execute(
+    "INSERT INTO assistant_usage_events (session_id, model, input_tokens, output_tokens, "
+    "cache_read_tokens, cache_write_tokens, reasoning_tokens, total_nano_aiu, duration_ms) "
+    "VALUES (?, 'claude-sonnet-5', ?, ?, 0, 0, 0, ?, 10)",
+    (session_id, int(input_tokens), int(output_tokens), int(nano_aiu)),
+)
+connection.commit()
+connection.close()
+PYEOF
+}
+
+run_provider_case() {
+  local case_name="$1"
+  local fake_exit_code="$2"
+  local fake_output="$3"
+  local expected_artifacts="$4"
+  local seed_store="$5"
+  local case_dir="${TEST_ROOT}/${case_name}"
+  local fake_bin="${case_dir}/bin"
+  local copilot_home="${case_dir}/copilot-home"
+  mkdir -p "${fake_bin}" "${case_dir}/outputs" "${copilot_home}"
+
+  write_store_seeder "${case_dir}/seed_store.py"
+
+  # A stale row for the same session, as a restored COPILOT_HOME cache would
+  # contain. It must NOT leak into this run's reported usage.
+  if [ "${seed_store}" = "seed" ]; then
+    python3 "${case_dir}/seed_store.py" "${copilot_home}/session-store.db" "${SESSION_ID}" 999999 88888 9000000000
+  fi
+
+  cat > "${fake_bin}/copilot" << 'BINEOF'
+#!/bin/bash
+if [ "${1:-}" = "--help" ]; then
+  echo "  --session-id"
+  exit 0
+fi
+if [ "${FAKE_COPILOT_RECORD_USAGE}" != "none" ]; then
+  python3 "${FAKE_COPILOT_SEEDER}" "${COPILOT_HOME}/session-store.db" "${FAKE_COPILOT_SESSION_ID}" 1500 50 2000000000
+fi
+printf '%s\n' "${FAKE_COPILOT_OUTPUT}"
+exit "${FAKE_COPILOT_EXIT_CODE}"
+BINEOF
+  chmod +x "${fake_bin}/copilot"
+
+  (
+    cd "${case_dir}"
+    export HOME="${case_dir}"
+    export PATH="${fake_bin}:${PATH}"
+    export COPILOT_HOME="${copilot_home}"
+    export FAKE_COPILOT_OUTPUT="${fake_output}"
+    export FAKE_COPILOT_EXIT_CODE="${fake_exit_code}"
+    export FAKE_COPILOT_SEEDER="${case_dir}/seed_store.py"
+    export FAKE_COPILOT_SESSION_ID="${SESSION_ID}"
+    export FAKE_COPILOT_RECORD_USAGE="${seed_store}"
+    export COPILOT_GITHUB_TOKEN="test-token"
+    export COPILOT_SESSION_ENABLED="false"
+    export AI_AGENT_USAGE_NAME="story_development"
+    export DMTOOLS_CLI_LOG_DIR="${case_dir}/logs"
+    unset COPILOT_SESSION_ID COPILOT_USD_PER_CREDIT
+    PROMPT_ARG="test prompt"
+    PROMPT="test prompt"
+    PROMPT_BYTES=11
+    PASS_ARGS=()
+
+    if [ "${expected_artifacts}" = "usage-only" ]; then
+      record_usage_file() { return 23; }
+    fi
+
+    actual_exit_code=0
+    if [ "${fake_exit_code}" -eq 0 ]; then
+      # run-agent.sh runs providers under `set -e`; calling run_copilot outside
+      # an `||` list keeps errexit active inside it, so any non-zero step in the
+      # best-effort usage reporting would abort the provider here.
+      run_copilot >/dev/null 2>&1
+    else
+      run_copilot >/dev/null 2>&1 || actual_exit_code=$?
+    fi
+
+    if [ "${actual_exit_code}" -ne "${fake_exit_code}" ]; then
+      echo "[${case_name}] expected provider exit ${fake_exit_code}, got ${actual_exit_code}" >&2
+      exit 1
+    fi
+
+    if [ "${expected_artifacts}" = "usage-and-manifest" ]; then
+      test -f outputs/story_development_usage.json
+      test -f outputs/token_usage_files.json
+      grep -q 'outputs/story_development_usage.json' outputs/token_usage_files.json
+      python3 - "outputs/story_development_usage.json" << 'PYEOF'
+import json
+import sys
+
+usage = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {
+    "provider": "copilot",
+    "models": ["claude-sonnet-5"],
+    "usage_records": 1,
+    "input_other": 1500,
+    "output": 50,
+    "total_tokens": 1550,
+    "ai_credits": 2.0,
+    "source": "session-store",
+}
+for key, value in expected.items():
+    if usage.get(key) != value:
+        raise SystemExit(f"expected {key}={value}, got {usage.get(key)}")
+if "cost_usd" in usage:
+    raise SystemExit("cost_usd must be omitted unless COPILOT_USD_PER_CREDIT is set")
+PYEOF
+    elif [ "${expected_artifacts}" = "usage-only" ]; then
+      test -f outputs/story_development_usage.json
+      test ! -e outputs/token_usage_files.json
+    elif [ "${expected_artifacts}" = "transcript-fallback" ]; then
+      test -f outputs/story_development_usage.json
+      grep -q '"source": "transcript-summary"' outputs/story_development_usage.json
+      grep -q '"approximate": true' outputs/story_development_usage.json
+    else
+      test ! -e outputs/story_development_usage.json
+      test ! -e outputs/token_usage_files.json
+    fi
+  )
+}
+
+FOOTER=$'Changes    +2 -2\nAI Credits 2 (12s)\nTokens     \u2191 1.5k (0 cached) \u2022 \u2193 50 (0 reasoning)\nResume     copilot --resume='"${SESSION_ID}"
+
+# Usage must be reported even when the agent itself fails, and stale rows from a
+# restored session-store cache must not be counted.
+run_provider_case "usage-on-failure" 7 "${FOOTER}" usage-and-manifest seed
+# The happy path also runs with errexit active (see run_provider_case).
+run_provider_case "usage-on-success" 0 "${FOOTER}" usage-and-manifest seed
+# A manifest write failure is a warning, never a change of the agent exit code.
+run_provider_case "manifest-failure" 11 "${FOOTER}" usage-only seed
+# No session store at all: fall back to the (rounded) transcript footer.
+run_provider_case "transcript-fallback" 0 "${FOOTER}" transcript-fallback none
+# Nothing to report: no store, no footer.
+run_provider_case "missing-usage" 9 "agent ran but printed no summary" none none
+
+echo "Copilot provider integration tests passed"

--- a/scripts/providers/tests/test_copilot_usage.py
+++ b/scripts/providers/tests/test_copilot_usage.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "copilot_usage.py"
+SPEC = importlib.util.spec_from_file_location("copilot_usage", MODULE_PATH)
+copilot_usage = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(copilot_usage)
+
+
+SCHEMA = """
+CREATE TABLE assistant_usage_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    turn_index INTEGER,
+    model TEXT NOT NULL,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_read_tokens INTEGER,
+    cache_write_tokens INTEGER,
+    reasoning_tokens INTEGER,
+    total_nano_aiu INTEGER,
+    duration_ms INTEGER
+);
+"""
+
+SESSION_A = "5970236a-c0cb-46b0-85da-db6898163d11"
+SESSION_B = "ccd0fd6f-d710-4b1d-9e7b-c7d1cda8e563"
+
+FOOTER_A = (
+    "Changes    +2 -2\n"
+    "AI Credits 58.8 (3m 46s)\n"
+    "Tokens     \u2191 1.8m (1.7m cached, 70.3k written) \u2022 \u2193 6.3k (1.0k reasoning)\n"
+    f"Resume     copilot --resume={SESSION_A}\n"
+)
+# Older/short runs omit the "written" segment entirely.
+FOOTER_B = (
+    "Changes    +32 -0\n"
+    "AI Credits 12.5 (49s)\n"
+    "Tokens     \u2191 449.8k (409.2k cached) \u2022 \u2193 2.2k (976 reasoning)\n"
+    f"Resume     copilot --resume={SESSION_B}\n"
+)
+
+
+def make_store(directory, rows):
+    store = Path(directory) / "session-store.db"
+    connection = sqlite3.connect(store)
+    try:
+        connection.executescript(SCHEMA)
+        connection.executemany(
+            "INSERT INTO assistant_usage_events (session_id, model, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens, reasoning_tokens, total_nano_aiu, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return store
+
+
+class SessionIdParsingTest(unittest.TestCase):
+    def test_finds_resume_ids_in_order_without_duplicates(self):
+        self.assertEqual(
+            copilot_usage.find_session_ids([FOOTER_A + FOOTER_B, FOOTER_A]),
+            [SESSION_A, SESSION_B],
+        )
+
+    def test_accepts_space_separated_resume_flag(self):
+        self.assertEqual(
+            copilot_usage.find_session_ids([f"copilot --resume {SESSION_A.upper()}"]),
+            [SESSION_A],
+        )
+
+    def test_returns_empty_when_no_session_is_printed(self):
+        self.assertEqual(copilot_usage.find_session_ids(["no session here"]), [])
+
+
+class ScaledNumberTest(unittest.TestCase):
+    def test_parses_suffixes_and_separators(self):
+        self.assertEqual(copilot_usage.parse_scaled_number("1.8m"), 1800000)
+        self.assertEqual(copilot_usage.parse_scaled_number("70.3k"), 70300)
+        self.assertEqual(copilot_usage.parse_scaled_number("1,017"), 1017)
+        self.assertEqual(copilot_usage.parse_scaled_number("976"), 976)
+
+    def test_rejects_garbage(self):
+        self.assertEqual(copilot_usage.parse_scaled_number("n/a"), 0)
+        self.assertEqual(copilot_usage.parse_scaled_number(None), 0)
+
+
+class StoreAggregationTest(unittest.TestCase):
+    def test_aggregates_rows_and_derives_input_other(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(
+                home,
+                [
+                    (SESSION_A, "claude-sonnet-5", 1000, 40, 900, 60, 7, 2_000_000_000, 1200),
+                    (SESSION_A, "claude-sonnet-5", 500, 10, 450, 30, 3, 500_000_000, 300),
+                ],
+            )
+
+            usage = copilot_usage.extract_usage([], home=home, session_ids=[SESSION_A])
+
+        self.assertEqual(
+            usage,
+            {
+                "provider": "copilot",
+                "models": ["claude-sonnet-5"],
+                "usage_records": 2,
+                "input_other": 60,
+                "input_cache_read": 1350,
+                "input_cache_creation": 90,
+                "output": 50,
+                "reasoning": 10,
+                "total_input": 1500,
+                "total_tokens": 1550,
+                "ai_credits": 2.5,
+                "duration_ms": 1500,
+                "source": "session-store",
+            },
+        )
+
+    def test_sorts_models_and_never_reports_negative_input_other(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(
+                home,
+                [
+                    (SESSION_A, "gpt-5-mini", 100, 5, 90, 30, 0, 0, 0),
+                    (SESSION_A, "claude-sonnet-5", 10, 1, 5, 0, 0, 0, 0),
+                ],
+            )
+
+            usage = copilot_usage.extract_usage([], home=home, session_ids=[SESSION_A])
+
+        self.assertEqual(usage["models"], ["claude-sonnet-5", "gpt-5-mini"])
+        self.assertEqual(usage["input_other"], 0)
+
+    def test_since_id_excludes_rows_from_previous_runs(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(
+                home,
+                [
+                    (SESSION_A, "gpt-5-mini", 999, 999, 0, 0, 0, 9_000_000_000, 0),
+                    (SESSION_A, "gpt-5-mini", 100, 20, 0, 0, 0, 1_000_000_000, 0),
+                ],
+            )
+
+            usage = copilot_usage.extract_usage(
+                [], home=home, since_id=1, session_ids=[SESSION_A]
+            )
+
+        self.assertEqual(usage["usage_records"], 1)
+        self.assertEqual(usage["total_tokens"], 120)
+        self.assertEqual(usage["ai_credits"], 1.0)
+
+    def test_baseline_reports_highest_row_id(self):
+        with tempfile.TemporaryDirectory() as home:
+            self.assertEqual(copilot_usage.max_usage_event_id(home), 0)
+            make_store(home, [(SESSION_A, "gpt-5-mini", 1, 1, 0, 0, 0, 0, 0)])
+            self.assertEqual(copilot_usage.max_usage_event_id(home), 1)
+
+    def test_retried_attempts_on_one_session_are_not_double_counted(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 100, 10, 0, 0, 0, 0, 0)])
+            transcript = Path(home) / "attempt.log"
+            transcript.write_text(FOOTER_A + FOOTER_A, encoding="utf-8")
+
+            usage = copilot_usage.extract_usage(
+                [transcript, transcript], home=home, session_ids=[SESSION_A]
+            )
+
+        self.assertEqual(usage["usage_records"], 1)
+        self.assertEqual(usage["total_tokens"], 110)
+
+    def test_rows_for_other_sessions_are_ignored(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(
+                home,
+                [
+                    (SESSION_A, "gpt-5-mini", 100, 10, 0, 0, 0, 0, 0),
+                    (SESSION_B, "gpt-5-mini", 700, 70, 0, 0, 0, 0, 0),
+                ],
+            )
+
+            usage = copilot_usage.extract_usage([], home=home, session_ids=[SESSION_A])
+
+        self.assertEqual(usage["total_tokens"], 110)
+
+
+class TranscriptFallbackTest(unittest.TestCase):
+    def test_parses_full_footer(self):
+        self.assertEqual(
+            copilot_usage.parse_transcript_footer(FOOTER_A),
+            {
+                "total_input": 1800000,
+                "input_cache_read": 1700000,
+                "input_cache_creation": 70300,
+                "output": 6300,
+                "reasoning": 1000,
+                "ai_credits": 58.8,
+            },
+        )
+
+    def test_parses_footer_without_written_segment(self):
+        footer = copilot_usage.parse_transcript_footer(FOOTER_B)
+
+        self.assertEqual(footer["input_cache_read"], 409200)
+        self.assertEqual(footer["input_cache_creation"], 0)
+        self.assertEqual(footer["reasoning"], 976)
+
+    def test_returns_none_without_a_footer(self):
+        self.assertIsNone(copilot_usage.parse_transcript_footer("nothing to see"))
+
+    def test_falls_back_when_store_has_no_rows(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [])
+            first = Path(home) / "attempt1.log"
+            second = Path(home) / "attempt2.log"
+            first.write_text(FOOTER_A, encoding="utf-8")
+            second.write_text(FOOTER_B, encoding="utf-8")
+
+            usage = copilot_usage.extract_usage([first, second], home=home)
+
+        self.assertEqual(usage["source"], "transcript-summary")
+        self.assertTrue(usage["approximate"])
+        self.assertEqual(usage["usage_records"], 2)
+        self.assertEqual(usage["total_input"], 1800000 + 449800)
+        self.assertEqual(usage["input_cache_read"], 1700000 + 409200)
+        self.assertEqual(usage["output"], 6300 + 2200)
+        self.assertAlmostEqual(usage["ai_credits"], 71.3)
+
+    def test_repeated_footers_for_one_session_count_once(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [])
+            first = Path(home) / "attempt1.log"
+            second = Path(home) / "attempt2.log"
+            first.write_text(FOOTER_A, encoding="utf-8")
+            second.write_text(FOOTER_A, encoding="utf-8")
+
+            usage = copilot_usage.extract_usage([first, second], home=home)
+
+        self.assertEqual(usage["usage_records"], 1)
+        self.assertEqual(usage["total_input"], 1800000)
+
+    def test_missing_usage_everywhere_raises(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [])
+            transcript = Path(home) / "attempt.log"
+            transcript.write_text("agent ran but printed no summary", encoding="utf-8")
+
+            with self.assertRaises(copilot_usage.UsageNotFoundError):
+                copilot_usage.extract_usage([transcript], home=home)
+
+
+class CostTest(unittest.TestCase):
+    def setUp(self):
+        self._previous = os.environ.pop("COPILOT_USD_PER_CREDIT", None)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        os.environ.pop("COPILOT_USD_PER_CREDIT", None)
+        if self._previous is not None:
+            os.environ["COPILOT_USD_PER_CREDIT"] = self._previous
+
+    def _usage(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 10, 1, 0, 0, 0, 4_000_000_000, 0)])
+            return copilot_usage.extract_usage([], home=home, session_ids=[SESSION_A])
+
+    def test_cost_is_omitted_by_default(self):
+        self.assertNotIn("cost_usd", self._usage())
+
+    def test_cost_is_derived_from_configured_rate(self):
+        os.environ["COPILOT_USD_PER_CREDIT"] = "0.04"
+
+        usage = self._usage()
+
+        self.assertEqual(usage["ai_credits"], 4.0)
+        self.assertEqual(usage["cost_usd"], 0.16)
+
+    def test_invalid_rate_is_ignored(self):
+        os.environ["COPILOT_USD_PER_CREDIT"] = "not-a-number"
+        self.assertNotIn("cost_usd", self._usage())
+
+        os.environ["COPILOT_USD_PER_CREDIT"] = "0"
+        self.assertNotIn("cost_usd", self._usage())
+
+
+class CliTest(unittest.TestCase):
+    def test_writes_usage_file_and_exits_zero(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 30, 5, 10, 5, 1, 1_000_000_000, 9)])
+            output = Path(home) / "outputs" / "story_development_usage.json"
+
+            exit_code = copilot_usage.main(
+                ["--home", home, "--session-id", SESSION_A, "--output", str(output)]
+            )
+
+            self.assertEqual(exit_code, 0)
+            written = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(written["total_tokens"], 35)
+        self.assertEqual(written["provider"], "copilot")
+
+    def test_exits_two_when_no_usage_is_available(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [])
+            transcript = Path(home) / "attempt.log"
+            transcript.write_text("no summary", encoding="utf-8")
+            output = Path(home) / "outputs" / "story_development_usage.json"
+
+            exit_code = copilot_usage.main(
+                ["--home", home, "--transcript", str(transcript), "--output", str(output)]
+            )
+
+            self.assertEqual(exit_code, 2)
+            self.assertFalse(output.exists())
+
+    def test_baseline_mode_needs_no_output(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 1, 1, 0, 0, 0, 0, 0)])
+
+            self.assertEqual(copilot_usage.main(["--home", home, "--baseline"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/providers/tests/test_copilot_usage.py
+++ b/scripts/providers/tests/test_copilot_usage.py
@@ -7,6 +7,7 @@ import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "copilot_usage.py"
@@ -55,6 +56,23 @@ def make_store(directory, rows):
     connection = sqlite3.connect(store)
     try:
         connection.executescript(SCHEMA)
+        connection.executemany(
+            "INSERT INTO assistant_usage_events (session_id, model, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens, reasoning_tokens, total_nano_aiu, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return store
+
+
+def append_rows(directory, rows):
+    """Insert more rows into a store already created by make_store()."""
+    store = Path(directory) / "session-store.db"
+    connection = sqlite3.connect(store)
+    try:
         connection.executemany(
             "INSERT INTO assistant_usage_events (session_id, model, input_tokens, output_tokens, "
             "cache_read_tokens, cache_write_tokens, reasoning_tokens, total_nano_aiu, duration_ms) "
@@ -193,6 +211,107 @@ class StoreAggregationTest(unittest.TestCase):
             usage = copilot_usage.extract_usage([], home=home, session_ids=[SESSION_A])
 
         self.assertEqual(usage["total_tokens"], 110)
+
+    def test_falls_back_to_unscoped_query_when_no_session_id_is_known(self):
+        # Simulates a crash/timeout: no --resume=<uuid> line was ever printed and
+        # no COPILOT_SESSION_ID was passed, but a real (non-zero) baseline id was
+        # captured before the run, so the exact new rows can still be recovered.
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 999, 999, 0, 0, 0, 9_000_000_000, 0)])
+            baseline = copilot_usage.max_usage_event_id(home)
+            append_rows(home, [(SESSION_A, "gpt-5-mini", 100, 20, 0, 0, 0, 1_000_000_000, 0)])
+
+            usage = copilot_usage.extract_usage(
+                [], home=home, since_id=baseline, session_ids=[]
+            )
+
+        self.assertEqual(usage["usage_records"], 1)
+        self.assertEqual(usage["total_tokens"], 120)
+        self.assertEqual(usage["source"], "session-store")
+        self.assertEqual(usage["scoped"], False)
+
+    def test_unscoped_fallback_does_not_fire_when_baseline_is_zero(self):
+        # Without a real baseline (since_id defaults to 0), falling back to an
+        # unscoped query would leak the store's entire history rather than one
+        # run's usage, so it must stay empty here.
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 100, 20, 0, 0, 0, 0, 0)])
+
+            with self.assertRaises(copilot_usage.UsageNotFoundError):
+                copilot_usage.extract_usage([], home=home, since_id=0, session_ids=[])
+
+    def test_scoped_query_is_unaffected_when_session_ids_are_known(self):
+        with tempfile.TemporaryDirectory() as home:
+            make_store(home, [(SESSION_A, "gpt-5-mini", 100, 20, 0, 0, 0, 0, 0)])
+
+            usage = copilot_usage.extract_usage(
+                [], home=home, since_id=0, session_ids=[SESSION_A]
+            )
+
+        self.assertNotIn("scoped", usage)
+
+
+class ConnectReadonlyCleanupTest(unittest.TestCase):
+    def test_removes_temp_dir_when_the_fallback_copy_fails(self):
+        with tempfile.TemporaryDirectory() as home:
+            # A file that isn't a valid sqlite database forces _connect_readonly
+            # past its direct-open attempt and into the copy-to-tempdir fallback.
+            store = Path(home) / "session-store.db"
+            store.write_bytes(b"not a real sqlite database")
+
+            created: dict[str, str] = {}
+            real_mkdtemp = copilot_usage.tempfile.mkdtemp
+
+            def tracking_mkdtemp(*args, **kwargs):
+                path = real_mkdtemp(*args, **kwargs)
+                created["path"] = path
+                return path
+
+            with mock.patch.object(
+                copilot_usage.tempfile, "mkdtemp", side_effect=tracking_mkdtemp
+            ), mock.patch.object(
+                copilot_usage.shutil, "copyfile", side_effect=OSError("simulated disk full")
+            ):
+                with self.assertRaises(OSError):
+                    copilot_usage._connect_readonly(store)
+
+            self.assertIn("path", created)
+            self.assertFalse(
+                os.path.exists(created["path"]),
+                "temp dir from the failed copy attempt should have been removed",
+            )
+
+    def test_removes_temp_dir_when_connecting_to_the_copy_fails(self):
+        with tempfile.TemporaryDirectory() as home:
+            store = Path(home) / "session-store.db"
+            store.write_bytes(b"not a real sqlite database")
+
+            created: dict[str, str] = {}
+            real_mkdtemp = copilot_usage.tempfile.mkdtemp
+
+            def tracking_mkdtemp(*args, **kwargs):
+                path = real_mkdtemp(*args, **kwargs)
+                created["path"] = path
+                return path
+
+            real_connect = copilot_usage.sqlite3.connect
+
+            def flaky_connect(target, *args, **kwargs):
+                if str(store) not in str(target):
+                    # The copy lives under the tracked temp dir, not next to store.
+                    raise sqlite3.OperationalError("simulated corrupt copy")
+                return real_connect(target, *args, **kwargs)
+
+            with mock.patch.object(
+                copilot_usage.tempfile, "mkdtemp", side_effect=tracking_mkdtemp
+            ), mock.patch.object(
+                copilot_usage.sqlite3, "connect", side_effect=flaky_connect
+            ):
+                with self.assertRaises(sqlite3.OperationalError):
+                    copilot_usage._connect_readonly(store)
+
+            self.assertIn("path", created)
+            self.assertFalse(os.path.exists(created["path"]))
 
 
 class TranscriptFallbackTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

[#359](https://github.com/IstiN/dmtools-agents/pull/359) (`fix: report Claude Code token usage`) wired token/cost reporting into **`claude.sh` only**.

`js/common/tokenUsageComment.js` is already provider-agnostic — it just reads the `outputs/token_usage_files.json` manifest — and `kimi.sh` writes a usage file too. The remaining gap for the *"Cost Tracking in DMT Tool"* requirement was that **`copilot.sh` never wrote `outputs/<agent>_usage.json`**, so every Copilot-provider run reported no usage at all.

## What changed

### New: `scripts/providers/copilot_usage.py`

Normalizes Copilot usage into the same provider-neutral schema as `claude_usage.py` / `kimi.sh`.

| Source | Used when | Precision |
| --- | --- | --- |
| `$COPILOT_HOME/session-store.db` → `assistant_usage_events` | default | **exact** — one row per model request with input/output/cache-read/cache-write/reasoning tokens and billed nano AIU |
| CLI transcript footer (`Tokens ↑ 1.8m (1.7m cached, 70.3k written) • ↓ 6.3k (1.0k reasoning)` / `AI Credits 58.8`) | store missing or unreadable | rounded by the CLI → flagged `"approximate": true` |

- The store is opened **strictly read-only** (`file:...?mode=ro`), with a copy-the-db-plus-`-wal`/`-shm`-to-a-tempdir retry for the locked/WAL case. It is never written to.
- Copilot's `input_tokens` is the *grand total* input, so `input_other = input_tokens - cache_read - cache_write`.
- Session ids come from the `Resume  copilot --resume=<uuid>` line in each transcript, plus `COPILOT_SESSION_ID`.
- Python stdlib only — no new dependencies.

### Cost field

Copilot bills **premium requests (AI credits)**, not dollars, so the usage JSON carries `ai_credits` (`total_nano_aiu / 1e9`). `cost_usd` is emitted **only** when `COPILOT_USD_PER_CREDIT` is set to a positive number.

### `scripts/providers/copilot.sh`

Snapshots `max(id)` of `assistant_usage_events` **before** the run and reports only rows above it. This matters because `setup/copilot-session.sh` caches and restores `COPILOT_HOME` across CI runs and resumes a *stable* session id per ticket/group — a restored store already contains previous runs' rows. Conversely, retried attempts that resume the same session are deduped by session id, so multi-attempt runs are not double counted.

Reporting is **strictly best-effort**: extractor or manifest failures print a warning and never replace the Copilot process exit code (same contract as `claude.sh`).

### Example output

```json
{
  "provider": "copilot",
  "models": ["claude-sonnet-5"],
  "usage_records": 29,
  "input_other": 58,
  "input_cache_read": 1745710,
  "input_cache_creation": 70267,
  "output": 6347,
  "reasoning": 1017,
  "total_input": 1816035,
  "total_tokens": 1822382,
  "ai_credits": 58.83955,
  "duration_ms": 104746,
  "source": "session-store"
}
```

The keys shared with the Claude/Kimi schema keep the Jira comment consistent across providers; `ai_credits`, `reasoning`, `duration_ms`, `source` and `approximate` are additive.

## Verification

Run against a real archived transcript, the extractor reproduces that run's footer exactly — `↑ 1.8m (1.7m cached, 70.3k written) • ↓ 6.3k (1.0k reasoning)`, `AI Credits 58.8` → `1,816,035 / 1,745,710 / 70,267 / 6,347 / 1,017 / 58.83955`.

New tests (mirroring the Claude pair):

- `scripts/providers/tests/test_copilot_usage.py` — 23 unit tests: store aggregation, `input_other` derivation, `--since-id` filtering, cross-session isolation, retry dedupe, session-id parsing, footer parsing with and without the `written` segment, `k`/`m` suffixes, `COPILOT_USD_PER_CREDIT`, and the no-usage-anywhere case.
- `scripts/providers/tests/test_copilot_provider.sh` — 5 integration cases with a fake `copilot` binary and a seeded `COPILOT_HOME` store: usage recorded when the agent **fails**, on success under active `errexit`, manifest-write failure downgraded to a warning, transcript fallback, and nothing-to-report. Every case asserts the provider exit code is preserved.

```
$ python3 scripts/providers/tests/test_copilot_usage.py   → Ran 23 tests ... OK
$ bash scripts/providers/tests/test_copilot_provider.sh   → Copilot provider integration tests passed
$ python3 scripts/providers/tests/test_claude_usage.py    → Ran 6 tests ... OK   (no regression)
$ bash scripts/providers/tests/test_claude_provider.sh    → Claude provider integration tests passed
```

## Out of scope

`js/aiTeammateTokenUsageReporter.js` (the GitHub-Actions-log-based cost report) still parses the *old* Copilot footer shape — it looks for `Requests N` and `1.7m (cached)`, while the current CLI prints `AI Credits 58.8` and `(1.7m cached, 70.3k written)` — so cached/reasoning/requests come out as `0` there. Left for a separate PR.
