### PR TITLE
Genericize project- and company-specific references

### DIFF
--- a/createRepoTasks.json
+++ b/createRepoTasks.json
@@ -1,7 +1,7 @@
 {
   "name": "Teammate",
   "params": {
-    "inputJql": "key = GENSGENP-52851",
+    "inputJql": "key = PROJ-1",
     "skipAIProcessing": true,
     "postJSAction": "agents/js/createRepoTasks.js",
     "localExecution": true,

--- a/createRepoTasksMulti.json
+++ b/createRepoTasksMulti.json
@@ -1,7 +1,7 @@
 {
   "name": "Teammate",
   "params": {
-    "inputJql": "key = GENSGENP-52851",
+    "inputJql": "key = PROJ-1",
     "skipAIProcessing": true,
     "postJSAction": "agents/js/createRepoTasksMulti.js",
     "localExecution": true,

--- a/instructions/common/acceptance_criteria_quality.md
+++ b/instructions/common/acceptance_criteria_quality.md
@@ -1,33 +1,12 @@
 # Acceptance Criteria Quality Rules
 
+These rules define baseline quality expectations for any acceptance criteria
+output. Project-specific workflow rules (e.g. how to reference existing
+workflows, enumerate copied steps, or handle upstream workflow fields) belong
+in the consuming repository's `.dmtools/instructions/` and are injected via
+`cliPrompts` in `.dmtools/config.js`.
+
 ## Prohibited patterns
-
-### ❌ Never write "follows standard X behavior"
-Instead of writing "follows [Workflow X] behavior", "same as [Workflow X]",
-"behaves as in [Workflow X]", or "no [story-specific] changes", you MUST first
-search the codebase using codegraph_search or codegraph_explore for that
-reference workflow, read its implementation, and describe the actual behavior
-in detail: exact columns, validations, file names, transitions, and error
-messages. A single-sentence reference to another workflow is never acceptable
-as an AC — it is not testable and cannot be implemented or verified without
-additional research.
-
-This prohibition applies **even when the step is genuinely unchanged**.
-"Unchanged" is a conclusion you reach only *after* verification, never a
-shortcut that lets you skip it — an unverified claim of parity is exactly how
-real, undetected differences slip through review. Concretely:
-- Every sentence that asserts equivalence to another workflow/step MUST be
-  immediately followed by the itemized proof: the actual columns, validations,
-  transitions, or error messages you found, and the exact codegraph
-  symbol/file you found them in (e.g. `[Verified via codegraph:
-  WorkflowXStepHandler.java]`).
-- If you could not verify — the reference workflow is not in the searched
-  codebase, or you ran out of context — do NOT assert equivalence at all.
-  Add an explicit blocker instead: `*⚠ BLOCKER:* behavior of [Workflow X] step
-  [N] could not be verified against the codebase — AC cannot confirm parity.`
-- A bare label such as "Copied as-is from {source}" is only acceptable once
-  the itemized proof (or an explicit blocker) has already been given earlier
-  in the same AC item; it may never *replace* the proof.
 
 ### ❌ Never include generic UI/accessibility AC
 WCAG AA, contrast ratios, focus states, style guide compliance —
@@ -53,12 +32,6 @@ Instead, add an explicit blocker entry:
 `*⚠ BLOCKER:* [artifact name] is not accessible — AC for [scope] cannot be
 finalized without this material.`
 
-### ❌ Never use partial detail for copied workflow steps
-Either describe a workflow step fully (all columns, validations, transitions)
-or mark it explicitly as `[Copied as-is from {reference}]`.
-Partial detail — describing some sub-steps but skipping others — is
-indistinguishable from missing requirements and leads to implementation gaps.
-
 ### ❌ Never mix inconsistent structures for the same kind of list
 Pick one structure per repeating list (e.g. steps, requirements, criteria) and
 use it for every item in that list — do not alternate between a table and
@@ -73,27 +46,6 @@ when starting a genuinely new list — never renumber or duplicate a list that
 was already presented.
 
 ## Required patterns
-
-### ✅ Separate new behavior from existing behavior
-Every AC output must clearly distinguish:
-- *Existing behavior* — what the system already does today (validated against code)
-- *New behavior* — what changes with this story
-- *Copied as-is* — steps that are identical to an existing workflow (name the source)
-- *Changed behavior* — existing steps that are modified (show before → after)
-
-Do not mix old and new in the same AC item.
-
-### ✅ "Follows X workflow" → enumerate it
-When an AC references another workflow:
-- Find it in the codebase via codegraph
-- List the actual columns, validations, file names, transitions
-- Only omit details that are genuinely identical AND already
-  documented elsewhere in the same story
-
-### ✅ Always cover the "missing input" case
-For any field pre-filled from an upstream source:
-- Describe what happens when the upstream value is absent
-- Is the field then required? Optional? Blocked?
 
 ### ✅ Error messages must be verbatim
 Use exact UI text: Header, Message, and variable placeholders.

--- a/js/common/pullRequest.js
+++ b/js/common/pullRequest.js
@@ -41,7 +41,7 @@ function sanitizeCommitMessage(message) {
 
 function extractPrUrl(output, runCommand, branchName, workingDir) {
     var cleaned = cleanCommandOutput(output);
-    var urlMatch = cleaned.match(/https:\/\/(?:github\.com|[^/\s]*gitlab[^/\s]*|git\.epam\.com)\/[^\s]+/);
+    var urlMatch = cleaned.match(/https:\/\/(?:github\.com|[^/\s]*gitlab[^/\s]*|gitlab\.example\.com)\/[^\s]+/);
     if (urlMatch) return urlMatch[0];
 
     var prNumberMatch = cleaned.match(/#(\d+)/);

--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -1007,7 +1007,7 @@ function _detectRepoFromGitRemote(provider) {
             .filter(function(l) {
                 return l.indexOf('github.com') !== -1 ||
                     l.indexOf('gitlab') !== -1 ||
-                    l.indexOf('git.epam.com') !== -1 ||
+                    l.indexOf('gitlab.example.com') !== -1 ||
                     l.indexOf('dev.azure.com') !== -1 ||
                     l.indexOf('ssh.dev.azure.com') !== -1;
             })[0] || '';

--- a/js/unit-tests/integration_gitlab_scm_smoke.js
+++ b/js/unit-tests/integration_gitlab_scm_smoke.js
@@ -19,8 +19,8 @@ function sizeOf(value) {
 
 function action(params) {
     var p = params.jobParams || params || {};
-    var workspace = p.workspace || 'mobile';
-    var repository = p.repository || 'dmtools-epamsample';
+    var workspace = p.workspace || 'example-group';
+    var repository = p.repository || 'example-project';
     var pullRequestId = String(p.pullRequestId || '1');
     var workflowLimit = p.workflowLimit || 5;
 

--- a/js/unit-tests/run_integration_gitlab_scm_smoke.json
+++ b/js/unit-tests/run_integration_gitlab_scm_smoke.json
@@ -3,8 +3,8 @@
   "params": {
     "jsPath": "js/unit-tests/integration_gitlab_scm_smoke.js",
     "jobParams": {
-      "workspace": "mobile",
-      "repository": "dmtools-epamsample",
+      "workspace": "example-group",
+      "repository": "example-project",
       "pullRequestId": "1",
       "workflowLimit": 5
     }

--- a/js/unit-tests/test_autoStart.js
+++ b/js/unit-tests/test_autoStart.js
@@ -224,7 +224,7 @@ suite('triggerConfiguredWorkflowForTicket local-execution chaining', function() 
 
         var result = autoStart.triggerConfiguredWorkflowForTicket({
             ticketKey: 'SOHO-132',
-            config: { repository: { owner: 'EPAM-DarkFactory', repo: 'SH_ANDR_WIP' } },
+            config: { repository: { owner: 'example-org', repo: 'example-repo' } },
             customParams: { localTeammate: true },
             configFile: 'agents/pr_rework.json'
         });
@@ -262,7 +262,7 @@ suite('triggerConfiguredWorkflowForTicket local-execution chaining', function() 
 
         var result = autoStart.triggerConfiguredWorkflowForTicket({
             ticketKey: 'SOHO-132',
-            config: { repository: { owner: 'EPAM-DarkFactory', repo: 'SH_ANDR_WIP' } },
+            config: { repository: { owner: 'example-org', repo: 'example-repo' } },
             customParams: {},
             configFile: 'agents/pr_rework.json'
         });
@@ -288,7 +288,7 @@ suite('triggerConfiguredWorkflowForTicket local-execution chaining', function() 
 
         var result = autoStart.triggerConfiguredWorkflowForTicket({
             ticketKey: 'SOHO-132',
-            config: { repository: { owner: 'EPAM-DarkFactory', repo: 'SH_ANDR_WIP' } },
+            config: { repository: { owner: 'example-org', repo: 'example-repo' } },
             customParams: { localTeammate: true },
             configFile: 'agents/pr_rework.json'
         });
@@ -317,7 +317,7 @@ suite('triggerConfiguredWorkflowForTicket local-execution chaining', function() 
 
         var result = autoStart.triggerConfiguredWorkflowForTicket({
             ticketKey: 'SOHO-132',
-            config: { repository: { owner: 'EPAM-DarkFactory', repo: 'SH_ANDR_WIP' } },
+            config: { repository: { owner: 'example-org', repo: 'example-repo' } },
             customParams: { localTeammate: true },
             configFile: 'agents/pr_rework.json'
         });

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -446,7 +446,7 @@ suite('configLoader.loadProjectConfig', function() {
     // snapshotBranchResolverFnPath silently never fired in production: real
     // Teammate execution passes preJSAction/postJSAction params as sibling
     // top-level keys { jobParams, ticket, response } (see JavaScriptExecutor.
-    // withJobContext in dm.ai), but every call site read `params.jobParams ||
+    // withJobContext in the tracker), but every call site read `params.jobParams ||
     // params` to reach customParams/configPath, which discarded the sibling
     // `params.ticket`.
 

--- a/js/unit-tests/test_createRepoTasks.js
+++ b/js/unit-tests/test_createRepoTasks.js
@@ -4,7 +4,7 @@
 
 function makeModule(globals) {
     var defaultGlobals = {
-        java: { lang: { System: { getenv: function() { return 'https://jiraeu.epam.com'; } } } },
+        java: { lang: { System: { getenv: function() { return 'https://jira.example.com'; } } } },
         jira_get_ticket: function() { return { fields: {} }; },
         jira_search_by_jql: function() { return []; },
         jira_create_ticket_with_parent: function() { return '{"key":"PROJ-2"}'; },
@@ -74,7 +74,7 @@ suite('createRepoTasks — action', function() {
                 if (opts.key === 'PROJ-100') {
                     return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
-                return { fields: { summary: 'Build PacBio workflow' } };
+                return { fields: { summary: 'Build example workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function(opts) {
@@ -93,7 +93,7 @@ suite('createRepoTasks — action', function() {
         assert.equal(created[0].parentKey, 'PROJ-50', 'parent is story');
         assert.equal(created[0].issueType, 'Sub-task', 'issueType is Sub-task');
         assert.equal(created[0].summary.indexOf('[core-db]') === 0, true, 'summary starts with [repo]');
-        assert.equal(created[0].summary.indexOf('Build PacBio workflow') !== -1, true, 'parent summary in subtask summary');
+        assert.equal(created[0].summary.indexOf('Build example workflow') !== -1, true, 'parent summary in subtask summary');
         assert.equal(created[0].description.indexOf('core-db') !== -1, true, 'repo name in description');
         assert.equal(created[0].description.indexOf('PROJ-100') !== -1, true, 'SA ticket link in description');
         assert.equal(created[0].description.indexOf('PROJ-50') !== -1, true, 'parent link in description');
@@ -109,7 +109,7 @@ suite('createRepoTasks — action', function() {
                 if (opts.key === 'PROJ-100') {
                     return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
-                return { fields: { summary: 'Build PacBio workflow' } };
+                return { fields: { summary: 'Build example workflow' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function() {

--- a/js/unit-tests/test_createRepoTasksMulti.js
+++ b/js/unit-tests/test_createRepoTasksMulti.js
@@ -4,7 +4,7 @@
 
 function makeModule(globals) {
     var defaultGlobals = {
-        java: { lang: { System: { getenv: function() { return 'https://jiraeu.epam.com'; } } } },
+        java: { lang: { System: { getenv: function() { return 'https://jira.example.com'; } } } },
         jira_get_ticket: function() { return { fields: {} }; },
         jira_search_by_jql: function() { return []; },
         jira_create_ticket_with_parent: function() { return '{"key":"PROJ-2"}'; },
@@ -38,58 +38,58 @@ suite('createRepoTasksMulti — flattenTasks', function() {
     test('repo with tasks array produces one task per entry', function() {
         var mod = makeModule();
         var flat = mod.flattenTasks([{
-            name: 'gens-igt',
+            name: 'backend-service',
             tasks: [
                 { id: 'schema', title: 'Add schema migration', reason: 'r1' },
                 { id: 'processor', title: 'Implement processor', reason: 'r2', depends_on: ['schema'] }
             ]
         }]);
         assert.equal(flat.length, 2, 'two tasks');
-        assert.equal(flat[0].key, 'gens-igt:schema', 'first task key');
-        assert.equal(flat[1].key, 'gens-igt:processor', 'second task key');
-        assert.deepEqual(flat[1].depends_on, ['gens-igt:schema'], 'same-repo bare id resolved to qualified key');
+        assert.equal(flat[0].key, 'backend-service:schema', 'first task key');
+        assert.equal(flat[1].key, 'backend-service:processor', 'second task key');
+        assert.deepEqual(flat[1].depends_on, ['backend-service:schema'], 'same-repo bare id resolved to qualified key');
     });
 
     test('bare repo-name dependency expands to all of that repo\'s task keys', function() {
         var mod = makeModule();
         var flat = mod.flattenTasks([
             {
-                name: 'gens-igt',
+                name: 'backend-service',
                 tasks: [
                     { id: 'schema', title: 'Schema' },
                     { id: 'processor', title: 'Processor' }
                 ]
             },
             {
-                name: 'lims-ui',
-                depends_on: ['gens-igt']
+                name: 'frontend-app',
+                depends_on: ['backend-service']
             }
         ]);
-        var limsTask = flat.filter(function(t) { return t.repo === 'lims-ui'; })[0];
-        assert.equal(limsTask.depends_on.length, 2, 'depends on both gens-igt tasks');
-        assert.equal(limsTask.depends_on.indexOf('gens-igt:schema') !== -1, true, 'includes schema task');
-        assert.equal(limsTask.depends_on.indexOf('gens-igt:processor') !== -1, true, 'includes processor task');
+        var frontendTask = flat.filter(function(t) { return t.repo === 'frontend-app'; })[0];
+        assert.equal(frontendTask.depends_on.length, 2, 'depends on both backend-service tasks');
+        assert.equal(frontendTask.depends_on.indexOf('backend-service:schema') !== -1, true, 'includes schema task');
+        assert.equal(frontendTask.depends_on.indexOf('backend-service:processor') !== -1, true, 'includes processor task');
     });
 
     test('fully-qualified "repo:id" cross-repo dependency resolves to exact task', function() {
         var mod = makeModule();
         var flat = mod.flattenTasks([
             {
-                name: 'gens-igt',
+                name: 'backend-service',
                 tasks: [
                     { id: 'schema', title: 'Schema' },
                     { id: 'processor', title: 'Processor' }
                 ]
             },
             {
-                name: 'lims-ui',
+                name: 'frontend-app',
                 tasks: [
-                    { id: 'view', title: 'View', depends_on: ['gens-igt:processor'] }
+                    { id: 'view', title: 'View', depends_on: ['backend-service:processor'] }
                 ]
             }
         ]);
-        var viewTask = flat.filter(function(t) { return t.key === 'lims-ui:view'; })[0];
-        assert.deepEqual(viewTask.depends_on, ['gens-igt:processor'], 'exact cross-repo task dependency resolved');
+        var viewTask = flat.filter(function(t) { return t.key === 'frontend-app:view'; })[0];
+        assert.deepEqual(viewTask.depends_on, ['backend-service:processor'], 'exact cross-repo task dependency resolved');
     });
 
     test('unresolvable dependency reference is silently dropped, not fatal', function() {
@@ -109,7 +109,7 @@ suite('createRepoTasksMulti — topologicalSortTasks', function() {
     test('orders prerequisite tasks before dependents', function() {
         var mod = makeModule();
         var flat = mod.flattenTasks([{
-            name: 'gens-igt',
+            name: 'backend-service',
             tasks: [
                 { id: 'processor', title: 'Processor', depends_on: ['schema'] },
                 { id: 'schema', title: 'Schema' }
@@ -117,7 +117,7 @@ suite('createRepoTasksMulti — topologicalSortTasks', function() {
         }]);
         var sorted = mod.topologicalSortTasks(flat);
         var keys = sorted.map(function(t) { return t.key; });
-        assert.equal(keys.indexOf('gens-igt:schema') < keys.indexOf('gens-igt:processor'), true, 'schema before processor');
+        assert.equal(keys.indexOf('backend-service:schema') < keys.indexOf('backend-service:processor'), true, 'schema before processor');
     });
 });
 
@@ -146,7 +146,7 @@ suite('createRepoTasksMulti — parseAffectedRepos', function() {
 suite('createRepoTasksMulti — action', function() {
     var reposJson = JSON.stringify([
         {
-            name: 'gens-igt',
+            name: 'backend-service',
             reason: 'Schema + processor',
             tasks: [
                 { id: 'schema', title: 'Add schema migration', reason: 'Flyway migration' },
@@ -154,9 +154,9 @@ suite('createRepoTasksMulti — action', function() {
             ]
         },
         {
-            name: 'lims-ui',
+            name: 'frontend-app',
             reason: 'New view',
-            depends_on: ['gens-igt']
+            depends_on: ['backend-service']
         }
     ]);
     var description = 'Solution text\n\n{code:json|title=affected_repos}\n' + reposJson + '\n{code}\n\n----';
@@ -169,7 +169,7 @@ suite('createRepoTasksMulti — action', function() {
                 if (opts.key === 'PROJ-100') {
                     return { fields: { description: description, parent: { key: 'PROJ-50' } } };
                 }
-                return { fields: { summary: 'Build PacBio Seq Run Prep' } };
+                return { fields: { summary: 'Build example feature' } };
             },
             jira_search_by_jql: function() { return []; },
             jira_create_ticket_with_parent: function(opts) {
@@ -185,10 +185,10 @@ suite('createRepoTasksMulti — action', function() {
         var result = mod.action({ ticket: { key: 'PROJ-100' } });
 
         assert.equal(result.success, true, 'succeeds');
-        assert.equal(created.length, 3, 'three sub-tasks: schema, processor, lims-ui view');
-        assert.equal(created[0].summary, '[gens-igt] Add schema migration', 'first task summary');
-        assert.equal(created[1].summary, '[gens-igt] Implement processor', 'second task summary');
-        assert.equal(created[2].summary, '[lims-ui] New view', 'implicit single-task repo summary');
+        assert.equal(created.length, 3, 'three sub-tasks: schema, processor, frontend-app view');
+        assert.equal(created[0].summary, '[backend-service] Add schema migration', 'first task summary');
+        assert.equal(created[1].summary, '[backend-service] Implement processor', 'second task summary');
+        assert.equal(created[2].summary, '[frontend-app] New view', 'implicit single-task repo summary');
     });
 
     test('links cross-task dependencies (same repo and cross repo) and moves dependents to Blocked', function() {
@@ -214,9 +214,9 @@ suite('createRepoTasksMulti — action', function() {
 
         mod.action({ ticket: { key: 'PROJ-100' } });
 
-        // schema(301) blocks processor(302); both schema+processor block lims-ui view(303)
+        // schema(301) blocks processor(302); both schema+processor block frontend-app view(303)
         assert.equal(links.length, 3, 'three Blocks links (1 intra-repo + 2 cross-repo)');
-        assert.equal(moved.length, 2, 'processor and lims-ui view moved to Blocked');
+        assert.equal(moved.length, 2, 'processor and frontend-app view moved to Blocked');
     });
 
     test('repo entry without tasks array still creates exactly one Sub-task (backward compatible)', function() {
@@ -252,7 +252,7 @@ suite('createRepoTasksMulti — action', function() {
                 return { fields: { summary: 'Story' } };
             },
             jira_search_by_jql: function() {
-                return [{ fields: { summary: '[gens-igt] Add schema migration' } }]; // already exists
+                return [{ fields: { summary: '[backend-service] Add schema migration' } }]; // already exists
             },
             jira_create_ticket_with_parent: function(opts) {
                 ticketCounter++;

--- a/js/unit-tests/test_fetchParentContextToInput.js
+++ b/js/unit-tests/test_fetchParentContextToInput.js
@@ -351,7 +351,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]');
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]');
             },
             jira_search_by_jql: function() { return []; },
             file_write: function(p, c) { writtenFiles.push(p); }
@@ -372,7 +372,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]');
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]');
             },
             jira_search_by_jql: function() { return []; },
             file_write: function(p, c) { writtenFiles.push(p); }
@@ -386,7 +386,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]');
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]');
             },
             jira_search_by_jql: function() { return []; },
             file_write: function(p, c) { writtenFiles.push(p); }
@@ -406,7 +406,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenContents = {};
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]');
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]');
             },
             jira_search_by_jql: function() { return []; },
             file_write: function(p, c) { writtenContents[p] = c; }
@@ -432,7 +432,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenContents = {};
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]', {
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]', {
                     'Acceptance Criteria': 'AC 1 - User can login\nAC 2 - User can logout'
                 });
             },
@@ -469,7 +469,7 @@ suite('fetchParentContextToInput — parentAsContext', function() {
         var writtenFiles = [];
         var m = loadFetchParentContext({
             jira_get_ticket: function(opts) {
-                return makeParentTicket(opts.key || PARENT_KEY, '[LIMS]');
+                return makeParentTicket(opts.key || PARENT_KEY, '[EXAMPLE]');
             },
             jira_search_by_jql: function() {
                 return [makeSearchResult('PROJ-300', '[SA]')];

--- a/js/unit-tests/test_githubHelpers.js
+++ b/js/unit-tests/test_githubHelpers.js
@@ -236,18 +236,18 @@ suite('github repo remote parsing', function() {
     [
         {
             name: 'https URL with dotted repo',
-            remote: 'https://github.com/epam/dm.ai',
-            expected: { owner: 'epam', repo: 'dm.ai' }
+            remote: 'https://github.com/example-org/example.repo',
+            expected: { owner: 'example-org', repo: 'example.repo' }
         },
         {
             name: 'https URL with dotted repo and .git suffix',
-            remote: 'https://github.com/epam/dm.ai.git',
-            expected: { owner: 'epam', repo: 'dm.ai' }
+            remote: 'https://github.com/example-org/example.repo.git',
+            expected: { owner: 'example-org', repo: 'example.repo' }
         },
         {
             name: 'ssh URL with dotted repo and .git suffix',
-            remote: 'git@github.com:epam/dm.ai.git',
-            expected: { owner: 'epam', repo: 'dm.ai' }
+            remote: 'git@github.com:example-org/example.repo.git',
+            expected: { owner: 'example-org', repo: 'example.repo' }
         }
     ].forEach(function(tc) {
         test('githubHelpers.getGitHubRepoInfo parses ' + tc.name, function() {
@@ -265,7 +265,7 @@ suite('github repo remote parsing', function() {
         var calls = [];
         var scmModule = loadScm({
             cli_execute_command: function() {
-                return 'git@github.com:epam/dm.ai.git\nCOMMAND_EXIT_CODE=0';
+                return 'git@github.com:example-org/example.repo.git\nCOMMAND_EXIT_CODE=0';
             },
             github_list_prs: function(args) {
                 calls.push(args);
@@ -277,8 +277,8 @@ suite('github repo remote parsing', function() {
         scm.listPrs('open');
 
         assert.deepEqual(calls[0], {
-            workspace: 'epam',
-            repository: 'dm.ai',
+            workspace: 'example-org',
+            repository: 'example.repo',
             state: 'open'
         });
     });
@@ -463,7 +463,7 @@ suite('scm GitLab provider', function() {
         var calls = [];
         var scmModule = loadScm({
             cli_execute_command: function() {
-                return 'git@git.epam.com:mobile/dmtools-epamsample.git\nCOMMAND_EXIT_CODE=0';
+                return 'git@gitlab.example.com:example-group/example-project.git\nCOMMAND_EXIT_CODE=0';
             },
             gitlab_list_mrs: function(args) {
                 calls.push(args);
@@ -475,8 +475,8 @@ suite('scm GitLab provider', function() {
         scm.listPrs('open');
 
         assert.deepEqual(calls[0], {
-            workspace: 'mobile',
-            repository: 'dmtools-epamsample',
+            workspace: 'example-group',
+            repository: 'example-project',
             state: 'opened'
         });
     });
@@ -492,7 +492,7 @@ suite('scm GitLab provider', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
         var closed = provider.listPrs('closed');
 
         assert.equal(closed.length, 2);
@@ -507,14 +507,14 @@ suite('scm GitLab provider', function() {
                 call = args;
                 return JSON.stringify({
                     iid: 42,
-                    web_url: 'https://git.epam.com/mobile/dmtools-epamsample/-/merge_requests/42',
+                    web_url: 'https://gitlab.example.com/example-group/example-project/-/merge_requests/42',
                     source_branch: 'feature/ABC-1',
                     target_branch: 'main'
                 });
             }
         });
 
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
         var result = provider.createPr({
             title: 'ABC-1: change',
             branchName: 'feature/ABC-1',
@@ -524,8 +524,8 @@ suite('scm GitLab provider', function() {
         });
 
         assert.deepEqual(call, {
-            workspace: 'mobile',
-            repository: 'dmtools-epamsample',
+            workspace: 'example-group',
+            repository: 'example-project',
             sourceBranch: 'feature/ABC-1',
             targetBranch: 'main',
             title: 'ABC-1: change',
@@ -534,7 +534,7 @@ suite('scm GitLab provider', function() {
         });
         assert.equal(result.success, true);
         assert.equal(result.number, 42);
-        assert.equal(result.prUrl, 'https://git.epam.com/mobile/dmtools-epamsample/-/merge_requests/42');
+        assert.equal(result.prUrl, 'https://gitlab.example.com/example-group/example-project/-/merge_requests/42');
     });
 
     test('_normalizeGitLabCommitStatus maps GitLab commit statuses into check-run shape', function() {
@@ -566,7 +566,7 @@ suite('scm GitLab provider', function() {
                 calledArgs = args;
                 return JSON.stringify([
                     { name: 'sonar-tests/Merge requests check', status: 'failed', target_url: 'https://jenkins.ci.example.com/job/sonar-tests/job/Merge%20requests%20check/23681/' },
-                    { name: 'ai-teammate', status: 'success', target_url: 'https://git.epam.com/acme-org/ai-teammate/-/pipelines/1' }
+                    { name: 'ai-teammate', status: 'success', target_url: 'https://gitlab.example.com/acme-org/ai-teammate/-/pipelines/1' }
                 ]);
             }
         });
@@ -609,7 +609,7 @@ suite('scm GitLab provider', function() {
                 ]);
             }
         });
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
         var raw = provider.listWorkflowRuns('in_progress', null, 20);
         var parsed = JSON.parse(raw);
 
@@ -629,12 +629,12 @@ suite('scm GitLab provider', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
-        provider.updateBranch(55, 'mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
+        provider.updateBranch(55, 'example-group', 'example-project');
 
         assert.deepEqual(call, {
-            workspace: 'mobile',
-            repository: 'dmtools-epamsample',
+            workspace: 'example-group',
+            repository: 'example-project',
             pullRequestId: '55'
         });
     });
@@ -1046,7 +1046,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
                     check_runs: [{
                         name: 'Jenkins PR Build',
                         conclusion: 'failure',
-                        details_url: 'https://jenkins.example.com/job/epam/job/dm.ai/job/PR-123/45/'
+                        details_url: 'https://jenkins.example.com/job/example-org/job/example.repo/job/PR-123/45/'
                     }]
                 };
             },
@@ -1064,17 +1064,17 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
         });
 
         var failed = gh.detectFailedChecks(
-            'epam', 'dm.ai', 'abc123def', '/tmp/input',
+            'example-org', 'example.repo', 'abc123def', '/tmp/input',
             'https://jenkins.example.com/'
         );
 
         assert.equal(failed.length, 1, 'one failed check should be reported');
         assert.equal(failed[0].name, 'Jenkins PR Build');
         assert.equal(jenkinsInfoCalls.length, 1, 'jenkins_get_job_info should be called once');
-        assert.equal(jenkinsInfoCalls[0].jobPath, 'job/epam/job/dm.ai/job/PR-123');
+        assert.equal(jenkinsInfoCalls[0].jobPath, 'job/example-org/job/example.repo/job/PR-123');
         assert.equal(jenkinsInfoCalls[0].buildNumber, 45);
         assert.equal(jenkinsLogCalls.length, 1, 'jenkins_get_build_log should be called once');
-        assert.equal(jenkinsLogCalls[0].jobPath, 'job/epam/job/dm.ai/job/PR-123');
+        assert.equal(jenkinsLogCalls[0].jobPath, 'job/example-org/job/example.repo/job/PR-123');
         assert.equal(jenkinsLogCalls[0].buildNumber, 45);
 
         var mdWrite = findWrite(writes, '/tmp/input/ci_failures.md');
@@ -1104,7 +1104,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
                     check_runs: [{
                         name: 'Jenkins PR Build',
                         conclusion: 'failure',
-                        details_url: 'https://jenkins.example.com/job/epam/job/dm.ai/job/PR-123/45/'
+                        details_url: 'https://jenkins.example.com/job/example-org/job/example.repo/job/PR-123/45/'
                     }]
                 };
             },
@@ -1117,7 +1117,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
             }
         });
 
-        var failed = gh.detectFailedChecks('epam', 'dm.ai', 'abc123def', '/tmp/input');
+        var failed = gh.detectFailedChecks('example-org', 'example.repo', 'abc123def', '/tmp/input');
 
         assert.equal(failed.length, 1);
         assert.equal(jenkinsLogCalls.length, 0, 'jenkins log should not be fetched without base path');
@@ -1153,7 +1153,7 @@ suite('githubHelpers.detectFailedChecks — Jenkins failed checks', function() {
             }
         });
 
-        gh.detectFailedChecks('epam', 'dm.ai', 'abc123def', '/tmp/input', 'https://jenkins.example.com/');
+        gh.detectFailedChecks('example-org', 'example.repo', 'abc123def', '/tmp/input', 'https://jenkins.example.com/');
 
         assert.equal(jenkinsLogCalls.length, 0, 'different host should be ignored');
         var mdWrite = findWrite(writes, '/tmp/input/ci_failures.md');
@@ -1245,10 +1245,10 @@ suite('scm.getDiffText', function() {
             }
         });
 
-        var provider = scmModule._createGithubProvider('epam', 'dm.ai');
+        var provider = scmModule._createGithubProvider('example-org', 'example.repo');
         var diff = provider.getDiffText(42);
 
-        assert.deepEqual(call, { workspace: 'epam', repository: 'dm.ai', pullRequestID: '42' });
+        assert.deepEqual(call, { workspace: 'example-org', repository: 'example.repo', pullRequestID: '42' });
         assert.equal(diff, 'diff --git a/x b/x');
     });
 
@@ -1257,7 +1257,7 @@ suite('scm.getDiffText', function() {
             github_get_pr_diff_text: function() { throw new Error('IS_READ_PULL_REQUEST_DIFF disabled'); }
         });
 
-        var provider = scmModule._createGithubProvider('epam', 'dm.ai');
+        var provider = scmModule._createGithubProvider('example-org', 'example.repo');
         var diff = provider.getDiffText(42);
 
         assert.ok(diff === null, 'must gracefully return null on failure');
@@ -1272,10 +1272,10 @@ suite('scm.getDiffText', function() {
             }
         });
 
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
         var diff = provider.getDiffText(7);
 
-        assert.deepEqual(call, { workspace: 'mobile', repository: 'dmtools-epamsample', pullRequestId: '7' });
+        assert.deepEqual(call, { workspace: 'example-group', repository: 'example-project', pullRequestId: '7' });
         assert.equal(diff, 'diff --git a/x b/x');
     });
 
@@ -1284,7 +1284,7 @@ suite('scm.getDiffText', function() {
             gitlab_get_mr_diff_text: function() { throw new Error('boom'); }
         });
 
-        var provider = scmModule._createGitLabProvider('mobile', 'dmtools-epamsample');
+        var provider = scmModule._createGitLabProvider('example-group', 'example-project');
         var diff = provider.getDiffText(7);
 
         assert.ok(diff === null, 'must gracefully return null on failure');
@@ -1292,7 +1292,7 @@ suite('scm.getDiffText', function() {
 
     test('ADO provider always returns null (no raw diff-text API available)', function() {
         var scmModule = loadScm({});
-        var provider = scmModule._createAdoProvider('dmtools-epamsample');
+        var provider = scmModule._createAdoProvider('example-project');
 
         assert.ok(provider.getDiffText(7) === null);
     });

--- a/js/unit-tests/test_postTestAutomationResults.js
+++ b/js/unit-tests/test_postTestAutomationResults.js
@@ -83,7 +83,7 @@ suite('postTestAutomationResults: PR creation', function() {
                 if (command === 'git diff --cached --stat') return ' testing/tests/DMC-898/test_dmc_898.py | 1 +';
                 if (command.indexOf('git ls-remote --heads origin test/DMC-898') === 0) return 'abc\trefs/heads/test/DMC-898';
                 if (command.indexOf('gh pr list --head test/DMC-898') === 0) return '';
-                if (command.indexOf('gh pr create') === 0) return 'https://github.com/epam/dm.ai/pull/898';
+                if (command.indexOf('gh pr create') === 0) return 'https://github.com/example-org/example.repo/pull/898';
                 return '';
             }
         });
@@ -94,7 +94,7 @@ suite('postTestAutomationResults: PR creation', function() {
         });
 
         assert.equal(result.success, true);
-        assert.equal(result.prUrl, 'https://github.com/epam/dm.ai/pull/898');
+        assert.equal(result.prUrl, 'https://github.com/example-org/example.repo/pull/898');
         assert.ok(writtenFiles.length > 0, 'PR body written to temp file');
         assert.ok(commands.some(function(command) { return command.indexOf('gh pr create') === 0; }), 'gh pr create called');
         assert.notOk(commands.some(function(command) { return command === 'pwd'; }), 'pwd command not used');
@@ -132,8 +132,8 @@ suite('postTestAutomationResults: PR creation', function() {
                 if (command === 'git diff --cached --stat') return ' testing/tests/DMC-909/test_dmc_909.py | 1 +';
                 if (command.indexOf('git ls-remote --heads origin test/DMC-909') === 0) return 'abc\trefs/heads/test/DMC-909';
                 if (command.indexOf('gh pr list --head test/DMC-909') === 0) return '';
-                if (command.indexOf('gh pr create') === 0) return 'https://github.com/epam/dm.ai/pull/909';
-                if (command.indexOf('gh pr view https://github.com/epam/dm.ai/pull/909 --json mergeable') === 0) {
+                if (command.indexOf('gh pr create') === 0) return 'https://github.com/example-org/example.repo/pull/909';
+                if (command.indexOf('gh pr view https://github.com/example-org/example.repo/pull/909 --json mergeable') === 0) {
                     return '{"mergeable":"CONFLICTING"}';
                 }
                 return '';
@@ -149,12 +149,12 @@ suite('postTestAutomationResults: PR creation', function() {
         assert.equal(result.success, true);
         assert.equal(result.status, 'blocked_by_human');
         assert.equal(result.blockedReason, 'pr_conflicts_with_main');
-        assert.equal(result.prUrl, 'https://github.com/epam/dm.ai/pull/909');
+        assert.equal(result.prUrl, 'https://github.com/example-org/example.repo/pull/909');
         assert.ok(statuses.indexOf('Blocked') !== -1, 'moved ticket to Blocked');
         assert.ok(removedLabels.indexOf('sm_test_automation_triggered') !== -1, 'removed SM trigger label');
         assert.ok(removedLabels.indexOf('test_case_automation_wip') !== -1, 'removed WIP label');
         assert.ok(commands.some(function(command) {
-            return command.indexOf('gh pr view https://github.com/epam/dm.ai/pull/909 --json mergeable') === 0;
+            return command.indexOf('gh pr view https://github.com/example-org/example.repo/pull/909 --json mergeable') === 0;
         }), 'checked PR mergeability');
         assert.equal(comments.length, 1);
         assert.contains(comments[0], 'PR Conflicts With Main');

--- a/js/unit-tests/test_pullRequestHelper.js
+++ b/js/unit-tests/test_pullRequestHelper.js
@@ -112,7 +112,7 @@ suite('pullRequest helper', function() {
             bodyContent: 'body',
             runCommand: function(command) {
                 if (command.indexOf('gh pr list --head feature/DMC-3') === 0) return '';
-                if (command === 'git config --get remote.origin.url') return 'git@github.com:epam/dm.ai.git';
+                if (command === 'git config --get remote.origin.url') return 'git@github.com:example-org/example.repo.git';
                 if (command.indexOf('gh pr create') === 0) return 'Created pull request #789';
                 return '';
             },
@@ -120,7 +120,7 @@ suite('pullRequest helper', function() {
         });
 
         assert.equal(result.success, true);
-        assert.equal(result.prUrl, 'https://github.com/epam/dm.ai/pull/789');
+        assert.equal(result.prUrl, 'https://github.com/example-org/example.repo/pull/789');
     });
 
     test('syncs branch with base before publishing when behind', function() {

--- a/scripts/create_test_commit.sh
+++ b/scripts/create_test_commit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # create_test_commit.sh
-# Used by story_development_dynamic_repo_test / gens-igt/story_development_test agents.
+# Used by story_development_dynamic_repo_test agents.
 #
 # Reads the target working directory from .dmtools-target-workingdir written by
 # preCliDevelopmentSetupDynamicRepo.js (which parses [repo] from the ticket summary).

--- a/scripts/install_global_maven_settings.sh
+++ b/scripts/install_global_maven_settings.sh
@@ -22,12 +22,12 @@
 # Usage:
 #   bash install_global_maven_settings.sh <path-to-settings.xml-relative-to-cwd>
 #
-# Example (matches the gens-igt quality gate config, run with workingDir "."
-# from ai-teammate root, after the target repo has already been checked out):
-#   bash agents/scripts/install_global_maven_settings.sh dependencies/gens-igt/mvn/settings.xml
+# Example (run with workingDir "." from ai-teammate root, after the target repo
+# has already been checked out):
+#   bash agents/scripts/install_global_maven_settings.sh dependencies/my-product/mvn/settings.xml
 set -euo pipefail
 
-SOURCE_SETTINGS="${1:?path to settings.xml required, e.g. dependencies/gens-igt/mvn/settings.xml}"
+SOURCE_SETTINGS="${1:?path to settings.xml required, e.g. dependencies/my-product/mvn/settings.xml}"
 
 if [ ! -f "${SOURCE_SETTINGS}" ]; then
   echo "install_global_maven_settings: source file not found: ${SOURCE_SETTINGS} — skipping"

--- a/scripts/warmup-session.sh
+++ b/scripts/warmup-session.sh
@@ -23,12 +23,12 @@
 #     [--exclude "tool1 tool2 ..."] [--install-args "extra args for install.sh"]
 #
 # Examples:
-#   warmup-session.sh --repo https://github.com/EPAM-DarkFactory/SH_ANDR_WIP.git \
-#     --dir SH_ANDR_WIP --branch master --exclude "cursor codemie kimi maestro playwright"
+#   warmup-session.sh --repo https://github.com/example-org/example-repo.git \
+#     --dir example-repo --branch main --exclude "cursor codemie kimi maestro playwright"
 #
 #   # Re-run against an already-cloned dir (updates + re-installs, idempotent)
-#   warmup-session.sh --repo https://github.com/EPAM-DarkFactory/SH_ANDR_WIP.git \
-#     --dir SH_ANDR_WIP --branch master
+#   warmup-session.sh --repo https://github.com/example-org/example-repo.git \
+#     --dir example-repo --branch main
 set -euo pipefail
 
 REPO_URL=""

--- a/setup/checkout.sh
+++ b/setup/checkout.sh
@@ -44,9 +44,9 @@
 #         },
 #         {
 #           "provider": "gitlab",
-#           "repo": "dmtools-epamsample",
-#           "gitlabGroup": "mobile",
-#           "gitlabHost": "git.epam.com",
+#           "repo": "example-project",
+#           "gitlabGroup": "example-group",
+#           "gitlabHost": "gitlab.example.com",
 #           "branch": "main",
 #           "envVar": "GITLAB_REPO_DIR"
 #         }

--- a/setup/dmtools.sh
+++ b/setup/dmtools.sh
@@ -2,11 +2,12 @@
 # Install DMtools CLI from epam/dm.ai.
 #
 # Usage:
-#   dmtools.sh [version]                # positional arg
-#   DMTOOLS_VERSION=v1.7.195 dmtools.sh # env override
+#   dmtools.sh [version]                  # positional arg
+#   DMTOOLS_VERSION=v1.7.195 dmtools.sh   # version env override
+#   DMTOOLS_INSTALL_REPO=owner/repo       # install source repo override
 #
 # Version examples: v1.7.195 (default)
-# Install source: https://raw.githubusercontent.com/epam/dm.ai/main/install
+# Install source: https://raw.githubusercontent.com/{DMTOOLS_INSTALL_REPO}/main/install
 # Cache path: ~/.dmtools
 set -eu
 
@@ -14,6 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_common.sh"
 
 DMTOOLS_VERSION="${1:-${DMTOOLS_VERSION:-v1.7.232}}"
+DMTOOLS_INSTALL_REPO="${DMTOOLS_INSTALL_REPO:-epam/dm.ai}"
 DMTOOLS_HOME="${HOME}/.dmtools"
 DMTOOLS_BIN="${DMTOOLS_HOME}/bin"
 
@@ -45,7 +47,7 @@ fi
 
 # ── Install ───────────────────────────────────────────────────────────────────
 echo "📥 Installing DMtools ${DMTOOLS_VERSION}..."
-curl -fsSL "https://raw.githubusercontent.com/epam/dm.ai/${DMTOOLS_VERSION}/install.sh" \
+curl -fsSL "https://raw.githubusercontent.com/${DMTOOLS_INSTALL_REPO}/${DMTOOLS_VERSION}/install.sh" \
   | DMTOOLS_VERSION="${DMTOOLS_VERSION}" bash -s -- "${DMTOOLS_VERSION}"
 
 register_path "${DMTOOLS_BIN}"

--- a/snapshots/story_acceptance_criteria.md
+++ b/snapshots/story_acceptance_criteria.md
@@ -211,34 +211,13 @@ flowchart TD
 
 # Acceptance Criteria Quality Rules
 
+These rules define baseline quality expectations for any acceptance criteria
+output. Project-specific workflow rules (e.g. how to reference existing
+workflows, enumerate copied steps, or handle upstream workflow fields) belong
+in the consuming repository's `.dmtools/instructions/` and are injected via
+`cliPrompts` in `.dmtools/config.js`.
+
 ## Prohibited patterns
-
-### ❌ Never write "follows standard X behavior"
-Instead of writing "follows [Workflow X] behavior", "same as [Workflow X]",
-"behaves as in [Workflow X]", or "no [story-specific] changes", you MUST first
-search the codebase using codegraph_search or codegraph_explore for that
-reference workflow, read its implementation, and describe the actual behavior
-in detail: exact columns, validations, file names, transitions, and error
-messages. A single-sentence reference to another workflow is never acceptable
-as an AC — it is not testable and cannot be implemented or verified without
-additional research.
-
-This prohibition applies **even when the step is genuinely unchanged**.
-"Unchanged" is a conclusion you reach only *after* verification, never a
-shortcut that lets you skip it — an unverified claim of parity is exactly how
-real, undetected differences slip through review. Concretely:
-- Every sentence that asserts equivalence to another workflow/step MUST be
-  immediately followed by the itemized proof: the actual columns, validations,
-  transitions, or error messages you found, and the exact codegraph
-  symbol/file you found them in (e.g. `[Verified via codegraph:
-  WorkflowXStepHandler.java]`).
-- If you could not verify — the reference workflow is not in the searched
-  codebase, or you ran out of context — do NOT assert equivalence at all.
-  Add an explicit blocker instead: `*⚠ BLOCKER:* behavior of [Workflow X] step
-  [N] could not be verified against the codebase — AC cannot confirm parity.`
-- A bare label such as "Copied as-is from {source}" is only acceptable once
-  the itemized proof (or an explicit blocker) has already been given earlier
-  in the same AC item; it may never *replace* the proof.
 
 ### ❌ Never include generic UI/accessibility AC
 WCAG AA, contrast ratios, focus states, style guide compliance —
@@ -264,12 +243,6 @@ Instead, add an explicit blocker entry:
 `*⚠ BLOCKER:* [artifact name] is not accessible — AC for [scope] cannot be
 finalized without this material.`
 
-### ❌ Never use partial detail for copied workflow steps
-Either describe a workflow step fully (all columns, validations, transitions)
-or mark it explicitly as `[Copied as-is from {reference}]`.
-Partial detail — describing some sub-steps but skipping others — is
-indistinguishable from missing requirements and leads to implementation gaps.
-
 ### ❌ Never mix inconsistent structures for the same kind of list
 Pick one structure per repeating list (e.g. steps, requirements, criteria) and
 use it for every item in that list — do not alternate between a table and
@@ -284,27 +257,6 @@ when starting a genuinely new list — never renumber or duplicate a list that
 was already presented.
 
 ## Required patterns
-
-### ✅ Separate new behavior from existing behavior
-Every AC output must clearly distinguish:
-- *Existing behavior* — what the system already does today (validated against code)
-- *New behavior* — what changes with this story
-- *Copied as-is* — steps that are identical to an existing workflow (name the source)
-- *Changed behavior* — existing steps that are modified (show before → after)
-
-Do not mix old and new in the same AC item.
-
-### ✅ "Follows X workflow" → enumerate it
-When an AC references another workflow:
-- Find it in the codebase via codegraph
-- List the actual columns, validations, file names, transitions
-- Only omit details that are genuinely identical AND already
-  documented elsewhere in the same story
-
-### ✅ Always cover the "missing input" case
-For any field pre-filled from an upstream source:
-- Describe what happens when the upstream value is absent
-- Is the field then required? Optional? Blocked?
 
 ### ✅ Error messages must be verbatim
 Use exact UI text: Header, Message, and variable placeholders.


### PR DESCRIPTION
Replaces Genssup/EPAM-specific examples and hardcoded hosts in the generic agents repo with project-agnostic placeholders.

Summary of changes:
- Removed gens-sup workflow-specific acceptance-criteria rules from the generic instruction.
- Replaced project/repo names (gens-igt, lims-ui, PacBio, EPAM-DarkFactory/SH_ANDR_WIP, dmtools-epamsample) and hosts (git.epam.com, jiraeu.epam.com) with generic placeholders in scripts, setup docs, common JS, and unit tests.
- Added DMTOOLS_INSTALL_REPO env override to setup/dmtools.sh.
- Regenerated acceptance-criteria snapshot.

All unit tests pass: 791 passed, 0 failed.