### PR TITLE
chore(setup): bump default DMtools version to v1.7.246

### DIFF
--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -24,7 +24,7 @@ OS_TAG="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
 # ── Per-tool cache definitions ────────────────────────────────────────────────
 
 _cache_dmtools() {
-  local version="${1:-${DMTOOLS_VERSION:-v1.7.232}}"
+  local version="${1:-${DMTOOLS_VERSION:-v1.7.246}}"
   export_var "DMTOOLS_CACHE_PATH" "${HOME}/.dmtools"
   export_var "DMTOOLS_CACHE_KEY"  "dmtools-${version}-${OS_TAG}"
   # Restore key uses only the minor version prefix (e.g. v1.7.) so cache
@@ -195,7 +195,7 @@ _print_info() {
   echo "┌─────────────┬──────────────────────────────────┬────────────────────────────────────────────────┐"
   printf "│ %-11s │ %-32s │ %-46s │\n" "Tool" "Cache Path" "Cache Key (example)"
   echo "├─────────────┼──────────────────────────────────┼────────────────────────────────────────────────┤"
-  printf "│ %-11s │ %-32s │ %-46s │\n" "dmtools"  "~/.dmtools"     "dmtools-v1.7.232-darwin-arm64"
+  printf "│ %-11s │ %-32s │ %-46s │\n" "dmtools"  "~/.dmtools"     "dmtools-v1.7.246-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "java"     "~/.sdkman/... " "java-17-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "node"     "~/.nvm"         "nvm-node20-darwin-arm64"
   printf "│ %-11s │ %-32s │ %-46s │\n" "maestro"  "~/.maestro"     "maestro-latest-darwin-arm64"

--- a/setup/dmtools.sh
+++ b/setup/dmtools.sh
@@ -14,7 +14,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_common.sh"
 
-DMTOOLS_VERSION="${1:-${DMTOOLS_VERSION:-v1.7.232}}"
+DMTOOLS_VERSION="${1:-${DMTOOLS_VERSION:-v1.7.246}}"
 DMTOOLS_INSTALL_REPO="${DMTOOLS_INSTALL_REPO:-epam/dm.ai}"
 DMTOOLS_HOME="${HOME}/.dmtools"
 DMTOOLS_BIN="${DMTOOLS_HOME}/bin"

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -28,7 +28,7 @@ if [ $# -eq 0 ]; then
   echo "  java      — Java (Temurin/OpenJDK). Default version: 17"
   echo "  maven     — Apache Maven.            Default version: 3.9.9"
   echo "  node      — Node.js via nvm.         Default version: 20"
-  echo "  dmtools   — DMtools CLI.             Default version: v1.7.232"
+  echo "  dmtools   — DMtools CLI.             Default version: v1.7.246"
   echo "  maestro   — Maestro mobile testing.  Default version: latest"
   echo "  copilot   — @github/copilot npm CLI. Default version: latest  (needs node)"
   echo "  codemie   — codemie-claude CLI.      Default version: latest"


### PR DESCRIPTION
Bumps the DMtools CLI default version pin from v1.7.232 to v1.7.246 in the setup scripts (`setup/install.sh`, `setup/dmtools.sh`, `setup/cache.sh`). Pure version bump, no behavior change.