### PR TITLE
feat(contentOutput): author Confluence-targeted content in Markdown via 'confluence' tracker prompts

### DIFF
--- a/docs/agents/generated/story_acceptance_criteria.md
+++ b/docs/agents/generated/story_acceptance_criteria.md
@@ -21,6 +21,14 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
 
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
+
 _Human doc: [`agents/docs/agents/story_acceptance_criteria.md`](agents/docs/agents/story_acceptance_criteria.md)_
 
 ## Attributes

--- a/docs/agents/generated/story_acceptance_criterias.md
+++ b/docs/agents/generated/story_acceptance_criterias.md
@@ -21,6 +21,14 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
 
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
+
 _Human doc: [`agents/docs/agents/story_acceptance_criterias.md`](agents/docs/agents/story_acceptance_criterias.md)_
 
 ## Attributes

--- a/docs/agents/generated/story_description.md
+++ b/docs/agents/generated/story_description.md
@@ -19,6 +19,14 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.pageTitleSuffix` — appended to the page title.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
+
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
 - `contentOutput.assignForReview` — assign the ticket back to the initiator and move it to the review status after writing. Default: `true`.
 
 _Human doc: [`agents/docs/agents/story_description.md`](agents/docs/agents/story_description.md)_

--- a/docs/agents/generated/story_solution.md
+++ b/docs/agents/generated/story_solution.md
@@ -24,6 +24,14 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments into the input folder before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the solution field. Default: `true`.
 
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
+
 > **Downstream consumers:** other agents in the pipeline (for example the
 > affected-repos / task-splitting flows that parse the Solution field) read the
 > tracker field, not Confluence. When such a consumer exists, use

--- a/docs/agents/story_acceptance_criteria.md
+++ b/docs/agents/story_acceptance_criteria.md
@@ -20,3 +20,11 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.pageTitleSuffix` — appended to the page title.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
+
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.

--- a/docs/agents/story_acceptance_criterias.md
+++ b/docs/agents/story_acceptance_criterias.md
@@ -20,3 +20,11 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.pageTitleSuffix` — appended to the page title.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
+
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.

--- a/docs/agents/story_description.md
+++ b/docs/agents/story_description.md
@@ -19,4 +19,12 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.pageTitleSuffix` — appended to the page title.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the tracker field. Default: `true`.
+
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
 - `contentOutput.assignForReview` — assign the ticket back to the initiator and move it to the review status after writing. Default: `true`.

--- a/docs/agents/story_solution.md
+++ b/docs/agents/story_solution.md
@@ -24,6 +24,14 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `contentOutput.includeInlineComments` — fetch the page's inline comments into the input folder before the run and publish `outputs/confluence_replies.json` after it. Default: `true`.
 - `contentOutput.updateTrackerField` — for `target: confluence`, also write the page link into the solution field. Default: `true`.
 
+**Markup for Confluence targets.** With `target: confluence` the tracker-specific CLI
+prompts are selected by the `confluence` key of `cliPromptsByTracker` (see
+`instructions/tracker/confluence_markup_transform.md`) instead of the configured default
+tracker, so the agent authors Markdown that the Confluence sync can render. This selection
+happens in `buildEncodedConfig.js` for encoded-config runs and in the dmtools CLI
+(`CliCommandBuilder`) for direct `dmtools run` invocations. With `target: both` the tracker
+markup is kept because the tracker field still receives the full content.
+
 > **Downstream consumers:** other agents in the pipeline (for example the
 > affected-repos / task-splitting flows that parse the Solution field) read the
 > tracker field, not Confluence. When such a consumer exists, use

--- a/instructions/tracker/confluence_markup_transform.md
+++ b/instructions/tracker/confluence_markup_transform.md
@@ -1,0 +1,31 @@
+# Confluence Markup Reference
+
+When the generated content is published to Confluence (contentOutput target `confluence`), the body is synced as **Markdown** and converted to Confluence storage format automatically. Replace every generic placeholder tag from the template with the GitHub-flavored Markdown shown below. Do not write literal XML-style tags in the final output.
+
+| Generic placeholder | Markdown | Example |
+|---------------------|----------|---------|
+| `<bold>X</bold>` | `**X**` | `**Background:**` |
+| `<italic>X</italic>` | `*X*` | `*hint*` |
+| `<strike>X</strike>` | `~~X~~` | `~~deprecated~~` |
+| `<underline>X</underline>` | `<u>X</u>` | `<u>important</u>` |
+| `<code>X</code>` | `` `X` `` | `` `main.dart` `` |
+| `<codeblock>X</codeblock>` | ` ```\nX\n``` ` | ` ```\nvoid main() {}\n``` ` |
+| `<codeblock:lang>X</codeblock:lang>` | ` ```lang\nX\n``` ` | ` ```dart\nvoid main() {}\n``` ` |
+| `<bullet> text` | `- text` | `- Option A` |
+| `<numbered> text` | `1. text` | `1. Step one` |
+| `<heading1>X</heading1>` | `# X` | `# Title` |
+| `<heading2>X</heading2>` | `## X` | `## Section` |
+| `<heading3>X</heading3>` | `### X` | `### Subsection` |
+| `<link>text\|url</link>` | `[text](url)` | `[TS-24](https://tracker.example.com/browse/TS-24)` |
+| `<image>url</image>` | `![image](url)` | `![diagram](https://.../diagram.png)` |
+| `<quote>X</quote>` | `> X` | `> cited text` |
+| `<panel>X</panel>` | `> X` | `> note` |
+| `<color color="red">X</color>` | `<span style="color:red">X</span>` | `<span style="color:red">alert</span>` |
+| `<hr>` | `---` | `---` |
+
+## Rules
+
+- Replace every placeholder tag with the Markdown shown above.
+- Do NOT use tracker-specific wiki markup in Confluence output: no `h2.` headings, no `{code}...{code}` blocks, no `{{monospace}}`, no `[text|url]` links.
+- Use `- item` for bullets and `1. item` for numbered lists.
+- For Mermaid diagrams, wrap the diagram in a fenced code block with the `mermaid` language tag: ` ```mermaid\n...\n``` `.

--- a/js/common/buildEncodedConfig.js
+++ b/js/common/buildEncodedConfig.js
@@ -113,6 +113,49 @@ function resolveParentMerge(agentJson, agentPath, depth) {
 }
 
 /**
+ * Read contentOutput.target from a customParams object, if present.
+ */
+function readContentOutputTarget(customParams) {
+    if (customParams && customParams.contentOutput &&
+            typeof customParams.contentOutput.target === 'string') {
+        return customParams.contentOutput.target;
+    }
+    return null;
+}
+
+/**
+ * Resolve the 'confluence' tracker-prompt override for an agent.
+ *
+ * When the effective customParams (agent JSON customParams, overridable via the project
+ * config's jobParamPatches.<agent>.customParams) route generated content exclusively to
+ * Confluence (contentOutput.target === 'confluence'), tracker-specific CLI prompts must be
+ * selected by the 'confluence' key so the CLI agent authors Markdown instead of tracker
+ * markup (e.g. Jira wiki). Returns 'confluence' only when confluence tracker prompts are
+ * actually declared (agent JSON or project config); otherwise null — callers then keep the
+ * default tracker, matching the runtime fallback in CliCommandBuilder.
+ */
+function resolveConfluenceTrackerOverride(agentParamsRoot, effectiveConfig, agentName) {
+    var target = readContentOutputTarget(agentParamsRoot && agentParamsRoot.customParams);
+    var patchCustomParams = effectiveConfig && effectiveConfig.jobParamPatches &&
+        effectiveConfig.jobParamPatches[agentName] &&
+        effectiveConfig.jobParamPatches[agentName].customParams;
+    var patchedTarget = readContentOutputTarget(patchCustomParams);
+    if (patchedTarget) {
+        target = patchedTarget;
+    }
+    if (target !== 'confluence') {
+        return null;
+    }
+    var agentByTracker = agentParamsRoot && agentParamsRoot.cliPromptsByTracker;
+    var configByTracker = effectiveConfig && effectiveConfig.cliPromptsByTracker;
+    if ((agentByTracker && agentByTracker.confluence) ||
+            (configByTracker && configByTracker.confluence)) {
+        return 'confluence';
+    }
+    return null;
+}
+
+/**
  * Build the encoded config payload for a workflow dispatch.
  *
  * @param {string} ticketKey - Ticket key to process.
@@ -154,7 +197,11 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig, isLocal) {
         var agentJson = tryReadJson(agentJsonPath);
         if (agentJson && agentJson.params) {
             agentParamsRoot = resolveParentMerge(agentJson, agentJsonPath);
-            var skipKeys = { inputJql: true };
+            // cliPromptsByTracker is NOT copied into the encoded params: tracker prompts
+            // are already resolved and flattened into cliPrompts below (resolveInstructions).
+            // Copying the map would make the runtime (CliCommandBuilder) merge them a
+            // second time, duplicating the tracker prompts in the final CLI prompt.
+            var skipKeys = { inputJql: true, cliPromptsByTracker: true };
             Object.keys(agentParamsRoot).forEach(function(paramKey) {
                 if (skipKeys[paramKey]) return;
                 var value = agentParamsRoot[paramKey];
@@ -167,10 +214,6 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig, isLocal) {
                 } else if (typeof value === 'boolean' || typeof value === 'number') {
                     p[paramKey] = value;
                 } else if (Array.isArray(value)) {
-                    if (paramKey === 'cliPromptsByTracker') {
-                        // Tracker prompts are merged into cliPrompts below.
-                        return;
-                    }
                     p[paramKey] = value.slice();
                 } else if (typeof value === 'object' && value !== null) {
                     p[paramKey] = JSON.parse(JSON.stringify(value));
@@ -190,7 +233,9 @@ function buildEncodedConfig(ticketKey, rule, effectiveConfig, isLocal) {
 
     if (effectiveConfig && resolvedCf) {
         var agentName = extractAgentName(resolvedCf);
-        var resolved = configLoader.resolveInstructions(agentName, null, effectiveConfig, agentParamsRoot.cliPromptsByTracker);
+        var trackerOverride = resolveConfluenceTrackerOverride(agentParamsRoot, effectiveConfig, agentName);
+        var resolved = configLoader.resolveInstructions(agentName, null, effectiveConfig, agentParamsRoot.cliPromptsByTracker,
+            trackerOverride ? { trackerOverride: trackerOverride } : undefined);
 
         if (resolved.instructionsOverridden) {
             if (!p.agentParams) p.agentParams = {};
@@ -260,5 +305,6 @@ module.exports = {
     extractAgentName: extractAgentName,
     resolveConfigFile: resolveConfigFile,
     resolveParentMerge: resolveParentMerge,
+    resolveConfluenceTrackerOverride: resolveConfluenceTrackerOverride,
     buildEncodedConfig: buildEncodedConfig
 };

--- a/js/configLoader.js
+++ b/js/configLoader.js
@@ -608,9 +608,14 @@ function resolveConfluenceUrls(items, config) {
  * @param {string[]} defaultInstructions - Default instructions from agent JSON
  * @param {Object} config - Loaded project config
  * @param {Object} [agentCliPromptsByTracker] - Optional agent JSON's cliPromptsByTracker so project config extends rather than replaces it
+ * @param {Object} [options] - Optional settings
+ * @param {string} [options.trackerOverride] - Tracker key to use for cliPromptsByTracker
+ *        selection instead of DEFAULT_TRACKER (e.g. 'confluence' when the agent's
+ *        contentOutput routes generated content exclusively to a Confluence page,
+ *        which needs Markdown rather than tracker markup)
  * @returns {Object} { instructions: string[], instructionsOverridden: boolean, additionalInstructions: string[], cliPrompts: string[], cliPrompt: string|null, agentParamPatch: Object|null, jobParamPatch: Object|null }
  */
-function resolveInstructions(agentName, defaultInstructions, config, agentCliPromptsByTracker) {
+function resolveInstructions(agentName, defaultInstructions, config, agentCliPromptsByTracker, options) {
     var instructions = defaultInstructions || [];
     var instructionsOverridden = false;
     var additional = [];
@@ -672,6 +677,11 @@ function resolveInstructions(agentName, defaultInstructions, config, agentCliPro
     }
     if (!trackerType) {
         trackerType = 'jira';
+    }
+    // Content routed exclusively to Confluence must be authored in Markdown,
+    // not in the tracker's markup — switch the tracker-prompt selection key.
+    if (options && options.trackerOverride) {
+        trackerType = options.trackerOverride;
     }
 
     // Helper to extract tracker-specific prompts from a cliPromptsByTracker object

--- a/js/unit-tests/test_buildEncodedConfig.js
+++ b/js/unit-tests/test_buildEncodedConfig.js
@@ -301,6 +301,99 @@ suite('buildEncodedConfig payload', function() {
         assert.deepEqual(decoded.params.agentParams, {});
         assert.notOk(decoded.params.customParams);
     });
+
+    test('cliPromptsByTracker is not copied into encoded params (already flattened into cliPrompts)', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    cliPrompts: ['./base.md'],
+                    cliPromptsByTracker: { jira: ['./jira.md'] }
+                }
+            })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.notOk(decoded.params.cliPromptsByTracker);
+    });
+
+    test('contentOutput.target=confluence in agent customParams selects confluence tracker prompts', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    cliPrompts: ['./base.md'],
+                    cliPromptsByTracker: {
+                        jira: ['./jira-markup.md'],
+                        confluence: ['./confluence-markup.md']
+                    },
+                    customParams: { contentOutput: { target: 'confluence' } }
+                }
+            })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.deepEqual(decoded.params.cliPrompts, ['./base.md', './confluence-markup.md']);
+    });
+
+    test('jobParamPatches customParams.contentOutput.target wins over agent JSON', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    cliPrompts: ['./base.md'],
+                    cliPromptsByTracker: {
+                        jira: ['./jira-markup.md'],
+                        confluence: ['./confluence-markup.md']
+                    }
+                }
+            })
+        });
+        var config = {
+            jobParamPatches: {
+                test: { customParams: { contentOutput: { target: 'confluence' } } }
+            }
+        };
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, config);
+        var decoded = decode(encoded);
+        assert.deepEqual(decoded.params.cliPrompts, ['./base.md', './confluence-markup.md']);
+    });
+
+    test('confluence target without declared confluence prompts keeps default tracker prompts', function() {
+        var builder = loadBuilder({
+            'agents/test.json': JSON.stringify({
+                params: {
+                    cliPrompts: ['./base.md'],
+                    cliPromptsByTracker: { jira: ['./jira-markup.md'] },
+                    customParams: { contentOutput: { target: 'confluence' } }
+                }
+            })
+        });
+        var encoded = builder.buildEncodedConfig('T-1', { configFile: 'agents/test.json' }, {});
+        var decoded = decode(encoded);
+        assert.deepEqual(decoded.params.cliPrompts, ['./base.md', './jira-markup.md']);
+    });
+
+    test('resolveConfluenceTrackerOverride unit checks', function() {
+        var builder = loadBuilder({});
+        var agentParamsRoot = {
+            cliPromptsByTracker: { confluence: ['./c.md'] },
+            customParams: { contentOutput: { target: 'confluence' } }
+        };
+        assert.equal(builder.resolveConfluenceTrackerOverride(agentParamsRoot, {}, 'test'), 'confluence');
+        // target both → no override (tracker field still needs tracker markup)
+        assert.equal(builder.resolveConfluenceTrackerOverride(
+            { cliPromptsByTracker: { confluence: ['./c.md'] }, customParams: { contentOutput: { target: 'both' } } },
+            {}, 'test'), null);
+        // no confluence prompts declared → no override
+        assert.equal(builder.resolveConfluenceTrackerOverride(
+            { cliPromptsByTracker: { jira: ['./j.md'] }, customParams: { contentOutput: { target: 'confluence' } } },
+            {}, 'test'), null);
+        // no contentOutput → no override
+        assert.equal(builder.resolveConfluenceTrackerOverride(
+            { cliPromptsByTracker: { confluence: ['./c.md'] } }, {}, 'test'), null);
+        // config-level confluence prompts are enough
+        assert.equal(builder.resolveConfluenceTrackerOverride(
+            { customParams: { contentOutput: { target: 'confluence' } } },
+            { cliPromptsByTracker: { confluence: ['./c.md'] } }, 'test'), 'confluence');
+    });
 });
 
 suite('resolveParentMerge — parent inheritance', function() {

--- a/js/unit-tests/test_configLoader.js
+++ b/js/unit-tests/test_configLoader.js
@@ -798,6 +798,72 @@ suite('configLoader.resolveInstructions', function() {
         assert.equal(result.cliPromptsStrategy, 'replace');
     });
 
+    test('trackerOverride switches cliPromptsByTracker selection regardless of DEFAULT_TRACKER', function() {
+        var config = configLoaderModule.mergeProjectConfig(defaults, {
+            cliPrompts: {
+                story_solution: ['./base.md']
+            }
+        });
+        var agentByTracker = {
+            jira: ['./jira-markup.md'],
+            confluence: ['./confluence-markup.md']
+        };
+        var originalGetenv = java.lang.System.getenv;
+        java.lang.System.getenv = function(key) {
+            if (key === 'DEFAULT_TRACKER') return 'jira';
+            return originalGetenv(key);
+        };
+        try {
+            var result = configLoaderModule.resolveInstructions('story_solution', [], config, agentByTracker,
+                { trackerOverride: 'confluence' });
+            assert.deepEqual(result.cliPrompts, ['./base.md', './confluence-markup.md']);
+        } finally {
+            java.lang.System.getenv = originalGetenv;
+        }
+    });
+
+    test('trackerOverride picks confluence prompts from project config when agent JSON lacks them', function() {
+        var config = configLoaderModule.mergeProjectConfig(defaults, {
+            cliPromptsByTracker: {
+                confluence: ['./config-confluence.md']
+            }
+        });
+        var agentByTracker = {
+            jira: ['./jira-markup.md']
+        };
+        var originalGetenv = java.lang.System.getenv;
+        java.lang.System.getenv = function(key) {
+            if (key === 'DEFAULT_TRACKER') return 'jira';
+            return originalGetenv(key);
+        };
+        try {
+            var result = configLoaderModule.resolveInstructions('story_solution', [], config, agentByTracker,
+                { trackerOverride: 'confluence' });
+            assert.deepEqual(result.cliPrompts, ['./config-confluence.md']);
+        } finally {
+            java.lang.System.getenv = originalGetenv;
+        }
+    });
+
+    test('without trackerOverride the configured tracker is used (unchanged behavior)', function() {
+        var config = configLoaderModule.mergeProjectConfig(defaults, {});
+        var agentByTracker = {
+            jira: ['./jira-markup.md'],
+            confluence: ['./confluence-markup.md']
+        };
+        var originalGetenv = java.lang.System.getenv;
+        java.lang.System.getenv = function(key) {
+            if (key === 'DEFAULT_TRACKER') return 'jira';
+            return originalGetenv(key);
+        };
+        try {
+            var result = configLoaderModule.resolveInstructions('story_solution', [], config, agentByTracker);
+            assert.deepEqual(result.cliPrompts, ['./jira-markup.md']);
+        } finally {
+            java.lang.System.getenv = originalGetenv;
+        }
+    });
+
 });
 
 

--- a/story_acceptance_criteria.json
+++ b/story_acceptance_criteria.json
@@ -34,6 +34,9 @@
       "ado": [
         "./agents/instructions/story/enhanced_story_formatting.md",
         "./agents/instructions/tracker/ado_markup_transform.md"
+      ],
+      "confluence": [
+        "./agents/instructions/tracker/confluence_markup_transform.md"
       ]
     },
     "customParams": {

--- a/story_acceptance_criterias.json
+++ b/story_acceptance_criterias.json
@@ -33,6 +33,9 @@
       "ado": [
         "./agents/instructions/story/enhanced_story_formatting.md",
         "./agents/instructions/tracker/ado_markup_transform.md"
+      ],
+      "confluence": [
+        "./agents/instructions/tracker/confluence_markup_transform.md"
       ]
     },
     "customParams": {

--- a/story_description.json
+++ b/story_description.json
@@ -36,6 +36,9 @@
       ],
       "ado": [
         "./agents/instructions/tracker/ado_markup_transform.md"
+      ],
+      "confluence": [
+        "./agents/instructions/tracker/confluence_markup_transform.md"
       ]
     },
     "metadata": {

--- a/story_solution.json
+++ b/story_solution.json
@@ -40,6 +40,9 @@
       "ado": [
         "./agents/instructions/tracker/ado_context.md",
         "./agents/instructions/tracker/ado_markup_transform.md"
+      ],
+      "confluence": [
+        "./agents/instructions/tracker/confluence_markup_transform.md"
       ]
     }
   }


### PR DESCRIPTION
## Problem

With `customParams.contentOutput.target: 'confluence'` the generated content is published to a Confluence page as Markdown (via `confluence_sync_markdown_directory`), but the CLI agent was still instructed through the configured tracker's markup transform (e.g. Jira wiki: `h2.`, `{code}`, `{{...}}`, `[text|url]`). The published page kept raw wiki markup and was unreadable.

## Change

**Tracker-prompt selection becomes output-aware** (mirrors the companion dmtools CLI change in epam/dm.ai — the CLI-side fix covers direct `dmtools run` without an encoded config; this repo's change covers the encoded-config path):

- `configLoader.resolveInstructions` accepts `options.trackerOverride` — an explicit key for `cliPromptsByTracker` selection instead of `DEFAULT_TRACKER`.
- `buildEncodedConfig` resolves the override from the effective `customParams.contentOutput.target` (agent JSON `customParams`, overridable via project config `jobParamPatches.<agent>.customParams`). The override applies only when `confluence` prompts are actually declared (agent JSON or project config); otherwise the default tracker selection is kept — same fallback semantics as the CLI.
- New `instructions/tracker/confluence_markup_transform.md` — the Markdown transform table for Confluence output.
- `confluence` key added to `cliPromptsByTracker` of the content-producing agents: `story_solution`, `story_description`, `story_acceptance_criteria`, `story_acceptance_criterias`.

**Drive-by fix — double prompt merge:** `buildEncodedConfig` no longer copies `cliPromptsByTracker` into the encoded params. Tracker prompts are already resolved and flattened into `cliPrompts` at encode time; the copied map made the runtime (`CliCommandBuilder.buildCommands`) merge the same prompts a second time (the existing skip check lived in the wrong branch — `Array.isArray` — while the value is an object).

`target: 'both'` intentionally keeps tracker markup, because the tracker field still receives the full content.

## Tests

- `test_configLoader.js`: trackerOverride selection (agent JSON and project config sources) + unchanged default behavior.
- `test_buildEncodedConfig.js`: no `cliPromptsByTracker` in encoded params; confluence selection from agent customParams; jobParamPatches precedence; fallback when no confluence prompts declared; `resolveConfluenceTrackerOverride` unit checks.
- Full suite: 799 passed, 0 failed (`run_all.json`); agentDocGenerator re-run (no diff).