### PR TITLE
feat(instructions): sibling-instance sweep for solution agents

### DIFF
--- a/instructions/common/investigate_before_solution.md
+++ b/instructions/common/investigate_before_solution.md
@@ -10,3 +10,5 @@ Use CodeGraph first for source-code investigation (`codegraph context "<solution
 Use `grep`, `find`, `cat`, or `sed` only after CodeGraph when you need literal text, file listing, or a specific file excerpt.
 
 Only propose new components or patterns when the existing codebase genuinely does not satisfy the requirement. Where existing code can be extended or reused, prefer that approach and justify the decision explicitly in the solution.
+
+**Sibling-instance sweep.** When the solution adds a new instance of an extensible category (a new enum value, type, step, processor, plugin, integration), pick the closest existing sibling and enumerate **all of its registration points** in the codebase: grep the sibling's identifier across source and configuration, then for every hit decide explicitly — reuse as-is / add a new entry / extend behavior. A solution that registers the new instance in fewer places than its sibling is incomplete; justify every omission in the solution text. The points this sweep exists to catch are exactly those the requirements text never mentions — discover them from the code, not from the ticket.


### PR DESCRIPTION
## Problem

Real-run feedback on a generated solution: when the solution added a new instance of an extensible category, the agent anchored on the requirements text and missed registration points the text never mentions. Reviewers had to enumerate them manually.

## Change

Adds a **sibling-instance sweep** paragraph to `instructions/common/investigate_before_solution.md`: when the solution introduces a new instance of an extensible category, the agent must grep the closest existing sibling's identifier across source and configuration, treat every hit as a registration point, and decide reuse / new entry / extend for each — with explicit justification for omissions. The points this sweep exists to catch are exactly those the requirements text never mentions; they must be discovered from the code, not from the ticket.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>