### PR TITLE
feat(discovery): extract inline comments and reply to them

### DIFF
--- a/discovery.json
+++ b/discovery.json
@@ -12,11 +12,17 @@
     "preCliJSAction": "agents/js/prepareDiscoveryContext.js",
     "postJSAction": "agents/js/publishDiscoveryToConfluence.js",
     "inputJql": "key = JD-82",
+    "customParams": {
+      "discovery": {
+        "includeConfluenceComments": true
+      }
+    },
     "cliPrompts": [
       "Experienced Product Discovery Lead / Business Analyst",
       "./agents/instructions/common/agent_task_preamble.md",
       "./agents/instructions/discovery/general_guidelines.md",
       "./agents/instructions/common/input_context_reading.md",
+      "./agents/instructions/discovery/inline_comments.md",
       "./agents/instructions/discovery/investigate_before_writing.md",
       "./agents/instructions/discovery/evidence_and_methods.md",
       "./agents/instructions/discovery/decision_and_governance.md",

--- a/instructions/discovery/inline_comments.md
+++ b/instructions/discovery/inline_comments.md
@@ -1,0 +1,30 @@
+# Inline comments on existing discovery pages
+
+When `input/discovery_inline_comments.md` is present, it contains inline (annotation) comments left on the existing discovery Confluence pages for this ticket.
+
+## How to use them
+
+- Read the file before editing any discovery content.
+- Treat **unresolved** comments as review feedback. If a comment points out a mistake, asks a question, or requests a clarification, update the relevant discovery page so the concern is addressed.
+- If a comment is already **resolved**, you do not need to act on it again, but you may reference it if useful.
+
+## Replying to comments
+
+If you make a change that directly answers an unresolved comment, add a reply entry to `outputs/discovery_replies.json`. The file must contain a JSON array with objects in this exact shape:
+
+```json
+[
+  {
+    "pageId": "12345678",
+    "commentId": "98765432",
+    "body": "Fixed — the assumption is now documented in the AS IS section."
+  }
+]
+```
+
+Rules:
+
+- Only reply when your update genuinely addresses the comment.
+- `pageId` and `commentId` must come from `input/discovery_inline_comments.md`.
+- Keep replies concise and professional.
+- If you do not reply to any comment, you may omit the file or write an empty array `[]`.

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -99,10 +99,11 @@ var DEFAULTS = {
     // own .dmtools/config.js before discovery pages can be published; this repo
     // stays project-agnostic.
     discovery: {
-        space: '',            // Confluence space key discovery pages are created in
-        parentPageId: '',     // Confluence page ID each ticket's discovery page nests under
-        deleteOrphans: false  // Whether confluence_sync_markdown_directory removes child
-                               // pages no longer present in outputs/discovery/
+        space: '',                     // Confluence space key discovery pages are created in
+        parentPageId: '',              // Confluence page ID each ticket's discovery page nests under
+        deleteOrphans: false,          // Whether confluence_sync_markdown_directory removes child
+                                       // pages no longer present in outputs/discovery/
+        includeConfluenceComments: true // Whether to fetch inline comments from existing discovery pages
     },
 
     smRules: null,

--- a/js/prepareDiscoveryContext.js
+++ b/js/prepareDiscoveryContext.js
@@ -24,7 +24,12 @@
  *     the CLI agent's view on the next iteration, and a project with
  *     deleteOrphans enabled would then delete them from Confluence entirely
  *     on publish, even though nothing about them changed.
- *  3. Writes input/discovery_meta.json with the resolved space/parentPageId
+ *  3. Collects inline comments (annotations) from every page in the existing
+ *     discovery tree and writes them to input/discovery_inline_comments.json
+ *     and input/discovery_inline_comments.md. The CLI agent can read these
+ *     comments as feedback and produce outputs/discovery_replies.json, which
+ *     publishDiscoveryToConfluence.js posts back to Confluence.
+ *  4. Writes input/discovery_meta.json with the resolved space/parentPageId
  *     and the existing page id (if found) — read by the matching postJSAction
  *     (publishDiscoveryToConfluence.js) so both steps agree on where to publish
  *     without re-resolving config or re-querying Confluence twice.
@@ -33,9 +38,105 @@
 var configLoader = require('./configLoader.js');
 
 var DISCOVERY_OUTPUT_DIR = 'outputs/discovery';
+var COMMENTS_FILE_NAME = 'discovery_inline_comments';
+var DEFAULT_COMMENTS_LIMIT = 100;
 
 function sanitizeFileName(title) {
     return String(title || 'untitled').replace(/[\\/:*?"<>|]/g, '-').trim();
+}
+
+function mergeObjects(base, override) {
+    var result = {};
+    var key;
+    for (key in (base || {})) {
+        if (Object.prototype.hasOwnProperty.call(base, key)) result[key] = base[key];
+    }
+    for (key in (override || {})) {
+        if (Object.prototype.hasOwnProperty.call(override, key)) result[key] = override[key];
+    }
+    return result;
+}
+
+/**
+ * Extract a readable string from a comment body returned by Confluence.
+ * Handles storage format, atlas_doc_format, plain strings, and fallbacks.
+ */
+function extractCommentBody(comment) {
+    if (!comment) return '';
+    var body = comment.body;
+    if (typeof body === 'string') return body;
+    if (body && body.storage && typeof body.storage.value === 'string') return body.storage.value;
+    if (body && body.atlas_doc_format && typeof body.atlas_doc_format.value === 'string') return body.atlas_doc_format.value;
+    if (body && body.view && typeof body.view.value === 'string') return body.view.value;
+    return JSON.stringify(body);
+}
+
+/**
+ * Fetch inline comments for every page in pageInfos. Errors are non-fatal.
+ */
+function fetchInlineComments(pageInfos, folder) {
+    var allComments = [];
+    var limit = DEFAULT_COMMENTS_LIMIT;
+    for (var i = 0; i < pageInfos.length; i++) {
+        var info = pageInfos[i];
+        try {
+            var raw = confluence_get_page_inline_comments({ pageId: String(info.id), limit: limit });
+            var parsed = JSON.parse(raw || '{}');
+            var comments = parsed.results || parsed.comments || (Array.isArray(parsed) ? parsed : []);
+            if (comments.length >= limit) {
+                console.warn('prepareDiscoveryContext: inline comments for page ' + info.id + ' may be truncated (limit ' + limit + ')');
+            }
+            for (var j = 0; j < comments.length; j++) {
+                var c = comments[j];
+                allComments.push({
+                    pageId: info.id,
+                    pageTitle: info.title || 'untitled',
+                    commentId: c.id || null,
+                    parentCommentId: c.parentCommentId || c.parentId || null,
+                    author: (c.author && (c.author.displayName || c.author.emailAddress)) || 'Unknown',
+                    created: c.createdDate || c.created || '',
+                    resolved: !!(c.resolvedDate || c.resolved || c.status === 'resolved' || c.status === 'closed'),
+                    body: extractCommentBody(c)
+                });
+            }
+        } catch (e) {
+            console.warn('prepareDiscoveryContext: failed to fetch inline comments for page ' + info.id + ':', e);
+        }
+    }
+    return allComments;
+}
+
+/**
+ * Write collected inline comments to both JSON (machine-readable) and Markdown
+ * (human/AI-readable) forms in the input folder.
+ */
+function writeCommentsFiles(folder, comments) {
+    try {
+        file_write(folder + '/' + COMMENTS_FILE_NAME + '.json', JSON.stringify({ comments: comments }, null, 2));
+    } catch (e) {
+        console.warn('prepareDiscoveryContext: failed to write ' + COMMENTS_FILE_NAME + '.json:', e);
+    }
+    try {
+        var lines = ['# Inline comments on discovery pages\n'];
+        if (!comments || comments.length === 0) {
+            lines.push('\n_No inline comments found._');
+        } else {
+            lines.push('\nTotal comments: ' + comments.length + '\n');
+            for (var i = 0; i < comments.length; i++) {
+                var c = comments[i];
+                lines.push('## Comment ' + (c.commentId || 'unknown') + ' on page "' + (c.pageTitle || 'untitled') + '" (pageId: ' + (c.pageId || 'unknown') + ')');
+                lines.push('- **Author:** ' + (c.author || 'Unknown'));
+                lines.push('- **Created:** ' + (c.created || ''));
+                lines.push('- **Resolved:** ' + (c.resolved ? 'yes' : 'no'));
+                if (c.parentCommentId) lines.push('- **Parent comment:** ' + c.parentCommentId);
+                lines.push('\n' + (c.body || ''));
+                lines.push('\n---\n');
+            }
+        }
+        file_write(folder + '/' + COMMENTS_FILE_NAME + '.md', lines.join('\n'));
+    } catch (e) {
+        console.warn('prepareDiscoveryContext: failed to write ' + COMMENTS_FILE_NAME + '.md:', e);
+    }
 }
 
 /**
@@ -67,16 +168,22 @@ function findTicketPage(children, ticketKey) {
  *     index.md into (its children go into named subfolders/files here)
  * @returns {number} total number of descendant pages snapshotted (all depths)
  */
-function snapshotPageTree(page, targetDir) {
+function snapshotPageTree(page, targetDir, pageInfos) {
     var total = 0;
     try {
         var rootMd = confluence_content_by_id({ contentId: page.id, format: 'md' });
         var rootBody = (rootMd && rootMd.body && rootMd.body.storage && rootMd.body.storage.value) || '';
         file_write(targetDir + '/index.md', rootBody || '_(existing page had no body)_');
+        if (pageInfos) {
+            pageInfos.push({ id: page.id, title: page.title || 'untitled' });
+        }
 
         var children = confluence_get_children_by_id({ contentId: page.id, format: 'md' }) || [];
         children.forEach(function(child) {
             total += 1;
+            if (pageInfos) {
+                pageInfos.push({ id: child.id, title: child.title || 'untitled' });
+            }
             var fileName = sanitizeFileName(child.title);
 
             var grandchildren;
@@ -90,7 +197,7 @@ function snapshotPageTree(page, targetDir) {
                 // This child has its own descendants — recurse into a subfolder
                 // named after it, matching the sync tool's folder-with-index.md
                 // convention for a page that itself has children.
-                total += snapshotPageTree(child, targetDir + '/' + fileName);
+                total += snapshotPageTree(child, targetDir + '/' + fileName, pageInfos);
             } else {
                 // Leaf page — a single Markdown file is enough.
                 var childBody = (child.body && child.body.storage && child.body.storage.value) || '';
@@ -118,7 +225,10 @@ function action(params) {
 
     try {
         var projectConfig = configLoader.loadProjectConfig(params.jobParams || params);
-        var discoveryConfig = projectConfig.discovery || {};
+        var discoveryConfig = mergeObjects(
+            projectConfig.discovery || {},
+            (projectConfig.customParams && projectConfig.customParams.discovery) || {}
+        );
         meta.space = discoveryConfig.space || null;
         meta.parentPageId = discoveryConfig.parentPageId || null;
 
@@ -145,11 +255,21 @@ function action(params) {
         }
 
         meta.existingPageId = existing.id;
-        console.log('Found existing discovery page for ' + ticketKey + ': ' + existing.id + ' ("' + existing.title + '") — seeding ' + DISCOVERY_OUTPUT_DIR + ' with its current content (full tree, recursively) for in-place editing.');
-        var snapshotted = snapshotPageTree(existing, DISCOVERY_OUTPUT_DIR);
+        var includeComments = discoveryConfig.includeConfluenceComments !== false;
+        console.log('Found existing discovery page for ' + ticketKey + ': ' + existing.id + ' ("' + existing.title + '") — seeding ' + DISCOVERY_OUTPUT_DIR + ' with its current content (full tree, recursively) for in-place editing. Inline comments enabled: ' + includeComments);
+        var pageInfos = [];
+        var snapshotted = snapshotPageTree(existing, DISCOVERY_OUTPUT_DIR, pageInfos);
+
+        if (includeComments && pageInfos.length > 0) {
+            var comments = fetchInlineComments(pageInfos, folder);
+            writeCommentsFiles(folder, comments);
+            meta.inlineCommentsCount = comments.length;
+            console.log('Collected ' + comments.length + ' inline comment(s) from ' + pageInfos.length + ' page(s)');
+        }
+
         file_write(folder + '/discovery_meta.json', JSON.stringify(meta, null, 2));
 
-        return { success: true, action: 'iteration', ticketKey: ticketKey, existingPageId: existing.id, snapshottedPages: snapshotted };
+        return { success: true, action: 'iteration', ticketKey: ticketKey, existingPageId: existing.id, snapshottedPages: snapshotted, inlineCommentsCount: meta.inlineCommentsCount || 0 };
     } catch (error) {
         console.error('Error in prepareDiscoveryContext:', error);
         try {
@@ -162,5 +282,16 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, findTicketPage, sanitizeFileName, snapshotPageTree, DISCOVERY_OUTPUT_DIR };
+    module.exports = {
+        action,
+        findTicketPage,
+        sanitizeFileName,
+        snapshotPageTree,
+        fetchInlineComments,
+        writeCommentsFiles,
+        extractCommentBody,
+        DISCOVERY_OUTPUT_DIR,
+        COMMENTS_FILE_NAME,
+        DEFAULT_COMMENTS_LIMIT
+    };
 }

--- a/js/publishDiscoveryToConfluence.js
+++ b/js/publishDiscoveryToConfluence.js
@@ -24,6 +24,7 @@ var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 
 var DISCOVERY_OUTPUT_DIR = 'outputs/discovery';
+var REPLIES_FILE_PATH = 'outputs/discovery_replies.json';
 
 function findTicketPage(children, ticketKey) {
     if (!children || !Array.isArray(children)) return null;
@@ -63,6 +64,55 @@ function resolvePageUrl(page) {
         console.warn('resolvePageUrl: follow-up confluence_content_by_id lookup failed:', e);
         return null;
     }
+}
+
+/**
+ * Read the optional discovery replies file produced by the CLI agent.
+ * Expected shape: an array of { pageId, commentId, body } objects, or an
+ * object with a `replies` array. Missing/invalid file → empty array.
+ */
+function readRepliesFile() {
+    try {
+        var raw = file_read(REPLIES_FILE_PATH);
+        if (!raw || raw.trim() === '') return [];
+        var parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) return parsed;
+        if (parsed && Array.isArray(parsed.replies)) return parsed.replies;
+        return [];
+    } catch (e) {
+        console.warn('publishDiscoveryToConfluence: could not read ' + REPLIES_FILE_PATH + ':', e);
+        return [];
+    }
+}
+
+/**
+ * Publish replies to Confluence inline comments. Errors are non-fatal.
+ */
+function publishCommentReplies(replies) {
+    var posted = 0;
+    var failed = 0;
+    if (!Array.isArray(replies) || replies.length === 0) return { posted: 0, failed: 0 };
+    for (var i = 0; i < replies.length; i++) {
+        var r = replies[i];
+        if (!r || !r.pageId || !r.commentId || !r.body) {
+            console.warn('publishDiscoveryToConfluence: skipping invalid reply entry', r);
+            failed += 1;
+            continue;
+        }
+        try {
+            confluence_reply_to_inline_comment({
+                pageId: String(r.pageId),
+                commentId: String(r.commentId),
+                body: String(r.body)
+            });
+            posted += 1;
+            console.log('Replied to inline comment ' + r.commentId + ' on page ' + r.pageId);
+        } catch (e) {
+            failed += 1;
+            console.warn('publishDiscoveryToConfluence: failed to reply to comment ' + r.commentId + ':', e);
+        }
+    }
+    return { posted: posted, failed: failed };
 }
 
 function action(params) {
@@ -143,9 +193,16 @@ function action(params) {
         var pageUrl = resolvePageUrl(page);
         var syncedCount = (syncSummary.syncedPages && syncSummary.syncedPages.length) || 0;
 
+        var replies = readRepliesFile();
+        var replyResult = publishCommentReplies(replies);
+
         var comment = 'h3. 📚 Discovery published to Confluence\n\n' +
             (pageUrl ? 'Page: ' + pageUrl + '\n\n' : '') +
             'Synced *' + syncedCount + '* page(s) from `' + DISCOVERY_OUTPUT_DIR + '`.';
+        if (replyResult.posted > 0 || replyResult.failed > 0) {
+            comment += '\n\nReplied to *' + replyResult.posted + '* inline comment(s)' +
+                (replyResult.failed > 0 ? ' (*' + replyResult.failed + '* failed)' : '') + '.';
+        }
         try {
             jira_post_comment({ key: ticketKey, comment: comment });
         } catch (commentError) {
@@ -165,7 +222,8 @@ function action(params) {
             ticketKey: ticketKey,
             pageId: page.id,
             pageUrl: pageUrl,
-            syncedPages: syncedCount
+            syncedPages: syncedCount,
+            replies: replyResult
         };
     } catch (error) {
         console.error('Error in publishDiscoveryToConfluence:', error);
@@ -182,5 +240,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, findTicketPage, buildPageUrl, resolvePageUrl };
+    module.exports = { action, findTicketPage, buildPageUrl, resolvePageUrl, readRepliesFile, publishCommentReplies };
 }

--- a/js/unit-tests/test_prepareDiscoveryContext.js
+++ b/js/unit-tests/test_prepareDiscoveryContext.js
@@ -6,6 +6,7 @@ function loadPrepareDiscoveryContext(mocks, discoveryConfig) {
     var defaults = {
         confluence_get_children_by_id: function() { return []; },
         confluence_content_by_id: function() { return { body: { storage: { value: '' } } }; },
+        confluence_get_page_inline_comments: function() { return JSON.stringify({ results: [] }); },
         file_write: function() {}
     };
 
@@ -176,6 +177,68 @@ suite('prepareDiscoveryContext', function() {
         assert.equal(result.success, false);
         assert.equal(result.action, 'children_lookup_failed');
         assert.contains(writes['input/PROJ-2/discovery_meta.json'], '"space": "DISC"');
+    });
+
+    test('iteration — collects inline comments and writes input/discovery_inline_comments files', function() {
+        var writes = {};
+        var commentCalls = [];
+        var mod = loadPrepareDiscoveryContext({
+            confluence_get_children_by_id: function(args) {
+                if (args.contentId === '123') {
+                    return [{ id: '456', title: 'PROJ-2 Some feature' }];
+                }
+                if (args.contentId === '456') {
+                    return [
+                        { id: '457', title: 'PRD' }
+                    ];
+                }
+                return [];
+            },
+            confluence_content_by_id: function(args) {
+                if (args.contentId === '456') return { body: { storage: { value: '# Index' } } };
+                return { body: { storage: { value: '' } } };
+            },
+            confluence_get_page_inline_comments: function(args) {
+                commentCalls.push(args);
+                if (args.pageId === '456') {
+                    return JSON.stringify({
+                        results: [
+                            { id: 'c1', author: { displayName: 'Alice' }, createdDate: '2026-08-01', body: { storage: { value: '<p>Clarify the goal.</p>' } } }
+                        ]
+                    });
+                }
+                return JSON.stringify({ results: [] });
+            },
+            file_write: function(p, c) { writes[p] = c; }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.action, 'iteration');
+        assert.equal(result.inlineCommentsCount, 1);
+        assert.equal(commentCalls.length, 2, 'should fetch comments for root and child');
+        assert.contains(writes['input/PROJ-2/discovery_inline_comments.json'], '"commentId": "c1"');
+        assert.contains(writes['input/PROJ-2/discovery_inline_comments.md'], 'Clarify the goal.');
+        assert.contains(writes['input/PROJ-2/discovery_inline_comments.md'], 'pageId: 456');
+    });
+
+    test('iteration — includeConfluenceComments=false skips inline comment fetch', function() {
+        var commentCalls = [];
+        var writes = {};
+        var mod = loadPrepareDiscoveryContext({
+            confluence_get_children_by_id: function(args) {
+                if (args.contentId === '123') return [{ id: '456', title: 'PROJ-2 Some feature' }];
+                return [];
+            },
+            confluence_get_page_inline_comments: function(args) { commentCalls.push(args); return JSON.stringify({ results: [] }); },
+            file_write: function(p, c) { writes[p] = c; }
+        }, { space: 'DISC', parentPageId: '123', includeConfluenceComments: false });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.action, 'iteration');
+        assert.equal(commentCalls.length, 0, 'should not fetch comments when disabled');
+        assert.equal(writes['input/PROJ-2/discovery_inline_comments.md'], undefined);
     });
 
 });

--- a/js/unit-tests/test_publishDiscoveryToConfluence.js
+++ b/js/unit-tests/test_publishDiscoveryToConfluence.js
@@ -9,6 +9,8 @@ function loadPublishDiscovery(mocks, discoveryConfig) {
         confluence_update_page: function(args) { return { id: args.contentId, title: args.title, _links: { webui: '/wiki/spaces/DISC/pages/1', base: 'https://confluence.example.com' } }; },
         confluence_content_by_id: function(args) { return { id: args.contentId, _links: { webui: '/wiki/spaces/DISC/pages/1', base: 'https://confluence.example.com' } }; },
         confluence_sync_markdown_directory: function() { return JSON.stringify({ syncedPages: ['index', 'prd'] }); },
+        confluence_reply_to_inline_comment: function(args) { return { id: 'reply-' + args.commentId }; },
+        file_read: function() { return ''; },
         jira_post_comment: function() {}
     };
 
@@ -203,6 +205,57 @@ suite('publishDiscoveryToConfluence', function() {
         assert.equal(result.action, 'error');
         assert.equal(comments.length, 1);
         assert.contains(comments[0].comment, 'publish failed');
+    });
+
+    test('publishes inline-comment replies from outputs/discovery_replies.json', function() {
+        var replies = [];
+        var comments = [];
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            },
+            file_read: function(path) {
+                if (path === 'outputs/discovery_replies.json') {
+                    return JSON.stringify([
+                        { pageId: '456', commentId: 'c1', body: 'Fixed in AS IS section.' },
+                        { pageId: '457', commentId: 'c2', body: 'Added to PRD.' }
+                    ]);
+                }
+                return '';
+            },
+            confluence_reply_to_inline_comment: function(args) { replies.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.success, true);
+        assert.equal(replies.length, 2);
+        assert.equal(replies[0].commentId, 'c1');
+        assert.equal(replies[1].pageId, '457');
+        assert.contains(comments[0].comment, 'Replied to *2* inline comment(s)');
+        assert.equal(result.replies.posted, 2);
+        assert.equal(result.replies.failed, 0);
+    });
+
+    test('missing or invalid replies file is ignored gracefully', function() {
+        var replies = [];
+        var comments = [];
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            },
+            file_read: function() { throw new Error('file not found'); },
+            confluence_reply_to_inline_comment: function(args) { replies.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.success, true);
+        assert.equal(replies.length, 0);
+        assert.equal(result.replies.posted, 0);
+        assert.notContains(comments[0].comment, 'inline comment');
     });
 
 });


### PR DESCRIPTION
Adds Confluence inline-comment support to the discovery agent:\n\n- Fetches comments for every existing discovery page and writes them to input/discovery_inline_comments.{json,md}.\n- CLI agent can now reply via outputs/discovery_replies.json.\n- Post-action publishes those replies via confluence_reply_to_inline_comment.\n- Flag includeConfluenceComments (default true) with backward compatibility.\n- Full unit-test coverage; all 692 agent tests pass.