### PR TITLE
fix(pr_review): clear stale pr_approved label on REQUEST_CHANGES

### DIFF
--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -842,7 +842,16 @@ function action(params) {
                     console.warn('Failed to add pr_approved label to GitHub PR:', labelErr);
                 }
             } else {
-                // STATE 2: REQUEST_CHANGES / BLOCK → do NOT merge
+                // STATE 2: REQUEST_CHANGES / BLOCK → do NOT merge.
+                // If a previous review cycle already approved this PR (label present),
+                // that approval is now superseded by this negative outcome — clear it so
+                // SM does not attempt to merge a PR that just received new blocking feedback.
+                try {
+                    scm.removeLabel(prNumber, LABELS.PR_APPROVED);
+                    console.log('ℹ️ Removed stale pr_approved label from GitHub PR #' + prNumber + ' (recommendation: ' + recommendation + ')');
+                } catch (labelErr) {
+                    // Label may not have existed — safe to ignore.
+                }
                 console.log('PR has issues (' + recommendation + ') - will NOT merge, returning ticket to In Development');
             }
 
@@ -853,6 +862,11 @@ function action(params) {
         // Step 6: Post review to Jira ticket (merge is handled by SM/required reviewers, not by this agent)
         postReviewToJira(ticketKey, jiraReview, reviewData, prUrl);
 
+        // Tracks whether we successfully cleared a stale pr_approved label from the Jira
+        // ticket in Step 7 below, so Step 12's "merge in progress" guard isn't fooled by
+        // the pre-run ticket snapshot that still shows the (now-removed) label.
+        var staleApprovedLabelCleared = false;
+
         // Step 7: Update ticket status based on outcome
         try {
             if (isApproved) {
@@ -862,28 +876,42 @@ function action(params) {
                     label: LABELS.PR_APPROVED
                 });
                 console.log('✅ Added pr_approved label to Jira ticket — SM will retry merge');
-            } else if (prNumber && repoInfo) {
-                // Has issues, and there is an actual PR to rework → move to In Rework for focused fixes
-                jira_move_to_status({
-                    key: ticketKey,
-                    statusName: statuses.IN_REWORK
-                });
-                console.log('✅ Ticket moved to In Rework');
             } else {
-                // Has issues, but no PR was ever matched to this ticket — moving to In Rework
-                // would start a rework cycle with nothing to rework. Leave the status alone
-                // and surface this explicitly instead of silently transitioning the ticket.
-                try {
-                    jira_post_comment({
-                        key: ticketKey,
-                        comment: 'h3. ⚠️ PR Review Could Not Be Attached\n\n' +
-                            'The review analysis completed, but no open Pull Request could be matched to this ticket. ' +
-                            'The ticket status was left unchanged (not moved to In Rework) since there is no PR to rework.'
-                    });
-                } catch (commentError) {
-                    console.warn('Could not post PR-review-could-not-be-attached comment:', commentError);
+                // Not approved → clear any stale pr_approved label from a previous review cycle
+                // so SM does not attempt to merge a PR that just received new blocking feedback.
+                if (hasPrApprovedLabel(params.ticket)) {
+                    try {
+                        jira_remove_label({ key: ticketKey, label: LABELS.PR_APPROVED });
+                        staleApprovedLabelCleared = true;
+                        console.log('ℹ️ Removed stale pr_approved label from Jira ticket');
+                    } catch (labelErr) {
+                        console.warn('Failed to remove stale pr_approved label from Jira ticket:', labelErr);
+                    }
                 }
-                console.warn('⚠️ No PR found for', ticketKey, '— leaving ticket status unchanged');
+
+                if (prNumber && repoInfo) {
+                    // Has issues, and there is an actual PR to rework → move to In Rework for focused fixes
+                    jira_move_to_status({
+                        key: ticketKey,
+                        statusName: statuses.IN_REWORK
+                    });
+                    console.log('✅ Ticket moved to In Rework');
+                } else {
+                    // Has issues, but no PR was ever matched to this ticket — moving to In Rework
+                    // would start a rework cycle with nothing to rework. Leave the status alone
+                    // and surface this explicitly instead of silently transitioning the ticket.
+                    try {
+                        jira_post_comment({
+                            key: ticketKey,
+                            comment: 'h3. ⚠️ PR Review Could Not Be Attached\n\n' +
+                                'The review analysis completed, but no open Pull Request could be matched to this ticket. ' +
+                                'The ticket status was left unchanged (not moved to In Rework) since there is no PR to rework.'
+                        });
+                    } catch (commentError) {
+                        console.warn('Could not post PR-review-could-not-be-attached comment:', commentError);
+                    }
+                    console.warn('⚠️ No PR found for', ticketKey, '— leaving ticket status unchanged');
+                }
             }
         } catch (statusError) {
             console.warn('Could not update ticket status/label:', statusError);
@@ -944,8 +972,10 @@ function action(params) {
             const autoStartRework = customParams && customParams.autoStartRework;
             const reworkConfigFile = customParams && customParams.autoStartReworkConfigFile;
             if (autoStartRework && reworkConfigFile) {
-                // Skip if ticket already has pr_approved label (merge in progress)
-                if (hasPrApprovedLabel(params.ticket)) {
+                // Skip if ticket still has a pr_approved label we couldn't clear above
+                // (a merge may genuinely be in progress). If we already cleared the stale
+                // label ourselves in Step 7, it's safe to proceed.
+                if (hasPrApprovedLabel(params.ticket) && !staleApprovedLabelCleared) {
                     console.log('ℹ️ autoStartRework: skipped — ticket has pr_approved label');
                 } else {
                     try {

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -277,14 +277,19 @@ suite('postPRReviewComments', function() {
         function loadPostPRReviewCommentsForAction(opts) {
             opts = opts || {};
             var jiraAddLabelCalls = [];
+            var jiraRemoveLabelCalls = [];
             var jiraMoveToStatusCalls = [];
             var jiraPostCommentCalls = [];
             var triggerSmIfIdleCalls = [];
+            var triggerConfiguredWorkflowCalls = [];
+            var scmAddLabelCalls = [];
+            var scmRemoveLabelCalls = [];
 
             var scm = {
                 listPrs: function() { return opts.openPrs || []; },
                 getRemoteRepoInfo: function() { return opts.repoInfo !== undefined ? opts.repoInfo : null; },
-                addLabel: function() {},
+                addLabel: function(prId, label) { scmAddLabelCalls.push({ prId: prId, label: label }); },
+                removeLabel: function(prId, label) { scmRemoveLabelCalls.push({ prId: prId, label: label }); },
                 fetchDiscussions: function() { return { rawThreads: { threads: [] } }; }
             };
 
@@ -304,9 +309,9 @@ suite('postPRReviewComments', function() {
                     return null;
                 },
                 jira_add_label: function(args) { jiraAddLabelCalls.push(args); },
+                jira_remove_label: function(args) { jiraRemoveLabelCalls.push(args); },
                 jira_move_to_status: function(args) { jiraMoveToStatusCalls.push(args); },
                 jira_post_comment: function(args) { jiraPostCommentCalls.push(args); },
-                jira_remove_label: function() {},
                 jira_assign_ticket_to: function() {}
             };
 
@@ -316,7 +321,10 @@ suite('postPRReviewComments', function() {
                     './config.js': configModule,
                     './common/scm.js': { createScm: function() { return scm; } },
                     './common/autoStart.js': {
-                        triggerConfiguredWorkflowForTicket: function() { return false; },
+                        triggerConfiguredWorkflowForTicket: function(args) {
+                            triggerConfiguredWorkflowCalls.push(args);
+                            return opts.reworkStarted === undefined ? false : opts.reworkStarted;
+                        },
                         triggerSmIfIdle: function(args) { triggerSmIfIdleCalls.push(args); }
                     },
                     './configLoader.js': {
@@ -333,9 +341,13 @@ suite('postPRReviewComments', function() {
             return {
                 mod: mod,
                 jiraAddLabelCalls: jiraAddLabelCalls,
+                jiraRemoveLabelCalls: jiraRemoveLabelCalls,
                 jiraMoveToStatusCalls: jiraMoveToStatusCalls,
                 jiraPostCommentCalls: jiraPostCommentCalls,
-                triggerSmIfIdleCalls: triggerSmIfIdleCalls
+                triggerSmIfIdleCalls: triggerSmIfIdleCalls,
+                triggerConfiguredWorkflowCalls: triggerConfiguredWorkflowCalls,
+                scmAddLabelCalls: scmAddLabelCalls,
+                scmRemoveLabelCalls: scmRemoveLabelCalls
             };
         }
 
@@ -418,6 +430,99 @@ suite('postPRReviewComments', function() {
                 }),
                 false,
                 'must not post the "could not attach" comment when a PR was found'
+            );
+        });
+
+        test('REQUEST_CHANGES clears a stale pr_approved label from both the GitHub PR and the Jira ticket', function() {
+            var loaded = loadPostPRReviewCommentsForAction({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                repoInfo: { owner: 'IstiN', repo: 'dmtools-agents' },
+                prInfoContent: '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n'
+            });
+
+            var result = loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: ['pr_approved'] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1'
+            });
+
+            assert.equal(result.success, true);
+
+            assert.ok(
+                loaded.scmRemoveLabelCalls.some(function(c) { return String(c.prId) === '42' && c.label === 'pr_approved'; }),
+                'should remove the stale pr_approved label from the GitHub PR'
+            );
+            assert.ok(
+                loaded.jiraRemoveLabelCalls.some(function(c) { return c.label === 'pr_approved'; }),
+                'should remove the stale pr_approved label from the Jira ticket'
+            );
+            assert.equal(
+                loaded.scmAddLabelCalls.filter(function(c) { return c.label === 'pr_approved'; }).length, 0,
+                'must NOT (re-)add the pr_approved label on a REQUEST_CHANGES outcome'
+            );
+        });
+
+        test('APPROVE does not touch pr_approved label removal (only adds it)', function() {
+            var loaded = loadPostPRReviewCommentsForAction({
+                reviewData: {
+                    recommendation: 'APPROVE',
+                    issueCounts: { blocking: 0, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                repoInfo: { owner: 'IstiN', repo: 'dmtools-agents' },
+                prInfoContent: '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n'
+            });
+
+            var result = loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1'
+            });
+
+            assert.equal(result.success, true);
+            assert.equal(loaded.scmRemoveLabelCalls.length, 0, 'must not remove any label on APPROVE');
+            assert.ok(
+                loaded.scmAddLabelCalls.some(function(c) { return c.label === 'pr_approved'; }),
+                'should add the pr_approved label to the GitHub PR'
+            );
+            assert.ok(
+                loaded.jiraAddLabelCalls.some(function(c) { return c.label === 'pr_approved'; }),
+                'should add the pr_approved label to the Jira ticket'
+            );
+        });
+
+        test('autoStartRework proceeds after clearing a stale pr_approved label in the same run', function() {
+            var loaded = loadPostPRReviewCommentsForAction({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                repoInfo: { owner: 'IstiN', repo: 'dmtools-agents' },
+                prInfoContent: '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n',
+                reworkStarted: true
+            });
+
+            var result = loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: ['pr_approved'] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1',
+                jobParams: {
+                    customParams: {
+                        autoStartRework: true,
+                        autoStartReworkConfigFile: 'agents/pr_rework.json'
+                    }
+                }
+            });
+
+            assert.equal(result.success, true);
+            assert.equal(
+                loaded.triggerConfiguredWorkflowCalls.length, 1,
+                'should NOT skip autoStartRework just because the pre-run ticket snapshot had the stale pr_approved label'
             );
         });
     });


### PR DESCRIPTION
## Problem
Reported: the pr_review agent adds a `pr_approved` label to the GitHub PR (and Jira ticket) once it approves a PR. If a **later** review round on the same PR comes back as `REQUEST_CHANGES` (e.g. new commits reintroduced an issue), the old `pr_approved` label was never removed — SM's retry-merge logic and the `autoStartRework` guard could keep treating the PR as approved.

## Fix
In `postPRReviewComments.js`, whenever the recommendation is not `APPROVE`:
- Remove `pr_approved` from the GitHub PR via `scm.removeLabel` (already backed by the existing `github_remove_pr_label` MCP tool — no new MCP tool was needed for this part).
- Remove `pr_approved` from the Jira ticket.
- Fixed a related latent bug: the `autoStartRework` guard checked the **pre-run** ticket snapshot for the `pr_approved` label and would skip auto-rework even after we just cleared it in the same run. Now tracked with a `staleApprovedLabelCleared` flag so it only skips if we couldn't confirm removal.

## Tests
Added 3 new tests to `test_postPRReviewComments.js` covering: label cleared on REQUEST_CHANGES, label untouched on APPROVE (only added), and autoStartRework proceeding after clearing the stale label in the same run.

`dmtools run js/unit-tests/run_all.json` → 805 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>