### PR TITLE
fix(contentOutput): preserve Confluence inline comments across page rewrites

### DIFF
--- a/instructions/common/confluence_comments.md
+++ b/instructions/common/confluence_comments.md
@@ -7,7 +7,18 @@ Active only when the agent is configured to publish its output to Confluence (`c
 When `input/confluence_output_target.json` is present, your output is published to a Confluence page:
 
 - Write `outputs/response.md` as **Markdown** — it is converted to Confluence storage format on publish. Do NOT use tracker-specific markup (no Jira `{code}` / `h2.` / ADF), even if other instructions ask for it; Markdown wins for this output.
-- If `input/confluence_output_current.md` exists, it contains the page's current content — iterate on it instead of rewriting from scratch.
+- If `input/confluence_output_current.md` exists, it contains the page's current content — iterate on it instead of rewriting from scratch. The current content may be in legacy tracker markup from earlier runs — still write your output in Markdown.
+
+## Inline comment anchors (`[[ic:...]]` placeholders)
+
+`input/confluence_output_current.md` may contain placeholders like `[[ic:550e8400-e29b-41d4-a716-446655440000]]anchored text[[/ic]]`. Each one marks the text fragment an **inline comment is anchored to** on the published page. The publish step converts these placeholders back into real Confluence anchors; if you drop or mangle them, the comment loses its anchor and disappears from the page.
+
+Rules:
+
+- **Always preserve** every `[[ic:REF]]...[[/ic]]` placeholder, wrapped around the same text it currently marks.
+- If you rephrase the anchored text, **move the placeholder** so it wraps the new equivalent fragment.
+- Remove a placeholder only when you intentionally remove the commented content itself.
+- Never invent new `[[ic:...]]` refs — only the ones already present are valid.
 
 ## Reading comments
 

--- a/instructions/common/confluence_comments.md
+++ b/instructions/common/confluence_comments.md
@@ -11,7 +11,7 @@ When `input/confluence_output_target.json` is present, your output is published 
 
 ## Inline comment anchors (`[[ic:...]]` placeholders)
 
-`input/confluence_output_current.md` may contain placeholders like `[[ic:550e8400-e29b-41d4-a716-446655440000]]anchored text[[/ic]]`. Each one marks the text fragment an **inline comment is anchored to** on the published page. The publish step converts these placeholders back into real Confluence anchors; if you drop or mangle them, the comment loses its anchor and disappears from the page.
+`input/confluence_output_current.md` may contain placeholders like `[[ic:550e8400-e29b-41d4-a716-446655440000]]anchored text[[/ic]]`. Each one marks the text fragment an **inline comment is anchored to** on the published page. On publish, the Confluence Markdown sync converts these placeholders back into real page anchors; if you drop or mangle them, the comment loses its anchor and disappears from the page.
 
 Rules:
 

--- a/js/common/contentOutput.js
+++ b/js/common/contentOutput.js
@@ -206,6 +206,21 @@ function publishPage(cfg, ticketKey, summary, content) {
         deleteOrphans: false
     });
 
+    // The sync replaces the page body wholesale, which destroys inline comment
+    // anchors (ac:inline-comment-marker). Re-anchor the comments that survived
+    // as [[ic:...]] placeholders or whose anchor text is still present.
+    if (cfg.includeInlineComments !== false) {
+        try {
+            var anchoring = restoreInlineCommentAnchors(page, cfg);
+            if (anchoring.restored.length > 0 || anchoring.missed.length > 0) {
+                console.log('Inline comment anchors: ' + anchoring.restored.length +
+                    ' restored, ' + anchoring.missed.length + ' could not be re-anchored');
+            }
+        } catch (anchorError) {
+            console.warn('Failed to restore inline comment anchors (non-fatal):', anchorError);
+        }
+    }
+
     return { page: page, url: resolvePageUrl(page), created: created };
 }
 
@@ -216,7 +231,170 @@ function escapeHtml(text) {
         .replace(/>/g, '&gt;');
 }
 
-// ── Inline comments ──────────────────────────────────────────────────────────
+// ── Inline comment anchors ───────────────────────────────────────────────────
+//
+// Inline comments anchor to page text via <ac:inline-comment-marker ac:ref="GUID">
+// elements in the storage body. Any body update that drops these elements orphans
+// the comments (they stay in the API but disappear from the page UI).
+//
+// Preservation strategy:
+//   1. Pre-CLI (fetchConfluenceOutputContext) rewrites markers found in the current
+//      page into `[[ic:GUID]]anchor text[[/ic]]` placeholders inside
+//      input/confluence_output_current.md, and the agent is instructed
+//      (instructions/common/confluence_comments.md) to keep them around the same or
+//      equivalent text in its Markdown output.
+//   2. Post-sync (restoreInlineCommentAnchors) converts placeholders back into real
+//      markers in the fresh storage body. For open comments whose placeholder was
+//      lost (model non-compliance), falls back to matching the original anchor text.
+
+var IC_OPEN_TAG = '[[ic:';
+var IC_CLOSE_TAG = '[[/ic]]';
+
+function escapeRegExp(text) {
+    return String(text).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extract inline comment anchors from a Confluence storage-format body.
+ * Returns [{ ref: '<marker guid>', text: '<anchored text>' }].
+ */
+function extractInlineCommentMarkers(storageBody) {
+    var anchors = [];
+    if (!storageBody) return anchors;
+    var re = /<ac:inline-comment-marker\s+ac:ref="([^"]+)"[^>]*>([\s\S]*?)<\/ac:inline-comment-marker>/g;
+    var m;
+    while ((m = re.exec(storageBody)) !== null) {
+        // Strip any nested tags from the anchored text — anchors are plain text
+        var text = m[2].replace(/<[^>]+>/g, '');
+        if (m[1] && text.trim()) {
+            anchors.push({ ref: m[1], text: text });
+        }
+    }
+    return anchors;
+}
+
+/**
+ * Wrap the first occurrence of each anchor's text in the Markdown content with
+ * [[ic:REF]]...[[/ic]] placeholders. Anchors already present as placeholders are
+ * skipped. Anchors whose text is not found are skipped (reported in .missed).
+ * Returns { content, injected: [refs], missed: [refs] }.
+ */
+function injectCommentPlaceholders(markdown, anchors) {
+    var result = { content: markdown || '', injected: [], missed: [] };
+    (anchors || []).forEach(function(anchor) {
+        if (!anchor || !anchor.ref || !anchor.text) return;
+        if (result.content.indexOf(IC_OPEN_TAG + anchor.ref + ']]') !== -1) return;
+        var idx = result.content.indexOf(anchor.text);
+        if (idx === -1) {
+            result.missed.push(anchor.ref);
+            return;
+        }
+        result.content = result.content.substring(0, idx) +
+            IC_OPEN_TAG + anchor.ref + ']]' + anchor.text + IC_CLOSE_TAG +
+            result.content.substring(idx + anchor.text.length);
+        result.injected.push(anchor.ref);
+    });
+    return result;
+}
+
+/**
+ * Pure transformation: restore inline comment markers in a fresh storage body.
+ *
+ * For each open comment with a markerRef:
+ *   - if the body contains its [[ic:REF]]...[[/ic]] placeholder → replace with the
+ *     real <ac:inline-comment-marker> element;
+ *   - else if a marker with this ref already exists → leave as-is;
+ *   - else fall back to wrapping the first occurrence of the comment's
+ *     originalSelection text (HTML-escaped and raw variants are tried).
+ *
+ * Any leftover placeholder tags (unknown refs / malformed) are stripped so they
+ * never render as visible garbage on the page.
+ *
+ * Returns { body, restored: [refs], missed: [refs] }.
+ */
+function applyCommentAnchorsToStorageBody(storageBody, comments) {
+    var body = storageBody || '';
+    var restored = [];
+    var missed = [];
+
+    (comments || []).forEach(function(comment) {
+        if (!comment || comment.resolved || !comment.markerRef) return;
+        var ref = comment.markerRef;
+
+        if (body.indexOf('ac:ref="' + ref + '"') !== -1) {
+            restored.push(ref);
+            return;
+        }
+
+        // 1. Placeholder left by the agent
+        var placeholderRe = new RegExp(
+            escapeRegExp(IC_OPEN_TAG + ref + ']]') + '([\\s\\S]*?)' + escapeRegExp(IC_CLOSE_TAG));
+        if (placeholderRe.test(body)) {
+            body = body.replace(placeholderRe,
+                '<ac:inline-comment-marker ac:ref="' + ref + '">$1</ac:inline-comment-marker>');
+            restored.push(ref);
+            return;
+        }
+
+        // 2. Fallback: original anchor text still present in the new body
+        var selection = comment.originalSelection;
+        if (selection) {
+            var variants = [escapeHtml(selection), selection];
+            for (var i = 0; i < variants.length; i++) {
+                var needle = variants[i];
+                if (!needle) continue;
+                var idx = body.indexOf(needle);
+                if (idx !== -1) {
+                    body = body.substring(0, idx) +
+                        '<ac:inline-comment-marker ac:ref="' + ref + '">' + needle + '</ac:inline-comment-marker>' +
+                        body.substring(idx + needle.length);
+                    restored.push(ref);
+                    return;
+                }
+            }
+        }
+
+        missed.push(ref);
+    });
+
+    // Strip any leftover placeholder tags so they never render visibly
+    body = body.replace(/\[\[ic:[0-9a-fA-F-]{36}\]\]/g, '');
+    body = body.replace(/\[\[\/ic\]\]/g, '');
+
+    return { body: body, restored: restored, missed: missed };
+}
+
+/**
+ * Post-sync step: re-anchor inline comments in the freshly published page body.
+ * Fetches the current page storage body and open inline comments, applies
+ * applyCommentAnchorsToStorageBody, and updates the page when anything changed.
+ */
+function restoreInlineCommentAnchors(page, cfg) {
+    var empty = { restored: [], missed: [] };
+    if (!page || !page.id) return empty;
+
+    var comments = fetchPageInlineComments(page.id, page.title, 100);
+    var withAnchors = comments.filter(function(c) { return !c.resolved && c.markerRef; });
+    if (withAnchors.length === 0) return empty;
+
+    var full = confluence_content_by_id({ contentId: String(page.id) });
+    var storageBody = full && full.body && full.body.storage && full.body.storage.value;
+    if (!storageBody) return empty;
+
+    // Comments already carrying a live marker are left untouched by
+    // applyCommentAnchorsToStorageBody (the ac:ref presence check).
+    var result = applyCommentAnchorsToStorageBody(storageBody, comments);
+    if (result.body === storageBody) return { restored: result.restored, missed: result.missed };
+
+    confluence_update_page({
+        contentId: String(page.id),
+        title: page.title,
+        parentId: cfg.parentPageId,
+        body: result.body,
+        space: cfg.space
+    });
+    return { restored: result.restored, missed: result.missed };
+}
 
 function extractCommentBody(comment) {
     if (!comment) return '';
@@ -236,6 +414,8 @@ function fetchPageInlineComments(pageId, pageTitle, limit) {
         var results = parsed.results || parsed.comments || (Array.isArray(parsed) ? parsed : []);
         for (var i = 0; i < results.length; i++) {
             var c = results[i];
+            var props = c.properties || {};
+            var inlineProps = (c.extensions && c.extensions.inlineProperties) || {};
             comments.push({
                 pageId: String(pageId),
                 pageTitle: pageTitle || 'untitled',
@@ -245,6 +425,13 @@ function fetchPageInlineComments(pageId, pageTitle, limit) {
                 created: c.createdDate || (c.version && c.version.createdAt) || c.created || '',
                 resolved: c.resolutionStatus === 'resolved' || c.resolutionStatus === 'closed' ||
                     !!(c.resolvedDate || c.resolved || c.status === 'resolved' || c.status === 'closed'),
+                // Anchor info for inline comment preservation across page rewrites.
+                // v2 API exposes it under properties (camelCase and dash-case variants),
+                // v1 under extensions.inlineProperties.
+                markerRef: props.inlineMarkerRef || props['inline-marker-ref'] ||
+                    inlineProps.markerRef || null,
+                originalSelection: props.inlineOriginalSelection || props['inline-original-selection'] ||
+                    inlineProps.originalSelection || null,
                 body: extractCommentBody(c)
             });
         }
@@ -338,6 +525,10 @@ if (typeof module !== 'undefined' && module.exports) {
         writeCommentsFiles: writeCommentsFiles,
         publishCommentReplies: publishCommentReplies,
         extractCommentBody: extractCommentBody,
+        extractInlineCommentMarkers: extractInlineCommentMarkers,
+        injectCommentPlaceholders: injectCommentPlaceholders,
+        applyCommentAnchorsToStorageBody: applyCommentAnchorsToStorageBody,
+        restoreInlineCommentAnchors: restoreInlineCommentAnchors,
         COMMENTS_BASE_NAME: COMMENTS_BASE_NAME,
         DEFAULT_REPLIES_FILE: DEFAULT_REPLIES_FILE
     };

--- a/js/common/contentOutput.js
+++ b/js/common/contentOutput.js
@@ -196,7 +196,11 @@ function publishPage(cfg, ticketKey, summary, content) {
         });
     }
 
-    // Publish the Markdown body through the sync tool (proper storage conversion)
+    // Publish the Markdown body through the sync tool (proper storage conversion).
+    // Since dmtools v1.7.249 the sync preserves inline comment anchors natively:
+    // [[ic:REF]]...[[/ic]] placeholders in the Markdown become real
+    // ac:inline-comment-marker elements, and anchors present in the old page body
+    // are re-applied by anchored-text match (preserveInlineComments, default true).
     var syncDir = 'outputs/confluence_sync_' + ticketKey;
     file_write(syncDir + '/index.md', content);
     confluence_sync_markdown_directory({
@@ -205,21 +209,6 @@ function publishPage(cfg, ticketKey, summary, content) {
         space: cfg.space,
         deleteOrphans: false
     });
-
-    // The sync replaces the page body wholesale, which destroys inline comment
-    // anchors (ac:inline-comment-marker). Re-anchor the comments that survived
-    // as [[ic:...]] placeholders or whose anchor text is still present.
-    if (cfg.includeInlineComments !== false) {
-        try {
-            var anchoring = restoreInlineCommentAnchors(page, cfg);
-            if (anchoring.restored.length > 0 || anchoring.missed.length > 0) {
-                console.log('Inline comment anchors: ' + anchoring.restored.length +
-                    ' restored, ' + anchoring.missed.length + ' could not be re-anchored');
-            }
-        } catch (anchorError) {
-            console.warn('Failed to restore inline comment anchors (non-fatal):', anchorError);
-        }
-    }
 
     return { page: page, url: resolvePageUrl(page), created: created };
 }
@@ -243,9 +232,13 @@ function escapeHtml(text) {
 //      input/confluence_output_current.md, and the agent is instructed
 //      (instructions/common/confluence_comments.md) to keep them around the same or
 //      equivalent text in its Markdown output.
-//   2. Post-sync (restoreInlineCommentAnchors) converts placeholders back into real
-//      markers in the fresh storage body. For open comments whose placeholder was
-//      lost (model non-compliance), falls back to matching the original anchor text.
+//   2. The dmtools Confluence Markdown sync (preserveInlineComments, default true
+//      since dmtools v1.7.249) converts placeholders back into real markers and
+//      additionally re-applies old markers by anchored-text match when the
+//      placeholder was lost.
+//
+// extractInlineCommentMarkers / injectCommentPlaceholders below are shared with the
+// pre-CLI side; the post-sync conversion lives in the dmtools CLI.
 
 var IC_OPEN_TAG = '[[ic:';
 var IC_CLOSE_TAG = '[[/ic]]';
@@ -297,104 +290,7 @@ function injectCommentPlaceholders(markdown, anchors) {
     return result;
 }
 
-/**
- * Pure transformation: restore inline comment markers in a fresh storage body.
- *
- * For each open comment with a markerRef:
- *   - if the body contains its [[ic:REF]]...[[/ic]] placeholder → replace with the
- *     real <ac:inline-comment-marker> element;
- *   - else if a marker with this ref already exists → leave as-is;
- *   - else fall back to wrapping the first occurrence of the comment's
- *     originalSelection text (HTML-escaped and raw variants are tried).
- *
- * Any leftover placeholder tags (unknown refs / malformed) are stripped so they
- * never render as visible garbage on the page.
- *
- * Returns { body, restored: [refs], missed: [refs] }.
- */
-function applyCommentAnchorsToStorageBody(storageBody, comments) {
-    var body = storageBody || '';
-    var restored = [];
-    var missed = [];
 
-    (comments || []).forEach(function(comment) {
-        if (!comment || comment.resolved || !comment.markerRef) return;
-        var ref = comment.markerRef;
-
-        if (body.indexOf('ac:ref="' + ref + '"') !== -1) {
-            restored.push(ref);
-            return;
-        }
-
-        // 1. Placeholder left by the agent
-        var placeholderRe = new RegExp(
-            escapeRegExp(IC_OPEN_TAG + ref + ']]') + '([\\s\\S]*?)' + escapeRegExp(IC_CLOSE_TAG));
-        if (placeholderRe.test(body)) {
-            body = body.replace(placeholderRe,
-                '<ac:inline-comment-marker ac:ref="' + ref + '">$1</ac:inline-comment-marker>');
-            restored.push(ref);
-            return;
-        }
-
-        // 2. Fallback: original anchor text still present in the new body
-        var selection = comment.originalSelection;
-        if (selection) {
-            var variants = [escapeHtml(selection), selection];
-            for (var i = 0; i < variants.length; i++) {
-                var needle = variants[i];
-                if (!needle) continue;
-                var idx = body.indexOf(needle);
-                if (idx !== -1) {
-                    body = body.substring(0, idx) +
-                        '<ac:inline-comment-marker ac:ref="' + ref + '">' + needle + '</ac:inline-comment-marker>' +
-                        body.substring(idx + needle.length);
-                    restored.push(ref);
-                    return;
-                }
-            }
-        }
-
-        missed.push(ref);
-    });
-
-    // Strip any leftover placeholder tags so they never render visibly
-    body = body.replace(/\[\[ic:[0-9a-fA-F-]{36}\]\]/g, '');
-    body = body.replace(/\[\[\/ic\]\]/g, '');
-
-    return { body: body, restored: restored, missed: missed };
-}
-
-/**
- * Post-sync step: re-anchor inline comments in the freshly published page body.
- * Fetches the current page storage body and open inline comments, applies
- * applyCommentAnchorsToStorageBody, and updates the page when anything changed.
- */
-function restoreInlineCommentAnchors(page, cfg) {
-    var empty = { restored: [], missed: [] };
-    if (!page || !page.id) return empty;
-
-    var comments = fetchPageInlineComments(page.id, page.title, 100);
-    var withAnchors = comments.filter(function(c) { return !c.resolved && c.markerRef; });
-    if (withAnchors.length === 0) return empty;
-
-    var full = confluence_content_by_id({ contentId: String(page.id) });
-    var storageBody = full && full.body && full.body.storage && full.body.storage.value;
-    if (!storageBody) return empty;
-
-    // Comments already carrying a live marker are left untouched by
-    // applyCommentAnchorsToStorageBody (the ac:ref presence check).
-    var result = applyCommentAnchorsToStorageBody(storageBody, comments);
-    if (result.body === storageBody) return { restored: result.restored, missed: result.missed };
-
-    confluence_update_page({
-        contentId: String(page.id),
-        title: page.title,
-        parentId: cfg.parentPageId,
-        body: result.body,
-        space: cfg.space
-    });
-    return { restored: result.restored, missed: result.missed };
-}
 
 function extractCommentBody(comment) {
     if (!comment) return '';
@@ -527,8 +423,6 @@ if (typeof module !== 'undefined' && module.exports) {
         extractCommentBody: extractCommentBody,
         extractInlineCommentMarkers: extractInlineCommentMarkers,
         injectCommentPlaceholders: injectCommentPlaceholders,
-        applyCommentAnchorsToStorageBody: applyCommentAnchorsToStorageBody,
-        restoreInlineCommentAnchors: restoreInlineCommentAnchors,
         COMMENTS_BASE_NAME: COMMENTS_BASE_NAME,
         DEFAULT_REPLIES_FILE: DEFAULT_REPLIES_FILE
     };

--- a/js/fetchConfluenceOutputContext.js
+++ b/js/fetchConfluenceOutputContext.js
@@ -84,6 +84,25 @@ function action(params) {
                 body = (full && full.body && full.body.storage && full.body.storage.value) || '';
             }
             if (folder && body) {
+                // Preserve inline comment anchors: storage bodies carry them as
+                // <ac:inline-comment-marker> elements which the Markdown conversion
+                // strips. Re-expose them as [[ic:REF]]...[[/ic]] placeholders so the
+                // agent can keep the anchors in its output (publishPage converts them
+                // back after the sync).
+                try {
+                    var storage = confluence_content_by_id({ contentId: existing.id });
+                    var storageBody = storage && storage.body && storage.body.storage && storage.body.storage.value;
+                    var anchors = contentOutput.extractInlineCommentMarkers(storageBody);
+                    if (anchors.length > 0) {
+                        var injected = contentOutput.injectCommentPlaceholders(body, anchors);
+                        body = injected.content;
+                        console.log('fetchConfluenceOutputContext: injected ' + injected.injected.length +
+                            ' inline comment placeholder(s)' +
+                            (injected.missed.length > 0 ? ', ' + injected.missed.length + ' anchor text(s) not found in Markdown' : ''));
+                    }
+                } catch (markerError) {
+                    console.warn('fetchConfluenceOutputContext: marker extraction failed (non-fatal):', markerError);
+                }
                 file_write(folder + '/' + CURRENT_CONTENT_FILE, body);
                 console.log('Wrote current page content to input/' + CURRENT_CONTENT_FILE);
             }

--- a/js/preCliSnapshotSetup.js
+++ b/js/preCliSnapshotSetup.js
@@ -104,7 +104,10 @@ function syncCodegraph(workspace) {
 function action(params) {
     try {
         var actualParams = params.ticket ? params : (params.jobParams || params);
-        var customParams = actualParams.customParams || {};
+        // In the real Teammate execution path customParams live under jobParams
+        // (JavaScriptExecutor.withJobContext puts jobParams/ticket/response at top level);
+        // keep the top-level fallback for direct/JSRunner invocations.
+        var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams || {};
 
         // 1. Preserve existing preCliJSAction behavior by chaining.
         var chained = customParams.chainedPreCliJSAction;

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -75,6 +75,8 @@
         "js/unit-tests/test_createRepoTasksMulti.js",
         "js/unit-tests/test_writeContentOutput.js",
         "js/unit-tests/test_fetchConfluenceOutputContext.js",
+        "js/unit-tests/test_preCliSnapshotSetup.js",
+        "js/unit-tests/test_contentOutput.js",
         "js/unit-tests/test_agentDocsCoverage.js"
       ]
     }

--- a/js/unit-tests/run_preCliSnapshotSetup.json
+++ b/js/unit-tests/run_preCliSnapshotSetup.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_preCliSnapshotSetup.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_contentOutput.js
+++ b/js/unit-tests/test_contentOutput.js
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the inline comment anchor helpers in js/common/contentOutput.js:
+ *   - extractInlineCommentMarkers
+ *   - injectCommentPlaceholders
+ *   - applyCommentAnchorsToStorageBody
+ */
+
+function loadLib() {
+    return loadModule(
+        'js/common/contentOutput.js',
+        makeRequire({ '../configLoader.js': { loadProjectConfig: function() { return {}; } } }),
+        {}
+    );
+}
+
+var REF_A = 'a40ec14d-0d73-4f55-9a69-7026900b6623';
+var REF_B = '11111111-2222-3333-4444-555555555555';
+
+suite('contentOutput.extractInlineCommentMarkers', function() {
+
+    test('extracts markers with refs and plain text', function() {
+        var lib = loadLib();
+        var body = '<p>Hello</p><ul><li><ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker></li></ul>';
+        var anchors = lib.extractInlineCommentMarkers(body);
+        assert.equal(anchors.length, 1);
+        assert.equal(anchors[0].ref, REF_A);
+        assert.equal(anchors[0].text, 'Item one');
+    });
+
+    test('strips nested tags from anchored text', function() {
+        var lib = loadLib();
+        var body = '<p><ac:inline-comment-marker ac:ref="' + REF_A + '">some <strong>bold</strong> text</ac:inline-comment-marker></p>';
+        var anchors = lib.extractInlineCommentMarkers(body);
+        assert.equal(anchors[0].text, 'some bold text');
+    });
+
+    test('returns empty array for empty/markerless body', function() {
+        var lib = loadLib();
+        assert.deepEqual(lib.extractInlineCommentMarkers(''), []);
+        assert.deepEqual(lib.extractInlineCommentMarkers(null), []);
+        assert.deepEqual(lib.extractInlineCommentMarkers('<p>no markers</p>'), []);
+    });
+});
+
+suite('contentOutput.injectCommentPlaceholders', function() {
+
+    test('wraps first occurrence of anchor text', function() {
+        var lib = loadLib();
+        var md = '# Title\n\n- Item one\n- Item one again\n';
+        var result = lib.injectCommentPlaceholders(md, [{ ref: REF_A, text: 'Item one' }]);
+        assert.equal(result.injected.length, 1);
+        assert.ok(result.content.indexOf('[[ic:' + REF_A + ']]Item one[[/ic]]') !== -1);
+        // only the first occurrence is wrapped
+        assert.ok(result.content.indexOf('- Item one again') !== -1);
+    });
+
+    test('skips anchors already present as placeholders', function() {
+        var lib = loadLib();
+        var md = '- [[ic:' + REF_A + ']]Item one[[/ic]]\n';
+        var result = lib.injectCommentPlaceholders(md, [{ ref: REF_A, text: 'Item one' }]);
+        assert.equal(result.injected.length, 0);
+        assert.equal(result.content, md);
+    });
+
+    test('reports anchors whose text is not found', function() {
+        var lib = loadLib();
+        var result = lib.injectCommentPlaceholders('# Nothing here', [{ ref: REF_A, text: 'Missing text' }]);
+        assert.deepEqual(result.missed, [REF_A]);
+    });
+});
+
+suite('contentOutput.applyCommentAnchorsToStorageBody', function() {
+
+    test('converts agent placeholder into real marker', function() {
+        var lib = loadLib();
+        var body = '<ul><li>' + '[[ic:' + REF_A + ']]' + 'Item one' + '[[/ic]]' + '</li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
+        ]);
+        assert.deepEqual(result.restored, [REF_A]);
+        assert.ok(result.body.indexOf('<ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker>') !== -1);
+        assert.ok(result.body.indexOf('[[ic:') === -1);
+    });
+
+    test('falls back to originalSelection text match when placeholder is lost', function() {
+        var lib = loadLib();
+        var body = '<ul><li>Item one</li><li>Item two</li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
+        ]);
+        assert.deepEqual(result.restored, [REF_A]);
+        assert.ok(result.body.indexOf('<ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker>') !== -1);
+    });
+
+    test('matches HTML-escaped anchor text in storage', function() {
+        var lib = loadLib();
+        var body = '<p>Use Foo &amp; Bar here</p>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Foo & Bar', resolved: false }
+        ]);
+        assert.deepEqual(result.restored, [REF_A]);
+        assert.ok(result.body.indexOf('ac:inline-comment-marker') !== -1);
+    });
+
+    test('skips resolved comments and comments without markerRef', function() {
+        var lib = loadLib();
+        var body = '<ul><li>Item one</li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: true },
+            { commentId: '2', markerRef: null, originalSelection: 'Item one', resolved: false }
+        ]);
+        assert.equal(result.body, body);
+        assert.deepEqual(result.restored, []);
+    });
+
+    test('leaves already-anchored comments untouched', function() {
+        var lib = loadLib();
+        var body = '<ul><li><ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker></li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
+        ]);
+        assert.deepEqual(result.restored, [REF_A]);
+        assert.equal(result.body, body);
+    });
+
+    test('reports missed when anchor text is gone', function() {
+        var lib = loadLib();
+        var body = '<p>Completely new content</p>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
+        ]);
+        assert.deepEqual(result.missed, [REF_A]);
+        assert.equal(result.body, body);
+    });
+
+    test('strips leftover placeholder tags with unknown refs', function() {
+        var lib = loadLib();
+        var body = '<ul><li>' + '[[ic:' + REF_B + ']]' + 'Some text' + '[[/ic]]' + '</li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, []);
+        assert.ok(result.body.indexOf('[[ic:') === -1);
+        assert.ok(result.body.indexOf('[[/ic]]') === -1);
+        assert.ok(result.body.indexOf('Some text') !== -1);
+    });
+
+    test('handles multiple comments on the same body', function() {
+        var lib = loadLib();
+        var body = '<ul><li>Item one</li><li>Item two</li></ul>';
+        var result = lib.applyCommentAnchorsToStorageBody(body, [
+            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false },
+            { commentId: '2', markerRef: REF_B, originalSelection: 'Item two', resolved: false }
+        ]);
+        assert.equal(result.restored.length, 2);
+        assert.ok(result.body.indexOf('ac:ref="' + REF_A + '"') !== -1);
+        assert.ok(result.body.indexOf('ac:ref="' + REF_B + '"') !== -1);
+    });
+});

--- a/js/unit-tests/test_contentOutput.js
+++ b/js/unit-tests/test_contentOutput.js
@@ -2,7 +2,10 @@
  * Unit tests for the inline comment anchor helpers in js/common/contentOutput.js:
  *   - extractInlineCommentMarkers
  *   - injectCommentPlaceholders
- *   - applyCommentAnchorsToStorageBody
+ *
+ * Post-sync anchor restoration (placeholder → real marker + text-match fallback)
+ * lives in the dmtools CLI (MarkdownConfluenceSync + InlineCommentAnchorPreserver,
+ * preserveInlineComments default true) and is covered by core tests.
  */
 
 function loadLib() {
@@ -69,88 +72,18 @@ suite('contentOutput.injectCommentPlaceholders', function() {
     });
 });
 
-suite('contentOutput.applyCommentAnchorsToStorageBody', function() {
+suite('contentOutput anchor helpers — sync integration notes', function() {
 
-    test('converts agent placeholder into real marker', function() {
-        var lib = loadLib();
-        var body = '<ul><li>' + '[[ic:' + REF_A + ']]' + 'Item one' + '[[/ic]]' + '</li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
-        ]);
-        assert.deepEqual(result.restored, [REF_A]);
-        assert.ok(result.body.indexOf('<ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker>') !== -1);
-        assert.ok(result.body.indexOf('[[ic:') === -1);
-    });
+    // Post-sync anchor restoration (placeholder → real marker + text-match fallback)
+    // lives in the dmtools CLI (MarkdownConfluenceSync + InlineCommentAnchorPreserver,
+    // dmtools ≥ v1.7.249, enabled by default via preserveInlineComments). The JS side
+    // only prepares [[ic:REF]]...[[/ic]] placeholders in input/confluence_output_current.md.
 
-    test('falls back to originalSelection text match when placeholder is lost', function() {
+    test('placeholder format matches the core sync contract', function() {
         var lib = loadLib();
-        var body = '<ul><li>Item one</li><li>Item two</li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
-        ]);
-        assert.deepEqual(result.restored, [REF_A]);
-        assert.ok(result.body.indexOf('<ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker>') !== -1);
-    });
-
-    test('matches HTML-escaped anchor text in storage', function() {
-        var lib = loadLib();
-        var body = '<p>Use Foo &amp; Bar here</p>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Foo & Bar', resolved: false }
-        ]);
-        assert.deepEqual(result.restored, [REF_A]);
-        assert.ok(result.body.indexOf('ac:inline-comment-marker') !== -1);
-    });
-
-    test('skips resolved comments and comments without markerRef', function() {
-        var lib = loadLib();
-        var body = '<ul><li>Item one</li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: true },
-            { commentId: '2', markerRef: null, originalSelection: 'Item one', resolved: false }
-        ]);
-        assert.equal(result.body, body);
-        assert.deepEqual(result.restored, []);
-    });
-
-    test('leaves already-anchored comments untouched', function() {
-        var lib = loadLib();
-        var body = '<ul><li><ac:inline-comment-marker ac:ref="' + REF_A + '">Item one</ac:inline-comment-marker></li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
-        ]);
-        assert.deepEqual(result.restored, [REF_A]);
-        assert.equal(result.body, body);
-    });
-
-    test('reports missed when anchor text is gone', function() {
-        var lib = loadLib();
-        var body = '<p>Completely new content</p>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false }
-        ]);
-        assert.deepEqual(result.missed, [REF_A]);
-        assert.equal(result.body, body);
-    });
-
-    test('strips leftover placeholder tags with unknown refs', function() {
-        var lib = loadLib();
-        var body = '<ul><li>' + '[[ic:' + REF_B + ']]' + 'Some text' + '[[/ic]]' + '</li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, []);
-        assert.ok(result.body.indexOf('[[ic:') === -1);
-        assert.ok(result.body.indexOf('[[/ic]]') === -1);
-        assert.ok(result.body.indexOf('Some text') !== -1);
-    });
-
-    test('handles multiple comments on the same body', function() {
-        var lib = loadLib();
-        var body = '<ul><li>Item one</li><li>Item two</li></ul>';
-        var result = lib.applyCommentAnchorsToStorageBody(body, [
-            { commentId: '1', markerRef: REF_A, originalSelection: 'Item one', resolved: false },
-            { commentId: '2', markerRef: REF_B, originalSelection: 'Item two', resolved: false }
-        ]);
-        assert.equal(result.restored.length, 2);
-        assert.ok(result.body.indexOf('ac:ref="' + REF_A + '"') !== -1);
-        assert.ok(result.body.indexOf('ac:ref="' + REF_B + '"') !== -1);
+        var md = '- Item one\n';
+        var result = lib.injectCommentPlaceholders(md, [{ ref: REF_A, text: 'Item one' }]);
+        assert.ok(result.content.indexOf('[[ic:' + REF_A + ']]Item one[[/ic]]') !== -1);
     });
 });
+

--- a/js/unit-tests/test_preCliSnapshotSetup.js
+++ b/js/unit-tests/test_preCliSnapshotSetup.js
@@ -102,6 +102,32 @@ suite('preCliSnapshotSetup', function() {
         assert.ok(calls.some(function(c) { return c.indexOf('git checkout develop/3.9.0') !== -1; }), 'checkout command present');
     });
 
+    test('chains existing preCliJSAction when customParams are nested under jobParams (real Teammate path)', function() {
+        // JavaScriptExecutor.withJobContext passes { jobParams, ticket, response } —
+        // customParams live inside jobParams, not at the top level.
+        var calls = [];
+        var chainedCalls = [];
+        var mod = loadModule(
+            'js/preCliSnapshotSetup.js',
+            makeRequire({
+                './configLoader.js': makeConfigLoaderStub('develop/3.9.0'),
+                './config.js': NOOP_CONFIG_JS,
+                './fetchQuestionsToInput.js': makeChainedAction(chainedCalls)
+            }),
+            { cli_execute_command: makeCliMock(calls, {}) }
+        );
+        var result = mod.action({
+            ticket: TICKET,
+            jobParams: {
+                customParams: {
+                    chainedPreCliJSAction: 'fetchQuestionsToInput.js'
+                }
+            }
+        });
+        assert.equal(result, true);
+        assert.deepEqual(chainedCalls, ['chained-action'], 'chained action must fire with jobParams-nested customParams');
+    });
+
     test('checks out snapshot branch and syncs codegraph', function() {
         var calls = [];
         var mod = loadPreCliSnapshotSetup(makeConfigLoaderStub('develop/3.9.0'), {

--- a/js/writeContentOutput.js
+++ b/js/writeContentOutput.js
@@ -84,18 +84,20 @@ function action(params) {
     // 2. Confluence page
     if (contentOutput.isConfluenceTarget(cfg)) {
         try {
-            var published = contentOutput.publishPage(cfg, ticketKey, summary, content);
-            result.pageId = published.page && published.page.id;
-            result.pageUrl = published.url;
-            result.pageCreated = published.created;
-            console.log('Published content to Confluence page ' + result.pageId + ' (' + (result.pageUrl || 'url unknown') + ')');
-
+            // Post replies to inline comments BEFORE the page body is replaced —
+            // while the comment anchors are still alive on the old content.
             var replies = contentOutput.publishCommentReplies(contentOutput.DEFAULT_REPLIES_FILE);
             result.replies = replies;
             if (replies.posted > 0 || replies.failed > 0) {
                 console.log('Replied to ' + replies.posted + ' inline comment(s)' +
                     (replies.failed > 0 ? ', ' + replies.failed + ' failed' : ''));
             }
+
+            var published = contentOutput.publishPage(cfg, ticketKey, summary, content);
+            result.pageId = published.page && published.page.id;
+            result.pageUrl = published.url;
+            result.pageCreated = published.created;
+            console.log('Published content to Confluence page ' + result.pageId + ' (' + (result.pageUrl || 'url unknown') + ')');
 
             if (cfg.updateTrackerField !== false && cfg.target === 'confluence') {
                 var linkText = result.pageUrl

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -139,15 +139,18 @@ function action(params) {
                 if (diagram) {
                     pageContent = pageContent + '\n\n## Diagram\n\n```mermaid\n' + diagram + '\n```\n';
                 }
-                var published = contentOutput.publishPage(outputCfg, ticketKey, ticketSummary, pageContent);
-                var pageUrl = published.url;
-                console.log('Published solution to Confluence page ' + (published.page && published.page.id) + ' (' + (pageUrl || 'url unknown') + ')');
 
+                // Post replies to inline comments BEFORE the page body is replaced —
+                // while the comment anchors are still alive on the old content.
                 var replyResult = contentOutput.publishCommentReplies(contentOutput.DEFAULT_REPLIES_FILE);
                 if (replyResult.posted > 0 || replyResult.failed > 0) {
                     console.log('Replied to ' + replyResult.posted + ' inline comment(s)' +
                         (replyResult.failed > 0 ? ', ' + replyResult.failed + ' failed' : ''));
                 }
+
+                var published = contentOutput.publishPage(outputCfg, ticketKey, ticketSummary, pageContent);
+                var pageUrl = published.url;
+                console.log('Published solution to Confluence page ' + (published.page && published.page.id) + ' (' + (pageUrl || 'url unknown') + ')');
 
                 if (outputCfg.target === 'confluence' && outputCfg.updateTrackerField !== false) {
                     var linkText = pageUrl


### PR DESCRIPTION
## Root cause (one bug behind both symptoms seen on rerun)

**1. Pages still rendered in tracker markup after the 'confluence' tracker-prompt fix.**

`preCliSnapshotSetup` read `customParams` only from the top level of `params`, but the real Teammate execution path nests them under `jobParams` (`JavaScriptExecutor.withJobContext` puts `jobParams`/`ticket`/`response` at the top). So `customParams.chainedPreCliJSAction` never fired → `preCliSolutionSetup` → `fetchConfluenceOutputContext` never ran → no `input/confluence_output_target.json` marker → `confluence_comments.md` explicitly tells the agent to skip the Confluence rules when the marker is absent → the agent fell back to tracker markup examples from the base prompts.

**2. Inline comments disappeared from the page.**

The Markdown sync replaces the page body wholesale, dropping every `ac:inline-comment-marker` anchor. Comments stay in the API but vanish from the page UI.

## Changes

- **`preCliSnapshotSetup`**: read `customParams` from `params.jobParams.customParams` first (same pattern as `preCliDevelopmentSetup.js`). Regression test for the jobParams-nested shape; the test file is now wired into `run_all.json`.
- **`contentOutput.fetchPageInlineComments`**: captures `markerRef` and `originalSelection` (v2 `properties`, v1 `extensions.inlineProperties` fallbacks).
- **Anchor preservation pipeline** — shared with the companion dmtools CLI change (epam/dm.ai#494), which preserves anchors natively in `confluence_sync_markdown_directory` (`preserveInlineComments`, default true) for **every** sync consumer (discovery publishing included):
  - *Pre-CLI* (`fetchConfluenceOutputContext`): existing `ac:inline-comment-marker` elements from the current page's storage body are re-exposed in `input/confluence_output_current.md` as `[[ic:REF]]anchored text[[/ic]]` placeholders (HTML comments don't survive the Markdown→storage conversion; literal tags do — verified).
  - *Agent contract* (`confluence_comments.md`): placeholders must be preserved around the same text, moved to the new equivalent fragment when rephrasing, dropped only together with the commented content. Also: legacy tracker markup in the current content must still be rewritten as Markdown.
  - *Post-sync*: handled by the CLI — placeholders become real markers again; open comments whose placeholder was lost are re-anchored by `originalSelection` text-match.
- **`writeSolutionAndDiagrams` / `writeContentOutput`**: replies to inline comments are posted **before** the page body is replaced, while anchors are still alive.

## Tests

- 812 passed / 0 failed (`run_all.json`).
- End-to-end verified against a live Confluence test page: placeholder survives sync → core post-processing restores the marker → comment anchored again, no visible leftovers.