### PR TITLE
feat(pr): robust ticket-to-PR matching with scoring and optional project hook

### DIFF
--- a/js/checkWipLabel.js
+++ b/js/checkWipLabel.js
@@ -69,7 +69,8 @@ function action(params) {
             try {
                 var config = configLoader.loadProjectConfig(params.jobParams || params);
                 var scm = configLoader.createScm(config);
-                var pr = gh.findPRForTicket(scm, ticketKey);
+                var prSearchOptions = config.prSearchFn ? { prSearchFn: config.prSearchFn } : {};
+                var pr = gh.findPRForTicket(scm, ticketKey, prSearchOptions);
                 if (!pr) {
                     console.log('⏸️  No open PR found for ' + ticketKey + ' - skipping processing');
                     try {

--- a/js/common/githubHelpers.js
+++ b/js/common/githubHelpers.js
@@ -49,34 +49,127 @@ function _isScm(x) {
     return x !== null && typeof x === 'object' && typeof x.listPrs === 'function';
 }
 
+// Helpers for robust ticket-key → PR matching.
+// Keep everything project-agnostic: no project/company names, no conventions tied to one org.
 
-function findPRForTicket(scmOrWorkspace, repositoryOrTicketKey, ticketKeyOpt) {
-    var openPRs, ticketKey;
+function _normalizeForMatch(s) {
+    return String(s || '').toLowerCase();
+}
+
+function _extractNumericPart(ticketKey) {
+    var m = String(ticketKey || '').match(/(\d+)$/);
+    return m ? m[1] : '';
+}
+
+function _containsBoundedNumber(s, number) {
+    if (!s || !number) return false;
+    var re = new RegExp('(^|[^a-z0-9])' + number + '([^a-z0-9]|$)', 'i');
+    return re.test(s);
+}
+
+function _isBotAuthor(author) {
+    if (!author) return false;
+    if (author.is_bot === true || author.type === 'Bot') return true;
+    var login = String(author.login || '');
+    return login.indexOf('[bot]') !== -1 ||
+           login.indexOf('-bot') !== -1 ||
+           login.indexOf('_bot') !== -1;
+}
+
+function _headPrefixScore(ref) {
+    if (!ref) return 0;
+    var lower = ref.toLowerCase();
+    if (lower.indexOf('feature/') === 0 || lower.indexOf('bug/') === 0) return 20;
+    if (lower.indexOf('release/') === 0) return -10;
+    return 0;
+}
+
+function _scorePR(pr, normalizedKey, numericPart) {
+    var title = _normalizeForMatch(pr.title);
+    var branch = _normalizeForMatch(pr.head && pr.head.ref);
+    var score = 0;
+
+    if (title.indexOf(normalizedKey) !== -1) score += 100;
+    if (branch.indexOf(normalizedKey) !== -1) score += 80;
+
+    if (numericPart && numericPart.length >= 3) {
+        if (_containsBoundedNumber(title, numericPart)) score += 40;
+        if (_containsBoundedNumber(branch, numericPart)) score += 30;
+    }
+
+    // Only apply preference bonuses/penalties when the PR actually matches the ticket.
+    if (score === 0) return 0;
+
+    score += _headPrefixScore(pr.head && pr.head.ref);
+
+    if (_isBotAuthor(pr.user || pr.author)) score -= 50;
+
+    var changedFiles = pr.changed_files;
+    if (typeof changedFiles === 'number') {
+        score += Math.max(0, 25 - Math.floor(changedFiles / 10));
+    }
+
+    return score;
+}
+
+function findPRForTicket(scmOrWorkspace, repositoryOrTicketKey, ticketKeyOpt, optionsOpt) {
+    var openPRs, ticketKey, options;
     try {
         if (_isScm(scmOrWorkspace)) {
             ticketKey = repositoryOrTicketKey;
+            options = ticketKeyOpt || {};
             console.log('Searching for PR related to', ticketKey);
             openPRs = scmOrWorkspace.listPrs('open');
         } else {
             ticketKey = ticketKeyOpt;
+            options = optionsOpt || {};
             console.log('Searching for PR related to', ticketKey);
             openPRs = github_list_prs({ workspace: scmOrWorkspace, repository: repositoryOrTicketKey, state: 'open' });
         }
         console.log('Found', openPRs.length, 'open PRs');
 
-        var match = function(pr) {
-            return (pr.title && pr.title.indexOf(ticketKey) !== -1) ||
-                   (pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1);
-        };
+        var normalizedKey = _normalizeForMatch(ticketKey);
+        var numericPart = _extractNumericPart(ticketKey);
+        var candidates = [];
 
-        var openMatch = openPRs.filter(match);
-        if (openMatch.length > 0) {
-            console.log('Found open PR #' + openMatch[0].number + ':', openMatch[0].title);
-            return openMatch[0];
+        for (var i = 0; i < openPRs.length; i++) {
+            var pr = openPRs[i];
+            var score = _scorePR(pr, normalizedKey, numericPart);
+            if (score > 0) {
+                candidates.push({ pr: pr, score: score });
+            }
         }
 
-        console.warn('No open PR found for ticket', ticketKey);
-        return null;
+        if (candidates.length === 0) {
+            console.warn('No open PR found for ticket', ticketKey);
+            return null;
+        }
+
+        candidates.sort(function(a, b) {
+            if (b.score !== a.score) return b.score - a.score;
+            var aFiles = a.pr.changed_files || 0;
+            var bFiles = b.pr.changed_files || 0;
+            return aFiles - bFiles;
+        });
+
+        if (typeof options.prSearchFn === 'function') {
+            try {
+                var hookResult = options.prSearchFn(
+                    candidates.map(function(c) { return c.pr; }),
+                    ticketKey,
+                    options
+                );
+                if (hookResult) {
+                    console.log('Project prSearchFn selected PR #' + hookResult.number + ':', hookResult.title);
+                    return hookResult;
+                }
+            } catch (hookErr) {
+                console.warn('prSearchFn hook failed (non-fatal):', hookErr);
+            }
+        }
+
+        console.log('Selected open PR #' + candidates[0].pr.number + ':', candidates[0].pr.title);
+        return candidates[0].pr;
     } catch (e) {
         console.error('Failed to find PR for ticket:', e);
         return null;
@@ -93,29 +186,54 @@ function findPRForTicket(scmOrWorkspace, repositoryOrTicketKey, ticketKeyOpt) {
  * findPRForTicket(). Only the scm-object calling convention is supported
  * (unlike findPRForTicket, no legacy workspace/repository overload).
  */
-function findMergedPRForTicket(scm, ticketKey) {
+function findMergedPRForTicket(scm, ticketKey, options) {
     try {
+        options = options || {};
         console.log('Searching for merged PR related to', ticketKey);
         var closedPRs = scm.listPrs('closed') || [];
         console.log('Found', closedPRs.length, 'closed PRs');
 
-        var match = function(pr) {
-            return (pr.title && pr.title.indexOf(ticketKey) !== -1) ||
-                   (pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1);
-        };
+        var normalizedKey = _normalizeForMatch(ticketKey);
+        var numericPart = _extractNumericPart(ticketKey);
+        var candidates = [];
 
-        var merged = closedPRs.filter(function(pr) { return match(pr) && !!pr.merged_at; });
-        if (merged.length === 0) {
+        for (var i = 0; i < closedPRs.length; i++) {
+            var pr = closedPRs[i];
+            if (!pr.merged_at) continue;
+            var score = _scorePR(pr, normalizedKey, numericPart);
+            if (score > 0) {
+                candidates.push({ pr: pr, score: score });
+            }
+        }
+
+        if (candidates.length === 0) {
             console.warn('No merged PR found for ticket', ticketKey);
             return null;
         }
 
-        merged.sort(function(a, b) {
-            return new Date(b.merged_at).getTime() - new Date(a.merged_at).getTime();
+        candidates.sort(function(a, b) {
+            if (b.score !== a.score) return b.score - a.score;
+            return new Date(b.pr.merged_at).getTime() - new Date(a.pr.merged_at).getTime();
         });
 
-        console.log('Found merged PR #' + merged[0].number + ':', merged[0].title);
-        return merged[0];
+        if (typeof options.prSearchFn === 'function') {
+            try {
+                var hookResult = options.prSearchFn(
+                    candidates.map(function(c) { return c.pr; }),
+                    ticketKey,
+                    options
+                );
+                if (hookResult) {
+                    console.log('Project prSearchFn selected merged PR #' + hookResult.number + ':', hookResult.title);
+                    return hookResult;
+                }
+            } catch (hookErr) {
+                console.warn('prSearchFn hook failed (non-fatal):', hookErr);
+            }
+        }
+
+        console.log('Found merged PR #' + candidates[0].pr.number + ':', candidates[0].pr.title);
+        return candidates[0].pr;
     } catch (e) {
         console.error('Failed to find merged PR for ticket:', e);
         return null;

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -465,6 +465,20 @@ function loadProjectConfig(params) {
         }
     }
 
+    // Apply prSearchFnPath from customParams — loads a JS file whose module.exports is a
+    // function(candidates, ticketKey, options) → pr | null. Lets a project plug in custom
+    // PR selection logic without putting project-specific code in the shared agents repo.
+    if (customParams.prSearchFnPath) {
+        var prSearchFn = loadConfigFile(customParams.prSearchFnPath);
+        if (typeof prSearchFn === 'function') {
+            config.prSearchFn = prSearchFn;
+            console.log('configLoader: Loaded prSearchFn from ' + customParams.prSearchFnPath);
+        } else {
+            console.warn('configLoader: prSearchFnPath "' + customParams.prSearchFnPath +
+                '" did not export a function — ignoring');
+        }
+    }
+
     // Allow individual agents to enable two-branch flow via customParams.featureBranchEnabled,
     // without requiring a project-wide config.git.featureBranch.enabled change.
     if (customParams.featureBranchEnabled === true) {

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -15,6 +15,7 @@ var autoStart = require('./common/autoStart.js');
 var configLoader = require('./configLoader.js');
 var outputFiles = require('./common/outputFiles.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
+var gh = require('./common/githubHelpers.js');
 
 var RESUME_MARKER = 'outputs/.pr-review-missing-output-resume-attempted';
 
@@ -286,28 +287,6 @@ function getGitHubRepoInfo() {
 
     } catch (error) {
         console.error('Failed to get GitHub repo info:', error);
-        return null;
-    }
-}
-
-function findPRForTicket(scm, ticketKey) {
-    try {
-        console.log('Searching for PR related to', ticketKey);
-        const openPRs = scm.listPrs('open');
-        console.log('Found', openPRs.length, 'open PRs');
-        const matchingPRs = openPRs.filter(function(pr) {
-            const titleMatch = pr.title && pr.title.indexOf(ticketKey) !== -1;
-            const branchMatch = pr.head && pr.head.ref && pr.head.ref.indexOf(ticketKey) !== -1;
-            return titleMatch || branchMatch;
-        });
-        if (matchingPRs.length === 0) {
-            console.log('No open PRs found mentioning', ticketKey);
-            return null;
-        }
-        console.log('Found matching PR:', matchingPRs[0].number);
-        return matchingPRs[0];
-    } catch (error) {
-        console.error('Error finding PR:', error);
         return null;
     }
 }
@@ -767,7 +746,8 @@ function action(params) {
         // Fallback: If no PR number found, search for PR using MCP tools
         if (!prNumber && repoInfo) {
             console.log('PR number not found in input folder, searching GitHub...');
-            const pr = findPRForTicket(scm, ticketKey);
+            var prSearchOptions = config.prSearchFn ? { prSearchFn: config.prSearchFn } : {};
+            const pr = gh.findPRForTicket(scm, ticketKey, prSearchOptions);
             if (pr) {
                 prNumber = pr.number;
                 prUrl = pr.html_url;

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -104,7 +104,8 @@ function action(params) {
         }
 
         // Step 2: Find existing PR
-        const pr = gh.findPRForTicket(scm, ticketKey);
+        var prSearchOptions = config.prSearchFn ? { prSearchFn: config.prSearchFn } : {};
+        const pr = gh.findPRForTicket(scm, ticketKey, prSearchOptions);
         if (!pr) {
             failSetup(
                 ticketKey,

--- a/js/preparePRForReview.js
+++ b/js/preparePRForReview.js
@@ -45,7 +45,8 @@ function action(params) {
 
         // Step 2: Find PR
         console.log('Searching for open PR associated with ticket:', ticketKey);
-        const pr = gh.findPRForTicket(scm, ticketKey);
+        var prSearchOptions = config.prSearchFn ? { prSearchFn: config.prSearchFn } : {};
+        const pr = gh.findPRForTicket(scm, ticketKey, prSearchOptions);
         if (!pr) {
             console.warn('No open PR found for ticket:', ticketKey);
             try {

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -517,6 +517,27 @@ suite('configLoader.loadProjectConfig', function() {
             'resolver must fire even though ticket only exists as a sibling of jobParams');
     });
 
+    test('loads prSearchFn from customParams.prSearchFnPath', function() {
+        var cl = makeLoader({
+            '.dmtools/prSearch/custom.js':
+                'module.exports = function(candidates, ticketKey, options) { return candidates[0]; };'
+        });
+        var config = cl.loadProjectConfig({
+            customParams: { prSearchFnPath: '.dmtools/prSearch/custom.js' }
+        });
+        assert.equal(typeof config.prSearchFn, 'function');
+    });
+
+    test('ignores prSearchFnPath that does not export a function', function() {
+        var cl = makeLoader({
+            '.dmtools/prSearch/bad.js': 'module.exports = { foo: 1 };'
+        });
+        var config = cl.loadProjectConfig({
+            customParams: { prSearchFnPath: '.dmtools/prSearch/bad.js' }
+        });
+        assert.ok(!config.prSearchFn, 'prSearchFn must not be set when file does not export a function');
+    });
+
 });
 
 // ── resolveConfluenceUrls ─────────────────────────────────────────────────────

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -87,6 +87,148 @@ function makeGraphQLResponse(nodes) {
     });
 }
 
+// ── Suite: findPRForTicket scoring/ranking ──────────────────────────────────
+
+function scmWithOpenPrs(prs) {
+    return {
+        listPrs: function(state) {
+            assert.equal(state, 'open', 'findPRForTicket must request open PRs');
+            return prs;
+        }
+    };
+}
+
+suite('githubHelpers.findPRForTicket', function() {
+
+    test('returns null when no open PR matches', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 1, title: 'OTHER-1: unrelated', head: { ref: 'feature/other-1' }, changed_files: 2 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.ok(!result, 'no matching PR should return null/falsy');
+    });
+
+    test('matches ticket key case-insensitively in title', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 1, title: 'proj-42: fix', head: { ref: 'feature/x' }, changed_files: 1 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.ok(result, 'should match lowercase title against uppercase ticket key');
+        assert.equal(result.number, 1);
+    });
+
+    test('matches ticket key case-insensitively in head branch', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 2, title: 'Unrelated title', head: { ref: 'feature/proj-42-fix' }, changed_files: 1 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.ok(result, 'should match lowercase branch against uppercase ticket key');
+        assert.equal(result.number, 2);
+    });
+
+    test('falls back to bounded numeric part when full key is absent', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 3, title: 'lions: update 420 navigation', head: { ref: 'feature/ft_lions_420_update' }, changed_files: 1 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-420');
+
+        assert.ok(result, 'should find PR by bounded ticket number when full key missing');
+        assert.equal(result.number, 3);
+    });
+
+    test('numeric fallback ignores unbounded digit substrings', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 4, title: 'fix for 14200 range', head: { ref: 'feature/x' }, changed_files: 1 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-420');
+
+        assert.ok(!result, 'number 420 embedded inside 14200 must not match');
+    });
+
+    test('prefers feature/bug prefix over release/ prefix', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 5, title: 'release: proj-42', head: { ref: 'release/rc_proj_42' }, changed_files: 250 },
+            { number: 6, title: 'proj-42 fix', head: { ref: 'feature/ft_proj_42' }, changed_files: 3 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.ok(result, 'should select a PR');
+        assert.equal(result.number, 6, 'feature branch PR should win over release/rc PR');
+    });
+
+    test('deprioritizes bot-authored PRs', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 7, title: 'proj-42 release', head: { ref: 'release/rc_proj_42' }, changed_files: 250, user: { login: 'release-bot', is_bot: true } },
+            { number: 8, title: 'proj-42 fix', head: { ref: 'feature/ft_proj_42' }, changed_files: 3, user: { login: 'dev' } }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.equal(result.number, 8, 'human-authored feature PR should win over bot release PR');
+    });
+
+    test('uses changed_files as tie-breaker when scores are equal', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 9, title: 'PROJ-42 fix a', head: { ref: 'feature/ft_proj_42_a' }, changed_files: 10 },
+            { number: 10, title: 'PROJ-42 fix b', head: { ref: 'feature/ft_proj_42_b' }, changed_files: 2 }
+        ]);
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.equal(result.number, 10, 'smaller PR should win when scores are tied');
+    });
+
+    test('project prSearchFn hook can override selection', function() {
+        var gh = loadGithubHelpers({});
+        var scm = scmWithOpenPrs([
+            { number: 11, title: 'PROJ-42 first', head: { ref: 'feature/ft_proj_42_first' }, changed_files: 1 },
+            { number: 12, title: 'PROJ-42 second', head: { ref: 'feature/ft_proj_42_second' }, changed_files: 1 }
+        ]);
+        var hookCalled = false;
+        var options = {
+            prSearchFn: function(candidates, key, opts) {
+                hookCalled = true;
+                assert.equal(key, 'PROJ-42');
+                assert.equal(candidates.length, 2);
+                return candidates[1];
+            }
+        };
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42', options);
+
+        assert.ok(hookCalled, 'prSearchFn hook should be called');
+        assert.equal(result.number, 12, 'hook should decide which PR to use');
+    });
+
+    test('returns null and does not throw when scm.listPrs throws', function() {
+        var gh = loadGithubHelpers({});
+        var scm = {
+            listPrs: function() { throw new Error('network down'); }
+        };
+
+        var result = gh.findPRForTicket(scm, 'PROJ-42');
+
+        assert.ok(!result, 'errors should be swallowed and null returned');
+    });
+});
+
 // ── Suite: resolved status from GraphQL ──────────────────────────────────────
 
 suite('github repo remote parsing', function() {

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -2,6 +2,11 @@
  * Unit tests for js/postPRReviewComments.js.
  */
 
+var githubHelpersStub = {
+    findPRForTicket: function() { return null; },
+    findMergedPRForTicket: function() { return null; }
+};
+
 function loadPostPRReviewComments(mocks) {
     var outputFiles = loadModule('js/common/outputFiles.js', makeRequire({}), {
         file_read: (mocks && mocks.file_read) || function() { return null; }
@@ -14,6 +19,7 @@ function loadPostPRReviewComments(mocks) {
             './common/autoStart.js': { triggerConfiguredWorkflowForTicket: function() { return false; } },
             './configLoader.js': configLoaderModule,
             './common/outputFiles.js': outputFiles,
+            './common/githubHelpers.js': githubHelpersStub,
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         {
@@ -318,6 +324,7 @@ suite('postPRReviewComments', function() {
                         resolveInstructions: function() { return { jobParamPatch: {} }; }
                     },
                     './common/outputFiles.js': outputFiles,
+                    './common/githubHelpers.js': githubHelpersStub,
                     './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
                 }),
                 defaultMocks

--- a/js/unit-tests/test_postStoryTestAutomationReview.js
+++ b/js/unit-tests/test_postStoryTestAutomationReview.js
@@ -59,6 +59,10 @@ function loadPostStoryTestAutomationReview(mocks) {
             },
             './configLoader.js': freshConfigLoader,
             './common/outputFiles.js': outputFiles,
+            './common/githubHelpers.js': {
+                findPRForTicket: function() { return null; },
+                findMergedPRForTicket: function() { return null; }
+            },
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
         }),
         allMocks


### PR DESCRIPTION
## What\nImproves the shared PR-review/rework PR lookup so it reliably finds human-created PRs even when branch/title naming diverges from the strict ticket-key format.\n\n## Changes\n- Case-insensitive ticket-key matching in both PR title and head branch.\n- Bounded numeric fallback: if the full key is missing, the ticket number (3+ digits) is matched as a standalone token.\n- Candidate scoring & ranking:\n  - title match outranks branch match;\n  - feature/bug branches are preferred over release/rc branches;\n  - bot-authored PRs are deprioritized;\n  - smaller PRs win ties.\n- New optional hook: set customParams.prSearchFnPath to inject project-specific selection logic without putting project code in the shared repo.\n- Updated callers: preparePRForReview, checkWipLabel, preCliReworkSetup, postPRReviewComments.\n- Unit tests added/updated.\n\n## Verification\nRan the full JS test suite: 763 passed, 0 failed.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>