### PR TITLE
fix(copilot): detect empty session resume and restart with fresh session

### DIFF
--- a/scripts/providers/copilot.sh
+++ b/scripts/providers/copilot.sh
@@ -196,6 +196,28 @@ run_copilot() {
       :
     fi
 
+    # Detect "empty resume": --resume on a completed/terminal session can exit 0
+    # after printing only the old session trailer (Changes/AI Units/Tokens) without
+    # processing the new prompt at all. A productive run always shows tool-call
+    # markers ("●"); a bare trailer means the prompt was never processed.
+    # Self-heal by starting a fresh session under a suffixed name.
+    if [ "$exit_code" -eq 0 ] && [ "${copilot_session_mode}" = "resume-name" ]; then
+      if ! grep -q "●" "$copilot_log"; then
+        echo ""
+        echo "Copilot resumed session ${COPILOT_SESSION_NAME} but produced no activity (terminal session state?)"
+        echo "Starting a fresh session with a new name instead"
+        COPILOT_SESSION_NAME="${COPILOT_SESSION_NAME}-r$(date +%s)"
+        copilot_session_args=(--name "${COPILOT_SESSION_NAME}")
+        copilot_session_mode="name"
+        copilot_log="$(new_agent_log_file "copilot-attempt${attempt}-fresh")"
+        copilot_log_files+=("$copilot_log")
+        set +e
+        run_copilot_once "$copilot_log" "$copilot_model_value"
+        exit_code=$?
+        set -e
+      fi
+    fi
+
     if [ "$exit_code" -eq 0 ]; then
       record_codegraph_usage "$copilot_log"
       break


### PR DESCRIPTION
## Problem
`--resume <name>` targeting a session in a terminal state (e.g. a previous run that hit the monthly quota) exits 0 after printing only the old session trailer:

```
Changes   +207 -34
AI Units  490 (65h 12m 41s)
Tokens    ↑ 1.3m • ↓ 19.3k • 3.4m (cached)
```

The new prompt (sent via stdin) is never processed — zero tool calls, no outputs written. The job then finds no `outputs/response.md`, marks the ticket for retry, and the next run resumes the same dead session again. Infinite loop.

## Fix
After a successful (exit 0) run in `resume-name` mode, check the transcript for tool-call markers (`●`). A productive run always has them; a bare trailer means the prompt was never processed. On detection, start a fresh session under a timestamp-suffixed name (`<name>-r<unixtime>`) and re-run.

## Testing
- `bash -n scripts/providers/copilot.sh` — syntax OK
- Manually verified the marker difference: productive run logs contain `●` tool-call lines, the empty-resume log contains only the 4-line trailer.