### PR TITLE
feat(pr_review): opt-in formal GitHub PR review (Approve/Request Changes)

### DIFF
--- a/docs/agents/generated/pr_review.md
+++ b/docs/agents/generated/pr_review.md
@@ -12,6 +12,7 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `autoStartReworkConfigFile` — agent config file used for the auto-started rework workflow.
 - `checkOpenPR` — when `true`, skip tickets that already have an open pull request for this work.
 - `configPath` — path to the project `.dmtools/config.js` to load for this run.
+- `formalGithubReview` — when `true`, in addition to the existing `pr_approved` label, formally submit a native GitHub PR review: `REQUEST_CHANGES` when the AI does not approve, or dismiss any prior `REQUEST_CHANGES` review when the AI approves. Does not change the `pr_approved` label lifecycle.
 - `maxReviewThreadsBeforeForceApprove` — maximum open review threads before the reviewer is forced to an approve/reject verdict.
 - `onApproved` — action to run when the review approves (e.g. trigger merge).
 - `projectKey` — tracker project key override.
@@ -69,6 +70,7 @@ _Post PR Review Comments Action_
   - `autoStartRework`
   - `autoStartReworkConfigFile`
   - `configPath`
+  - `formalGithubReview`
   - `maxReviewThreadsBeforeForceApprove`
   - `onApproved`
   - `projectKey`
@@ -95,6 +97,7 @@ _Post PR Review Comments Action_
 - `autoStartRework` _(used by JS action)_
 - `autoStartReworkConfigFile` _(used by JS action)_
 - `configPath` _(used by JS action)_
+- `formalGithubReview` _(used by JS action)_
 - `maxReviewThreadsBeforeForceApprove` _(used by JS action)_
 - `onApproved` _(used by JS action)_
 - `projectKey` _(used by JS action)_

--- a/docs/agents/pr_review.md
+++ b/docs/agents/pr_review.md
@@ -12,6 +12,7 @@ Configured via `customParams` in the agent JSON or the project `.dmtools/config.
 - `autoStartReworkConfigFile` — agent config file used for the auto-started rework workflow.
 - `checkOpenPR` — when `true`, skip tickets that already have an open pull request for this work.
 - `configPath` — path to the project `.dmtools/config.js` to load for this run.
+- `formalGithubReview` — when `true`, in addition to the existing `pr_approved` label, formally submit a native GitHub PR review: `REQUEST_CHANGES` when the AI does not approve, or dismiss any prior `REQUEST_CHANGES` review when the AI approves. Does not change the `pr_approved` label lifecycle.
 - `maxReviewThreadsBeforeForceApprove` — maximum open review threads before the reviewer is forced to an approve/reject verdict.
 - `onApproved` — action to run when the review approves (e.g. trigger merge).
 - `projectKey` — tracker project key override.

--- a/js/common/scm.js
+++ b/js/common/scm.js
@@ -240,6 +240,24 @@ function _createGithubProvider(workspace, repository) {
         removeLabel: function(prId, label, labelId) {
             return github_remove_pr_label({ workspace: workspace, repository: repository, pullRequestId: String(prId), label: label });
         },
+        // Formal GitHub PR review (Approve / Request Changes / Comment), separate from
+        // the pr_approved label lifecycle. Opt-in feature — see postPRReviewComments.js.
+        submitReview: function(prId, event, body) {
+            return github_submit_pr_review({
+                workspace: workspace, repository: repository,
+                pullRequestId: String(prId), event: event, body: body || ''
+            });
+        },
+        listReviews: function(prId) {
+            var raw = github_list_pr_reviews({ workspace: workspace, repository: repository, pullRequestId: String(prId) });
+            return _toArray(raw);
+        },
+        dismissReview: function(prId, reviewId, message) {
+            return github_dismiss_pr_review({
+                workspace: workspace, repository: repository,
+                pullRequestId: String(prId), reviewId: String(reviewId), message: message
+            });
+        },
         getPrDiff: function(prId, workingDir) {
             var prIdStr = String(prId);
 

--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -610,6 +610,57 @@ function resolveApprovedThreads(scm, pullRequestId, resolvedThreadIds) {
 }
 
 /**
+ * Opt-in native GitHub PR review (formal Approve/Request Changes decision via the
+ * real GitHub Review API), entirely additive to — and independent from — the
+ * pr_approved label lifecycle managed elsewhere in this file. Enabled via
+ * customParams.formalGithubReview = true.
+ *
+ * When AI does not approve (recommendation !== APPROVE, i.e. isApproved === false):
+ *   formally requests changes on the PR (scm.submitReview(..., 'REQUEST_CHANGES', ...)).
+ * When AI approves (isApproved === true):
+ *   dismisses any prior formally-requested-changes review left on the PR so the
+ *   PR is no longer blocked by our own earlier "Request Changes" decision.
+ *
+ * Never touches LABELS.PR_APPROVED or any Jira/GitHub label.
+ */
+function applyFormalGithubReview(scm, pullRequestId, isApproved, recommendation, generalComment) {
+    if (typeof scm.submitReview !== 'function') {
+        console.warn('formalGithubReview: SCM provider does not support submitReview — skipping');
+        return;
+    }
+    try {
+        if (isApproved) {
+            var reviews = [];
+            try {
+                reviews = scm.listReviews(pullRequestId) || [];
+            } catch (listErr) {
+                console.warn('formalGithubReview: failed to list existing reviews:', listErr.message || listErr);
+                return;
+            }
+            var priorChangesRequested = reviews.filter(function(r) {
+                return r && r.state === 'CHANGES_REQUESTED';
+            });
+            priorChangesRequested.forEach(function(r) {
+                try {
+                    scm.dismissReview(pullRequestId, r.id, 'Superseded — issues addressed, AI review now approves.');
+                    console.log('✅ Dismissed prior formal Request Changes review', r.id);
+                } catch (dismissErr) {
+                    console.warn('formalGithubReview: failed to dismiss review ' + r.id + ':', dismissErr.message || dismissErr);
+                }
+            });
+        } else {
+            var body = (generalComment && String(generalComment).trim())
+                ? generalComment
+                : ('AI review returned ' + recommendation + '. See PR comments for details.');
+            scm.submitReview(pullRequestId, 'REQUEST_CHANGES', body);
+            console.log('✅ Submitted formal GitHub Request Changes review');
+        }
+    } catch (e) {
+        console.warn('formalGithubReview: failed to apply formal review:', e.message || e);
+    }
+}
+
+/**
  * Post review results to Jira ticket
  * @param {string} ticketKey - Ticket key
  * @param {string} reviewContent - Review content (from outputs/response.md)
@@ -844,6 +895,12 @@ function action(params) {
             } else {
                 // STATE 2: REQUEST_CHANGES / BLOCK → do NOT merge
                 console.log('PR has issues (' + recommendation + ') - will NOT merge, returning ticket to In Development');
+            }
+
+            // Opt-in: formal GitHub PR review (Approve/Request Changes decision via the
+            // real Review API), independent of the pr_approved label logic above.
+            if (customParams && customParams.formalGithubReview === true) {
+                applyFormalGithubReview(scm, prNumber, isApproved, recommendation, reviewData.generalComment);
             }
 
         } else {

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -421,5 +421,233 @@ suite('postPRReviewComments', function() {
             );
         });
     });
+
+    // ── action(): opt-in formal GitHub PR review (Approve/Request Changes) ────
+    // customParams.formalGithubReview enables a native GitHub review decision via
+    // scm.submitReview/listReviews/dismissReview, entirely additive to — and never
+    // touching — the pr_approved label lifecycle (addLabel/removeLabel).
+    suite('action — formal GitHub PR review (opt-in)', function() {
+
+        function loadPostPRReviewCommentsForFormalReview(opts) {
+            opts = opts || {};
+            var addLabelCalls = [];
+            var submitReviewCalls = [];
+            var dismissReviewCalls = [];
+
+            var scm = {
+                listPrs: function() { return opts.openPrs || []; },
+                getRemoteRepoInfo: function() { return opts.repoInfo !== undefined ? opts.repoInfo : { owner: 'IstiN', repo: 'dmtools-agents' }; },
+                addLabel: function(prId, label) { addLabelCalls.push({ prId: prId, label: label }); },
+                removeLabel: function() {},
+                fetchDiscussions: function() { return { rawThreads: { threads: [] } }; },
+                submitReview: function(prId, event, body) {
+                    submitReviewCalls.push({ prId: prId, event: event, body: body });
+                },
+                listReviews: function() { return opts.existingReviews || []; },
+                dismissReview: function(prId, reviewId, message) {
+                    dismissReviewCalls.push({ prId: prId, reviewId: reviewId, message: message });
+                }
+            };
+
+            var outputFiles = {
+                readOutputFileDetailed: function() {
+                    return { content: JSON.stringify(opts.reviewData), path: 'outputs/pr_review.json' };
+                },
+                readOutputFile: function() { return null; }
+            };
+
+            var mod = loadModule(
+                'js/postPRReviewComments.js',
+                makeRequire({
+                    './config.js': configModule,
+                    './common/scm.js': { createScm: function() { return scm; } },
+                    './common/autoStart.js': {
+                        triggerConfiguredWorkflowForTicket: function() { return false; },
+                        triggerSmIfIdle: function() {}
+                    },
+                    './configLoader.js': {
+                        loadProjectConfig: function() { return opts.config || {}; },
+                        resolveInstructions: function() { return { jobParamPatch: {} }; }
+                    },
+                    './common/outputFiles.js': outputFiles,
+                    './common/githubHelpers.js': githubHelpersStub,
+                    './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+                }),
+                {
+                    file_read: function(args) {
+                        var p = args && (args.path || args);
+                        if (p && p.indexOf('pr_info.md') !== -1) {
+                            return opts.prInfoContent || '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n';
+                        }
+                        return null;
+                    },
+                    jira_add_label: function() {},
+                    jira_move_to_status: function() {},
+                    jira_post_comment: function() {},
+                    jira_remove_label: function() {},
+                    jira_assign_ticket_to: function() {}
+                }
+            );
+
+            return {
+                mod: mod,
+                addLabelCalls: addLabelCalls,
+                submitReviewCalls: submitReviewCalls,
+                dismissReviewCalls: dismissReviewCalls
+            };
+        }
+
+        test('disabled by default: does not submit a formal review when customParams.formalGithubReview is not set', function() {
+            var loaded = loadPostPRReviewCommentsForFormalReview({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                }
+            });
+
+            loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1'
+            });
+
+            assert.equal(loaded.submitReviewCalls.length, 0, 'must not submit a formal review when the opt-in flag is off');
+            assert.equal(loaded.dismissReviewCalls.length, 0, 'must not dismiss a review when the opt-in flag is off');
+        });
+
+        test('enabled + REQUEST_CHANGES: submits a formal Request Changes review, and still adds no pr_approved label', function() {
+            var loaded = loadPostPRReviewCommentsForFormalReview({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    generalComment: 'Blocking issue found in file X.',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                }
+            });
+
+            loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1',
+                customParams: { formalGithubReview: true }
+            });
+
+            assert.equal(loaded.submitReviewCalls.length, 1, 'should submit exactly one formal review');
+            assert.equal(loaded.submitReviewCalls[0].event, 'REQUEST_CHANGES');
+            assert.equal(loaded.submitReviewCalls[0].body, 'Blocking issue found in file X.');
+            assert.equal(loaded.dismissReviewCalls.length, 0);
+            assert.equal(
+                loaded.addLabelCalls.filter(function(c) { return c.label === 'pr_approved'; }).length, 0,
+                'must not touch the pr_approved label logic'
+            );
+        });
+
+        test('enabled + APPROVE: dismisses a prior CHANGES_REQUESTED review, and still adds the pr_approved label as before', function() {
+            var loaded = loadPostPRReviewCommentsForFormalReview({
+                reviewData: {
+                    recommendation: 'APPROVE',
+                    issueCounts: { blocking: 0, important: 0, suggestions: 0 },
+                    inlineComments: []
+                },
+                existingReviews: [
+                    { id: 111, state: 'CHANGES_REQUESTED' },
+                    { id: 222, state: 'APPROVED' }
+                ]
+            });
+
+            loaded.mod.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1',
+                customParams: { formalGithubReview: true }
+            });
+
+            assert.equal(loaded.submitReviewCalls.length, 0, 'must not submit a new review when approving');
+            assert.equal(loaded.dismissReviewCalls.length, 1, 'should dismiss exactly the CHANGES_REQUESTED review');
+            assert.equal(loaded.dismissReviewCalls[0].reviewId, 111);
+            assert.equal(
+                loaded.addLabelCalls.filter(function(c) { return c.label === 'pr_approved'; }).length, 1,
+                'pr_approved label lifecycle on approve must be unchanged'
+            );
+        });
+
+        test('enabled + scm without submitReview support (e.g. non-GitHub provider): skips gracefully, no error thrown', function() {
+            var loaded = loadPostPRReviewCommentsForFormalReview({
+                reviewData: {
+                    recommendation: 'REQUEST_CHANGES',
+                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                    inlineComments: []
+                }
+            });
+            delete loaded.mod; // not used further
+
+            // Re-load with an scm lacking submitReview entirely.
+            var addLabelCalls = [];
+            var mod2 = loadModule(
+                'js/postPRReviewComments.js',
+                makeRequire({
+                    './config.js': configModule,
+                    './common/scm.js': {
+                        createScm: function() {
+                            return {
+                                listPrs: function() { return []; },
+                                getRemoteRepoInfo: function() { return { owner: 'IstiN', repo: 'dmtools-agents' }; },
+                                addLabel: function(prId, label) { addLabelCalls.push({ prId: prId, label: label }); },
+                                removeLabel: function() {},
+                                fetchDiscussions: function() { return { rawThreads: { threads: [] } }; }
+                            };
+                        }
+                    },
+                    './common/autoStart.js': {
+                        triggerConfiguredWorkflowForTicket: function() { return false; },
+                        triggerSmIfIdle: function() {}
+                    },
+                    './configLoader.js': {
+                        loadProjectConfig: function() { return {}; },
+                        resolveInstructions: function() { return { jobParamPatch: {} }; }
+                    },
+                    './common/outputFiles.js': {
+                        readOutputFileDetailed: function() {
+                            return {
+                                content: JSON.stringify({
+                                    recommendation: 'REQUEST_CHANGES',
+                                    issueCounts: { blocking: 1, important: 0, suggestions: 0 },
+                                    inlineComments: []
+                                }),
+                                path: 'outputs/pr_review.json'
+                            };
+                        },
+                        readOutputFile: function() { return null; }
+                    },
+                    './common/githubHelpers.js': githubHelpersStub,
+                    './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+                }),
+                {
+                    file_read: function(args) {
+                        var p = args && (args.path || args);
+                        if (p && p.indexOf('pr_info.md') !== -1) {
+                            return '- **PR #**: 42\n- **URL**: https://github.com/IstiN/dmtools-agents/pull/42\n- **Branch**: bug/PROJ-1\n';
+                        }
+                        return null;
+                    },
+                    jira_add_label: function() {},
+                    jira_move_to_status: function() {},
+                    jira_post_comment: function() {},
+                    jira_remove_label: function() {},
+                    jira_assign_ticket_to: function() {}
+                }
+            );
+
+            var result = mod2.action({
+                ticket: { key: 'PROJ-1', fields: { labels: [] } },
+                response: 'Jira review content',
+                inputFolderPath: 'input/PROJ-1',
+                customParams: { formalGithubReview: true }
+            });
+
+            assert.equal(result.success, true, 'action must still succeed when the scm provider lacks submitReview');
+        });
+    });
 });
 

--- a/snapshots/story_acceptance_criteria.md
+++ b/snapshots/story_acceptance_criteria.md
@@ -482,3 +482,42 @@ When the target tracker is Azure DevOps, replace every generic placeholder tag f
 
 
 ---
+
+### Tracker: `confluence`
+
+#### [1] `./agents/instructions/tracker/confluence_markup_transform.md`
+
+# Confluence Markup Reference
+
+When the generated content is published to Confluence (contentOutput target `confluence`), the body is synced as **Markdown** and converted to Confluence storage format automatically. Replace every generic placeholder tag from the template with the GitHub-flavored Markdown shown below. Do not write literal XML-style tags in the final output.
+
+| Generic placeholder | Markdown | Example |
+|---------------------|----------|---------|
+| `<bold>X</bold>` | `**X**` | `**Background:**` |
+| `<italic>X</italic>` | `*X*` | `*hint*` |
+| `<strike>X</strike>` | `~~X~~` | `~~deprecated~~` |
+| `<underline>X</underline>` | `<u>X</u>` | `<u>important</u>` |
+| `<code>X</code>` | `` `X` `` | `` `main.dart` `` |
+| `<codeblock>X</codeblock>` | ` ```\nX\n``` ` | ` ```\nvoid main() {}\n``` ` |
+| `<codeblock:lang>X</codeblock:lang>` | ` ```lang\nX\n``` ` | ` ```dart\nvoid main() {}\n``` ` |
+| `<bullet> text` | `- text` | `- Option A` |
+| `<numbered> text` | `1. text` | `1. Step one` |
+| `<heading1>X</heading1>` | `# X` | `# Title` |
+| `<heading2>X</heading2>` | `## X` | `## Section` |
+| `<heading3>X</heading3>` | `### X` | `### Subsection` |
+| `<link>text\|url</link>` | `[text](url)` | `[TS-24](https://tracker.example.com/browse/TS-24)` |
+| `<image>url</image>` | `![image](url)` | `![diagram](https://.../diagram.png)` |
+| `<quote>X</quote>` | `> X` | `> cited text` |
+| `<panel>X</panel>` | `> X` | `> note` |
+| `<color color="red">X</color>` | `<span style="color:red">X</span>` | `<span style="color:red">alert</span>` |
+| `<hr>` | `---` | `---` |
+
+## Rules
+
+- Replace every placeholder tag with the Markdown shown above.
+- Do NOT use tracker-specific wiki markup in Confluence output: no `h2.` headings, no `{code}...{code}` blocks, no `{{monospace}}`, no `[text|url]` links.
+- Use `- item` for bullets and `1. item` for numbered lists.
+- For Mermaid diagrams, wrap the diagram in a fenced code block with the `mermaid` language tag: ` ```mermaid\n...\n``` `.
+
+
+---

--- a/snapshots/story_acceptance_criterias.md
+++ b/snapshots/story_acceptance_criterias.md
@@ -406,3 +406,42 @@ When the target tracker is Azure DevOps, replace every generic placeholder tag f
 
 
 ---
+
+### Tracker: `confluence`
+
+#### [1] `./agents/instructions/tracker/confluence_markup_transform.md`
+
+# Confluence Markup Reference
+
+When the generated content is published to Confluence (contentOutput target `confluence`), the body is synced as **Markdown** and converted to Confluence storage format automatically. Replace every generic placeholder tag from the template with the GitHub-flavored Markdown shown below. Do not write literal XML-style tags in the final output.
+
+| Generic placeholder | Markdown | Example |
+|---------------------|----------|---------|
+| `<bold>X</bold>` | `**X**` | `**Background:**` |
+| `<italic>X</italic>` | `*X*` | `*hint*` |
+| `<strike>X</strike>` | `~~X~~` | `~~deprecated~~` |
+| `<underline>X</underline>` | `<u>X</u>` | `<u>important</u>` |
+| `<code>X</code>` | `` `X` `` | `` `main.dart` `` |
+| `<codeblock>X</codeblock>` | ` ```\nX\n``` ` | ` ```\nvoid main() {}\n``` ` |
+| `<codeblock:lang>X</codeblock:lang>` | ` ```lang\nX\n``` ` | ` ```dart\nvoid main() {}\n``` ` |
+| `<bullet> text` | `- text` | `- Option A` |
+| `<numbered> text` | `1. text` | `1. Step one` |
+| `<heading1>X</heading1>` | `# X` | `# Title` |
+| `<heading2>X</heading2>` | `## X` | `## Section` |
+| `<heading3>X</heading3>` | `### X` | `### Subsection` |
+| `<link>text\|url</link>` | `[text](url)` | `[TS-24](https://tracker.example.com/browse/TS-24)` |
+| `<image>url</image>` | `![image](url)` | `![diagram](https://.../diagram.png)` |
+| `<quote>X</quote>` | `> X` | `> cited text` |
+| `<panel>X</panel>` | `> X` | `> note` |
+| `<color color="red">X</color>` | `<span style="color:red">X</span>` | `<span style="color:red">alert</span>` |
+| `<hr>` | `---` | `---` |
+
+## Rules
+
+- Replace every placeholder tag with the Markdown shown above.
+- Do NOT use tracker-specific wiki markup in Confluence output: no `h2.` headings, no `{code}...{code}` blocks, no `{{monospace}}`, no `[text|url]` links.
+- Use `- item` for bullets and `1. item` for numbered lists.
+- For Mermaid diagrams, wrap the diagram in a fenced code block with the `mermaid` language tag: ` ```mermaid\n...\n``` `.
+
+
+---

--- a/snapshots/story_description.md
+++ b/snapshots/story_description.md
@@ -227,3 +227,42 @@ When the target tracker is Azure DevOps, replace every generic placeholder tag f
 
 
 ---
+
+### Tracker: `confluence`
+
+#### [1] `./agents/instructions/tracker/confluence_markup_transform.md`
+
+# Confluence Markup Reference
+
+When the generated content is published to Confluence (contentOutput target `confluence`), the body is synced as **Markdown** and converted to Confluence storage format automatically. Replace every generic placeholder tag from the template with the GitHub-flavored Markdown shown below. Do not write literal XML-style tags in the final output.
+
+| Generic placeholder | Markdown | Example |
+|---------------------|----------|---------|
+| `<bold>X</bold>` | `**X**` | `**Background:**` |
+| `<italic>X</italic>` | `*X*` | `*hint*` |
+| `<strike>X</strike>` | `~~X~~` | `~~deprecated~~` |
+| `<underline>X</underline>` | `<u>X</u>` | `<u>important</u>` |
+| `<code>X</code>` | `` `X` `` | `` `main.dart` `` |
+| `<codeblock>X</codeblock>` | ` ```\nX\n``` ` | ` ```\nvoid main() {}\n``` ` |
+| `<codeblock:lang>X</codeblock:lang>` | ` ```lang\nX\n``` ` | ` ```dart\nvoid main() {}\n``` ` |
+| `<bullet> text` | `- text` | `- Option A` |
+| `<numbered> text` | `1. text` | `1. Step one` |
+| `<heading1>X</heading1>` | `# X` | `# Title` |
+| `<heading2>X</heading2>` | `## X` | `## Section` |
+| `<heading3>X</heading3>` | `### X` | `### Subsection` |
+| `<link>text\|url</link>` | `[text](url)` | `[TS-24](https://tracker.example.com/browse/TS-24)` |
+| `<image>url</image>` | `![image](url)` | `![diagram](https://.../diagram.png)` |
+| `<quote>X</quote>` | `> X` | `> cited text` |
+| `<panel>X</panel>` | `> X` | `> note` |
+| `<color color="red">X</color>` | `<span style="color:red">X</span>` | `<span style="color:red">alert</span>` |
+| `<hr>` | `---` | `---` |
+
+## Rules
+
+- Replace every placeholder tag with the Markdown shown above.
+- Do NOT use tracker-specific wiki markup in Confluence output: no `h2.` headings, no `{code}...{code}` blocks, no `{{monospace}}`, no `[text|url]` links.
+- Use `- item` for bullets and `1. item` for numbered lists.
+- For Mermaid diagrams, wrap the diagram in a fenced code block with the `mermaid` language tag: ` ```mermaid\n...\n``` `.
+
+
+---

--- a/snapshots/story_solution.md
+++ b/snapshots/story_solution.md
@@ -495,3 +495,42 @@ When the target tracker is Azure DevOps, replace every generic placeholder tag f
 
 
 ---
+
+### Tracker: `confluence`
+
+#### [1] `./agents/instructions/tracker/confluence_markup_transform.md`
+
+# Confluence Markup Reference
+
+When the generated content is published to Confluence (contentOutput target `confluence`), the body is synced as **Markdown** and converted to Confluence storage format automatically. Replace every generic placeholder tag from the template with the GitHub-flavored Markdown shown below. Do not write literal XML-style tags in the final output.
+
+| Generic placeholder | Markdown | Example |
+|---------------------|----------|---------|
+| `<bold>X</bold>` | `**X**` | `**Background:**` |
+| `<italic>X</italic>` | `*X*` | `*hint*` |
+| `<strike>X</strike>` | `~~X~~` | `~~deprecated~~` |
+| `<underline>X</underline>` | `<u>X</u>` | `<u>important</u>` |
+| `<code>X</code>` | `` `X` `` | `` `main.dart` `` |
+| `<codeblock>X</codeblock>` | ` ```\nX\n``` ` | ` ```\nvoid main() {}\n``` ` |
+| `<codeblock:lang>X</codeblock:lang>` | ` ```lang\nX\n``` ` | ` ```dart\nvoid main() {}\n``` ` |
+| `<bullet> text` | `- text` | `- Option A` |
+| `<numbered> text` | `1. text` | `1. Step one` |
+| `<heading1>X</heading1>` | `# X` | `# Title` |
+| `<heading2>X</heading2>` | `## X` | `## Section` |
+| `<heading3>X</heading3>` | `### X` | `### Subsection` |
+| `<link>text\|url</link>` | `[text](url)` | `[TS-24](https://tracker.example.com/browse/TS-24)` |
+| `<image>url</image>` | `![image](url)` | `![diagram](https://.../diagram.png)` |
+| `<quote>X</quote>` | `> X` | `> cited text` |
+| `<panel>X</panel>` | `> X` | `> note` |
+| `<color color="red">X</color>` | `<span style="color:red">X</span>` | `<span style="color:red">alert</span>` |
+| `<hr>` | `---` | `---` |
+
+## Rules
+
+- Replace every placeholder tag with the Markdown shown above.
+- Do NOT use tracker-specific wiki markup in Confluence output: no `h2.` headings, no `{code}...{code}` blocks, no `{{monospace}}`, no `[text|url]` links.
+- Use `- item` for bullets and `1. item` for numbered lists.
+- For Mermaid diagrams, wrap the diagram in a fenced code block with the `mermaid` language tag: ` ```mermaid\n...\n``` `.
+
+
+---


### PR DESCRIPTION
## Summary

Adds a new, opt-in `customParams.formalGithubReview` flag to `postPRReviewComments.js` that submits a **native GitHub PR review** (a real Approve / Request Changes reviewer decision via GitHub's Review API) in addition to the existing comment-posting and Jira status logic.

This is entirely separate from — and never modifies — the existing `pr_approved` label add/remove lifecycle. That lifecycle continues to work exactly as before, regardless of this flag.

## Behavior when `formalGithubReview: true`

- On `REQUEST_CHANGES` / `BLOCK`: submits a formal GitHub review with `event=REQUEST_CHANGES` (via `scm.submitReview`).
- On `APPROVE`: looks up existing reviews and dismisses any prior `CHANGES_REQUESTED` review (via `scm.listReviews` + `scm.dismissReview`), so the PR is no longer blocked by our own earlier decision.
- Default (flag unset/false): no behavior change at all.

## Dependency

Requires new GitHub MCP tools added in a companion `epam/dm.ai` PR:
- `github_submit_pr_review`
- `github_list_pr_reviews`
- `github_dismiss_pr_review`

Until that dmtools-core release is picked up, leave `formalGithubReview` unset (default off).

## Testing

- Added unit tests to `test_postPRReviewComments.js`: disabled-by-default, REQUEST_CHANGES submission, APPROVE dismissal, and graceful no-op when the scm provider doesn't support `submitReview`.
- Regenerated `docs/agents/generated/pr_review.md` and documented the new param in `docs/agents/pr_review.md`.
- Full suite: `dmtools run js/unit-tests/run_all.json` → 807 passed, 0 failed.
