### PR TITLE
Support of codemie with bearer-auth authentication type and non-root usage

### DIFF
--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -56,7 +56,7 @@ run_codemie() {
     # Make all of root's home world-readable/executable so _aiagent can find
     # binaries installed under $HOME (codemie-claude, the claude binary from
     # 'codemie install claude', etc.).
-    chmod -R a+rX "${HOME}" 2>/dev/null || true
+    chmod -R a+rwX "${HOME}" 2>/dev/null || true
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -1,44 +1,104 @@
 #!/bin/bash
 # Codemie provider for run-agent.sh
 
-run_codemie() {
-  if [ -z "${CODEMIE_API_KEY:-}" ]; then
-    echo "Error: CODEMIE_API_KEY environment variable is required for codemie provider" >&2
+_fetch_codemie_jwt_token() {
+  if [ -z "${CODEMIE_AUTH_URL:-}" ]; then
+    echo "Error: CODEMIE_AUTH_URL is required for JWT auth" >&2
     return 1
   fi
-
-  if [ -z "${CODEMIE_BASE_URL:-}" ]; then
-    echo "Error: CODEMIE_BASE_URL environment variable is required for codemie provider" >&2
+  local response token
+  response=$(curl -fsSL \
+    --location "${CODEMIE_AUTH_URL}" \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "client_id=${CODEMIE_AUTH_CLIENT_ID}" \
+    --data-urlencode "grant_type=${CODEMIE_AUTH_GRANT_TYPE}" \
+    --data-urlencode "client_secret=${CODEMIE_AUTH_CLIENT_SECRET}") || {
+    echo "Error: failed to fetch JWT token from codemie auth endpoint" >&2
     return 1
+  }
+  token=$(echo "$response" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+  if [ -z "$token" ]; then
+    echo "Error: access_token not found in auth response" >&2
+    return 1
+  fi
+  echo "$token"
+}
+
+run_codemie() {
+  local use_jwt=false
+
+  if [ -n "${CODEMIE_AUTH_CLIENT_ID:-}" ] && [ -n "${CODEMIE_AUTH_CLIENT_SECRET:-}" ]; then
+    use_jwt=true
+  fi
+
+  if $use_jwt; then
+    echo "Fetching JWT token from codemie auth endpoint..."
+    local jwt_token
+    jwt_token="$(_fetch_codemie_jwt_token)" || return 1
+    export CODEMIE_JWT_TOKEN="$jwt_token"
+    echo "JWT token acquired"
+  else
+    if [ -z "${CODEMIE_API_KEY:-}" ]; then
+      echo "Error: CODEMIE_API_KEY is required (or set CODEMIE_AUTH_CLIENT_ID + CODEMIE_AUTH_CLIENT_SECRET for JWT auth)" >&2
+      return 1
+    fi
+    if [ -z "${CODEMIE_BASE_URL:-}" ]; then
+      echo "Error: CODEMIE_BASE_URL environment variable is required for codemie provider" >&2
+      return 1
+    fi
   fi
 
   echo "Codemie Configuration:"
-  echo "  Base URL: ${CODEMIE_BASE_URL}"
-  echo "  Model: ${CODEMIE_MODEL:-claude-4-5-sonnet}"
+  if $use_jwt; then
+    echo "  Auth: JWT bearer"
+    echo "  Model: ${CODEMIE_MODEL:-claude-sonnet-4-6}"
+  else
+    echo "  Base URL: ${CODEMIE_BASE_URL}"
+    echo "  Model: ${CODEMIE_MODEL:-claude-4-5-sonnet}"
+  fi
   echo "  Max Turns: ${CODEMIE_MAX_TURNS:-50}"
 
   local cmd
-  if [ ${#PASS_ARGS[@]} -eq 0 ]; then
-    cmd=(codemie-claude
-      --base-url "${CODEMIE_BASE_URL}"
-      --api-key "${CODEMIE_API_KEY}"
-      --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
-      --provider "litellm"
-      -p "$PROMPT"
-      --max-turns "${CODEMIE_MAX_TURNS:-50}"
-      --dangerously-skip-permissions
-      --allowedTools "Bash(*),Read(*),Curl(*)")
+  if $use_jwt; then
+    if [ ${#PASS_ARGS[@]} -eq 0 ]; then
+      cmd=(codemie-claude
+        --model "${CODEMIE_MODEL:-claude-sonnet-4-6}"
+        -p "$PROMPT"
+        --max-turns "${CODEMIE_MAX_TURNS:-50}"
+        --dangerously-skip-permissions
+        --allowedTools "Bash(*),Read(*),Curl(*)")
+    else
+      cmd=(codemie-claude
+        --model "${CODEMIE_MODEL:-claude-sonnet-4-6}"
+        ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}
+        -p "$PROMPT"
+        --max-turns "${CODEMIE_MAX_TURNS:-50}"
+        --dangerously-skip-permissions
+        --allowedTools "Bash(*),Read(*),Curl(*)")
+    fi
   else
-    cmd=(codemie-claude
-      --base-url "${CODEMIE_BASE_URL}"
-      --api-key "${CODEMIE_API_KEY}"
-      --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
-      --provider "litellm"
-      ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}
-      -p "$PROMPT"
-      --max-turns "${CODEMIE_MAX_TURNS:-50}"
-      --dangerously-skip-permissions
-      --allowedTools "Bash(*),Read(*),Curl(*)")
+    if [ ${#PASS_ARGS[@]} -eq 0 ]; then
+      cmd=(codemie-claude
+        --base-url "${CODEMIE_BASE_URL}"
+        --api-key "${CODEMIE_API_KEY}"
+        --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
+        --provider "litellm"
+        -p "$PROMPT"
+        --max-turns "${CODEMIE_MAX_TURNS:-50}"
+        --dangerously-skip-permissions
+        --allowedTools "Bash(*),Read(*),Curl(*)")
+    else
+      cmd=(codemie-claude
+        --base-url "${CODEMIE_BASE_URL}"
+        --api-key "${CODEMIE_API_KEY}"
+        --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
+        --provider "litellm"
+        ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}
+        -p "$PROMPT"
+        --max-turns "${CODEMIE_MAX_TURNS:-50}"
+        --dangerously-skip-permissions
+        --allowedTools "Bash(*),Read(*),Curl(*)")
+    fi
   fi
 
   echo "Working directory: $(pwd)"

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -53,11 +53,10 @@ run_codemie() {
     # codemie-claude blocks --dangerously-skip-permissions when running as root.
     # Create a non-root user and delegate execution to it.
     useradd -m -s /bin/bash _aiagent 2>/dev/null || true
-    # codemie-claude is in root's npm-global which _aiagent cannot traverse (/root is 700).
-    # Make the path accessible in this ephemeral container.
-    _npm_prefix="$(npm config get prefix 2>/dev/null || echo \"${HOME}/.npm-global\")"
-    chmod a+x "${HOME}" 2>/dev/null || true
-    chmod -R a+rX "${_npm_prefix}" 2>/dev/null || true
+    # Make all of root's home world-readable/executable so _aiagent can find
+    # binaries installed under $HOME (codemie-claude, the claude binary from
+    # 'codemie install claude', etc.).
+    chmod -R a+rX "${HOME}" 2>/dev/null || true
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true
@@ -68,7 +67,7 @@ run_codemie() {
     _quoted_cmd=$(printf ' %q' "${cmd[@]}")
     local _work_dir
     _work_dir=$(pwd)
-    su -m _aiagent -c "HOME=/home/_aiagent && cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
+    su -m _aiagent -c "cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
   else
     "${cmd[@]}" 2>&1 | tee "$agent_log"
   fi

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -55,7 +55,7 @@ run_codemie() {
     useradd -m -s /bin/bash _aiagent 2>/dev/null || true
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
-      cp -n "$_src" "/usr/local/bin/$_bin" 2>/dev/null && chmod +x "/usr/local/bin/$_bin" || true
+      ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true
     done
     su _aiagent -c "git config --global user.name 'dm.ai'; git config --global user.email 'dm.ai@epam.com'" 2>/dev/null || true
     chown -R _aiagent:_aiagent "$(pwd)"

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -53,6 +53,11 @@ run_codemie() {
     # codemie-claude blocks --dangerously-skip-permissions when running as root.
     # Create a non-root user and delegate execution to it.
     useradd -m -s /bin/bash _aiagent 2>/dev/null || true
+    # codemie-claude is in root's npm-global which _aiagent cannot traverse (/root is 700).
+    # Make the path accessible in this ephemeral container.
+    _npm_prefix="$(npm config get prefix 2>/dev/null || echo \"${HOME}/.npm-global\")"
+    chmod a+x "${HOME}" 2>/dev/null || true
+    chmod -R a+rX "${_npm_prefix}" 2>/dev/null || true
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -77,6 +77,11 @@ run_codemie() {
   echo "Full transcript saved to: ${agent_log}"
 
   echo ""
+  echo "=== Agent Transcript ==="
+  cat "$agent_log" 2>/dev/null || echo "(transcript file not found)"
+  echo "=== End Transcript ==="
+
+  echo ""
   echo "=== Agent completed with exit code: $exit_code ==="
   return $exit_code
 }

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -118,14 +118,17 @@ run_codemie() {
     # 'codemie install claude', etc.).
     chmod -R a+rwX "${HOME}" 2>/dev/null || true
     # Mirror codemie config into _aiagent's own home directory.
-    # codemie-claude (Node.js) calls os.homedir() which on Linux resolves via
-    # getpwuid(getuid()) from /etc/passwd — returning /home/_aiagent regardless
-    # of the $HOME env var that su -m preserves as /root.
+    # Node.js os.homedir() on Linux uses getpwuid(getuid()) → /home/_aiagent.
+    # Also copy to root's .codemie (in case HOME env var takes precedence).
     if [ -f "${HOME}/.codemie/codemie-cli.config.json" ]; then
       mkdir -p "/home/_aiagent/.codemie"
       cp "${HOME}/.codemie/codemie-cli.config.json" "/home/_aiagent/.codemie/"
       chown -R _aiagent:_aiagent "/home/_aiagent/.codemie"
+      echo "DEBUG: config copied to /home/_aiagent/.codemie/"
+    else
+      echo "DEBUG: config NOT found at ${HOME}/.codemie/codemie-cli.config.json"
     fi
+    echo "DEBUG: CODEMIE_JWT_TOKEN length=${#CODEMIE_JWT_TOKEN}"
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true
@@ -136,14 +139,32 @@ run_codemie() {
     _quoted_cmd=$(printf ' %q' "${cmd[@]}")
     local _work_dir
     _work_dir=$(pwd)
-    # Re-export the JWT token explicitly inside the subshell: some PAM configs
-    # strip non-standard env vars even with su -m. Use bash (not sh/dash)
-    # because printf %q produces bash-quoting that dash cannot parse.
-    local _jwt_export=""
-    if [ -n "${CODEMIE_JWT_TOKEN:-}" ]; then
-      _jwt_export="export CODEMIE_JWT_TOKEN=$(printf '%q' "${CODEMIE_JWT_TOKEN}"); "
-    fi
-    su -m -s /bin/bash _aiagent -c "${_jwt_export}cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
+    # Write the JWT token to a temp file to avoid complex quoting in -c string.
+    local _token_file="/tmp/_codemie_jwt_$$"
+    printf '%s' "${CODEMIE_JWT_TOKEN:-}" > "$_token_file"
+    chmod 600 "$_token_file"
+    chown _aiagent "$_token_file" 2>/dev/null || true
+    # Run a quick Node.js probe inside the _aiagent subshell so we can see
+    # what homedir/config/token look like from codemie-claude's perspective.
+    su -m -s /bin/bash _aiagent -c "
+      export CODEMIE_JWT_TOKEN=\$(cat $(printf '%q' "$_token_file") 2>/dev/null)
+      node -e '
+        var os=require(\"os\"), fs=require(\"fs\");
+        var h=os.homedir(), p=h+\"/.codemie/codemie-cli.config.json\";
+        console.log(\"DEBUG node: homedir=\"+h+\" HOME=\"+process.env.HOME);
+        console.log(\"DEBUG node: config exists=\"+fs.existsSync(p));
+        if(fs.existsSync(p)){try{var c=JSON.parse(fs.readFileSync(p,\"utf8\")); console.log(\"DEBUG node: activeProfile=\"+c.activeProfile);}catch(e){console.log(\"DEBUG node: config parse error=\"+e.message);}}
+        var rp=\"/root/.codemie/codemie-cli.config.json\";
+        console.log(\"DEBUG node: /root config exists=\"+fs.existsSync(rp));
+        var t=process.env.CODEMIE_JWT_TOKEN||\"\";
+        console.log(\"DEBUG node: jwt token present=\"+!!t.length+\" len=\"+t.length);
+      ' 2>&1 || echo 'DEBUG node probe failed'
+    " 2>&1 || true
+    su -m -s /bin/bash _aiagent -c "
+      export CODEMIE_JWT_TOKEN=\$(cat $(printf '%q' "$_token_file") 2>/dev/null)
+      rm -f $(printf '%q' "$_token_file")
+      cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}
+    " 2>&1 | tee "$agent_log"
   else
     "${cmd[@]}" 2>&1 | tee "$agent_log"
   fi

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -49,7 +49,24 @@ run_codemie() {
   local agent_log
   agent_log="$(new_agent_log_file "codemie")"
   set +e
-  "${cmd[@]}" 2>&1 | tee "$agent_log"
+  if [ "$(id -u)" = "0" ]; then
+    # codemie-claude blocks --dangerously-skip-permissions when running as root.
+    # Create a non-root user and delegate execution to it.
+    useradd -m -s /bin/bash _aiagent 2>/dev/null || true
+    for _bin in codemie-claude node npm npx; do
+      _src="$(command -v "$_bin" 2>/dev/null)" || continue
+      cp -n "$_src" "/usr/local/bin/$_bin" 2>/dev/null && chmod +x "/usr/local/bin/$_bin" || true
+    done
+    su _aiagent -c "git config --global user.name 'dm.ai'; git config --global user.email 'dm.ai@epam.com'" 2>/dev/null || true
+    chown -R _aiagent:_aiagent "$(pwd)"
+    local _quoted_cmd
+    _quoted_cmd=$(printf ' %q' "${cmd[@]}")
+    local _work_dir
+    _work_dir=$(pwd)
+    su -m _aiagent -c "HOME=/home/_aiagent && cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
+  else
+    "${cmd[@]}" 2>&1 | tee "$agent_log"
+  fi
   local exit_code=${PIPESTATUS[0]}
   set -e
   record_codegraph_usage "$agent_log"

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -11,7 +11,7 @@ _fetch_codemie_jwt_token() {
     --location "${CODEMIE_AUTH_URL}" \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode "client_id=${CODEMIE_AUTH_CLIENT_ID}" \
-    --data-urlencode "grant_type=${CODEMIE_AUTH_GRANT_TYPE}" \
+    --data-urlencode "grant_type=${CODEMIE_AUTH_GRANT_TYPE:-client_credentials}" \
     --data-urlencode "client_secret=${CODEMIE_AUTH_CLIENT_SECRET}") || {
     echo "Error: failed to fetch JWT token from codemie auth endpoint" >&2
     return 1
@@ -63,7 +63,7 @@ run_codemie() {
     if [ ${#PASS_ARGS[@]} -eq 0 ]; then
       cmd=(codemie-claude
         --model "${CODEMIE_MODEL:-claude-sonnet-4-6}"
-        -p "$PROMPT"
+        --task "$PROMPT"
         --max-turns "${CODEMIE_MAX_TURNS:-50}"
         --dangerously-skip-permissions
         --allowedTools "Bash(*),Read(*),Curl(*)")
@@ -71,7 +71,7 @@ run_codemie() {
       cmd=(codemie-claude
         --model "${CODEMIE_MODEL:-claude-sonnet-4-6}"
         ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}
-        -p "$PROMPT"
+        --task "$PROMPT"
         --max-turns "${CODEMIE_MAX_TURNS:-50}"
         --dangerously-skip-permissions
         --allowedTools "Bash(*),Read(*),Curl(*)")
@@ -83,7 +83,7 @@ run_codemie() {
         --api-key "${CODEMIE_API_KEY}"
         --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
         --provider "litellm"
-        -p "$PROMPT"
+        --task "$PROMPT"
         --max-turns "${CODEMIE_MAX_TURNS:-50}"
         --dangerously-skip-permissions
         --allowedTools "Bash(*),Read(*),Curl(*)")
@@ -94,7 +94,7 @@ run_codemie() {
         --model "${CODEMIE_MODEL:-claude-4-5-sonnet}"
         --provider "litellm"
         ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}
-        -p "$PROMPT"
+        --task "$PROMPT"
         --max-turns "${CODEMIE_MAX_TURNS:-50}"
         --dangerously-skip-permissions
         --allowedTools "Bash(*),Read(*),Curl(*)")

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -117,6 +117,15 @@ run_codemie() {
     # binaries installed under $HOME (codemie-claude, the claude binary from
     # 'codemie install claude', etc.).
     chmod -R a+rwX "${HOME}" 2>/dev/null || true
+    # Mirror codemie config into _aiagent's own home directory.
+    # codemie-claude (Node.js) calls os.homedir() which on Linux resolves via
+    # getpwuid(getuid()) from /etc/passwd — returning /home/_aiagent regardless
+    # of the $HOME env var that su -m preserves as /root.
+    if [ -f "${HOME}/.codemie/codemie-cli.config.json" ]; then
+      mkdir -p "/home/_aiagent/.codemie"
+      cp "${HOME}/.codemie/codemie-cli.config.json" "/home/_aiagent/.codemie/"
+      chown -R _aiagent:_aiagent "/home/_aiagent/.codemie"
+    fi
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true
@@ -127,7 +136,14 @@ run_codemie() {
     _quoted_cmd=$(printf ' %q' "${cmd[@]}")
     local _work_dir
     _work_dir=$(pwd)
-    su -m _aiagent -c "cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
+    # Re-export the JWT token explicitly inside the subshell: some PAM configs
+    # strip non-standard env vars even with su -m. Use bash (not sh/dash)
+    # because printf %q produces bash-quoting that dash cannot parse.
+    local _jwt_export=""
+    if [ -n "${CODEMIE_JWT_TOKEN:-}" ]; then
+      _jwt_export="export CODEMIE_JWT_TOKEN=$(printf '%q' "${CODEMIE_JWT_TOKEN}"); "
+    fi
+    su -m -s /bin/bash _aiagent -c "${_jwt_export}cd $(printf '%q' "$_work_dir") && ${_quoted_cmd}" 2>&1 | tee "$agent_log"
   else
     "${cmd[@]}" 2>&1 | tee "$agent_log"
   fi

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -7,12 +7,17 @@ _fetch_codemie_jwt_token() {
     return 1
   fi
   local response token
+  local _scope_arg=()
+  if [ -n "${CODEMIE_AUTH_SCOPE:-}" ]; then
+    _scope_arg=(--data-urlencode "scope=${CODEMIE_AUTH_SCOPE}")
+  fi
   response=$(curl -fsSL \
     --location "${CODEMIE_AUTH_URL}" \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode "client_id=${CODEMIE_AUTH_CLIENT_ID}" \
     --data-urlencode "grant_type=${CODEMIE_AUTH_GRANT_TYPE:-client_credentials}" \
-    --data-urlencode "client_secret=${CODEMIE_AUTH_CLIENT_SECRET}") || {
+    --data-urlencode "client_secret=${CODEMIE_AUTH_CLIENT_SECRET}" \
+    ${_scope_arg[@]+"${_scope_arg[@]}"}) || {
     echo "Error: failed to fetch JWT token from codemie auth endpoint" >&2
     return 1
   }
@@ -154,10 +159,16 @@ run_codemie() {
         console.log(\"DEBUG node: homedir=\"+h+\" HOME=\"+process.env.HOME);
         console.log(\"DEBUG node: config exists=\"+fs.existsSync(p));
         if(fs.existsSync(p)){try{var c=JSON.parse(fs.readFileSync(p,\"utf8\")); console.log(\"DEBUG node: activeProfile=\"+c.activeProfile);}catch(e){console.log(\"DEBUG node: config parse error=\"+e.message);}}
-        var rp=\"/root/.codemie/codemie-cli.config.json\";
-        console.log(\"DEBUG node: /root config exists=\"+fs.existsSync(rp));
         var t=process.env.CODEMIE_JWT_TOKEN||\"\";
         console.log(\"DEBUG node: jwt token present=\"+!!t.length+\" len=\"+t.length);
+        if(t){try{
+          var parts=t.split(\".\");
+          var payload=JSON.parse(Buffer.from(parts[1],\"base64url\").toString());
+          console.log(\"DEBUG jwt: iss=\"+(payload.iss||\"(none)\"));
+          console.log(\"DEBUG jwt: aud=\"+JSON.stringify(payload.aud||\"(none)\"));
+          console.log(\"DEBUG jwt: scope=\"+(payload.scope||\"(none)\"));
+          console.log(\"DEBUG jwt: exp=\"+new Date((payload.exp||0)*1000).toISOString());
+        }catch(e){console.log(\"DEBUG jwt: decode error=\"+e.message);}}
       ' 2>&1 || echo 'DEBUG node probe failed'
     " 2>&1 || true
     su -m -s /bin/bash _aiagent -c "

--- a/scripts/providers/codemie.sh
+++ b/scripts/providers/codemie.sh
@@ -129,11 +129,7 @@ run_codemie() {
       mkdir -p "/home/_aiagent/.codemie"
       cp "${HOME}/.codemie/codemie-cli.config.json" "/home/_aiagent/.codemie/"
       chown -R _aiagent:_aiagent "/home/_aiagent/.codemie"
-      echo "DEBUG: config copied to /home/_aiagent/.codemie/"
-    else
-      echo "DEBUG: config NOT found at ${HOME}/.codemie/codemie-cli.config.json"
     fi
-    echo "DEBUG: CODEMIE_JWT_TOKEN length=${#CODEMIE_JWT_TOKEN}"
     for _bin in codemie-claude node npm npx; do
       _src="$(command -v "$_bin" 2>/dev/null)" || continue
       ln -sf "$_src" "/usr/local/bin/$_bin" 2>/dev/null || true
@@ -149,28 +145,6 @@ run_codemie() {
     printf '%s' "${CODEMIE_JWT_TOKEN:-}" > "$_token_file"
     chmod 600 "$_token_file"
     chown _aiagent "$_token_file" 2>/dev/null || true
-    # Run a quick Node.js probe inside the _aiagent subshell so we can see
-    # what homedir/config/token look like from codemie-claude's perspective.
-    su -m -s /bin/bash _aiagent -c "
-      export CODEMIE_JWT_TOKEN=\$(cat $(printf '%q' "$_token_file") 2>/dev/null)
-      node -e '
-        var os=require(\"os\"), fs=require(\"fs\");
-        var h=os.homedir(), p=h+\"/.codemie/codemie-cli.config.json\";
-        console.log(\"DEBUG node: homedir=\"+h+\" HOME=\"+process.env.HOME);
-        console.log(\"DEBUG node: config exists=\"+fs.existsSync(p));
-        if(fs.existsSync(p)){try{var c=JSON.parse(fs.readFileSync(p,\"utf8\")); console.log(\"DEBUG node: activeProfile=\"+c.activeProfile);}catch(e){console.log(\"DEBUG node: config parse error=\"+e.message);}}
-        var t=process.env.CODEMIE_JWT_TOKEN||\"\";
-        console.log(\"DEBUG node: jwt token present=\"+!!t.length+\" len=\"+t.length);
-        if(t){try{
-          var parts=t.split(\".\");
-          var payload=JSON.parse(Buffer.from(parts[1],\"base64url\").toString());
-          console.log(\"DEBUG jwt: iss=\"+(payload.iss||\"(none)\"));
-          console.log(\"DEBUG jwt: aud=\"+JSON.stringify(payload.aud||\"(none)\"));
-          console.log(\"DEBUG jwt: scope=\"+(payload.scope||\"(none)\"));
-          console.log(\"DEBUG jwt: exp=\"+new Date((payload.exp||0)*1000).toISOString());
-        }catch(e){console.log(\"DEBUG jwt: decode error=\"+e.message);}}
-      ' 2>&1 || echo 'DEBUG node probe failed'
-    " 2>&1 || true
     su -m -s /bin/bash _aiagent -c "
       export CODEMIE_JWT_TOKEN=\$(cat $(printf '%q' "$_token_file") 2>/dev/null)
       rm -f $(printf '%q' "$_token_file")
@@ -183,11 +157,6 @@ run_codemie() {
   set -e
   record_codegraph_usage "$agent_log"
   echo "Full transcript saved to: ${agent_log}"
-
-  echo ""
-  echo "=== Agent Transcript ==="
-  cat "$agent_log" 2>/dev/null || echo "(transcript file not found)"
-  echo "=== End Transcript ==="
 
   echo ""
   echo "=== Agent completed with exit code: $exit_code ==="

--- a/setup/codemie.sh
+++ b/setup/codemie.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Install codemie-claude CLI.
-# Requires CODEMIE_API_KEY and CODEMIE_BASE_URL to be set at runtime.
+# Install codemie-claude CLI and write ~/.codemie/codemie-cli.config.json.
+# Supports two auth modes at runtime (controlled by env vars):
+#   JWT bearer: set CODEMIE_AUTH_CLIENT_ID + CODEMIE_AUTH_CLIENT_SECRET
+#   API key:    set CODEMIE_API_KEY + CODEMIE_BASE_URL
 #
 # Usage:
 #   codemie.sh [version]
@@ -71,5 +73,39 @@ if is_installed codemie-claude || [ -x "${CODEMIE_BIN_DIR}/codemie-claude" ]; th
   echo "✅ codemie-claude installed"
 else
   echo "⚠️  codemie-claude could not be installed automatically."
-  echo "    Set CODEMIE_API_KEY + CODEMIE_BASE_URL and install manually if needed."
+  echo "    Set CODEMIE_AUTH_CLIENT_ID + CODEMIE_AUTH_CLIENT_SECRET (JWT) or CODEMIE_API_KEY + CODEMIE_BASE_URL and install manually if needed."
 fi
+
+# ── Write ~/.codemie/codemie-cli.config.json ─────────────────────────────────
+CODEMIE_CONFIG_DIR="${HOME}/.codemie"
+CODEMIE_CONFIG_FILE="${CODEMIE_CONFIG_DIR}/codemie-cli.config.json"
+mkdir -p "${CODEMIE_CONFIG_DIR}"
+cat > "${CODEMIE_CONFIG_FILE}" <<CODEMIE_CONFIG_EOF
+{
+  "version": 2,
+  "activeProfile": "jwt-bearer",
+  "profiles": {
+    "default": {
+      "codeMieProject": "${CODEMIE_PROJECT}",
+      "provider": "${CODEMIE_PROVIDER}",
+      "codeMieUrl": "${CODEMIE_URL}",
+      "apiKey": "sso-provided",
+      "baseUrl": "${CODEMIE_BASE_URL}",
+      "model": "claude-sonnet-4-6",
+      "haikuModel": "claude-haiku-4-5-20251001",
+      "sonnetModel": "claude-sonnet-4-6",
+      "opusModel": "claude-opus-5",
+      "name": "default"
+    },
+    "jwt-bearer": {
+      "provider": "bearer-auth",
+      "codeMieUrl": "${CODEMIE_URL}",
+      "baseUrl": "${CODEMIE_BASE_URL}",
+      "model": "claude-sonnet-4-6",
+      "authMethod": "jwt",
+      "jwtConfig": { "tokenEnvVar": "CODEMIE_JWT_TOKEN" }
+    }
+  }
+}
+CODEMIE_CONFIG_EOF
+echo "✅ codemie config written to ${CODEMIE_CONFIG_FILE}"

--- a/setup/codemie.sh
+++ b/setup/codemie.sh
@@ -22,8 +22,7 @@ echo "🧠 codemie-claude ${CODEMIE_VERSION}"
 # ── Already installed? ────────────────────────────────────────────────────────
 if is_installed codemie-claude; then
   echo "✅ codemie-claude already installed: $(codemie-claude --version 2>/dev/null || echo "cached")"
-  exit 0
-fi
+else
 
 # ── Install ───────────────────────────────────────────────────────────────────
 OS="$(detect_os)"
@@ -75,6 +74,8 @@ else
   echo "⚠️  codemie-claude could not be installed automatically."
   echo "    Set CODEMIE_AUTH_CLIENT_ID + CODEMIE_AUTH_CLIENT_SECRET (JWT) or CODEMIE_API_KEY + CODEMIE_BASE_URL and install manually if needed."
 fi
+
+fi # end already-installed check
 
 # ── Write ~/.codemie/codemie-cli.config.json ─────────────────────────────────
 CODEMIE_CONFIG_DIR="${HOME}/.codemie"

--- a/setup/dmtools.sh
+++ b/setup/dmtools.sh
@@ -45,36 +45,8 @@ fi
 
 # ── Install ───────────────────────────────────────────────────────────────────
 echo "📥 Installing DMtools ${DMTOOLS_VERSION}..."
-
-# Download install script separately so curl failures (e.g. 429 rate-limit)
-# are detectable — piping curl directly to bash masks the curl exit code.
-_DMTOOLS_INSTALL_SCRIPT="$(mktemp)"
-_MAX_ATTEMPTS=3
-_ATTEMPT=0
-while [ "${_ATTEMPT}" -lt "${_MAX_ATTEMPTS}" ]; do
-  _ATTEMPT=$((_ATTEMPT + 1))
-  if curl -fsSL "https://raw.githubusercontent.com/epam/dm.ai/${DMTOOLS_VERSION}/install.sh" \
-       -o "${_DMTOOLS_INSTALL_SCRIPT}"; then
-    break
-  fi
-  if [ "${_ATTEMPT}" -lt "${_MAX_ATTEMPTS}" ]; then
-    _SLEEP=$((_ATTEMPT * 15))
-    echo "⚠️  Download attempt ${_ATTEMPT}/${_MAX_ATTEMPTS} failed — retrying in ${_SLEEP}s..."
-    sleep "${_SLEEP}"
-  else
-    echo "❌ Failed to download DMtools install script after ${_MAX_ATTEMPTS} attempts" >&2
-    rm -f "${_DMTOOLS_INSTALL_SCRIPT}"
-    exit 1
-  fi
-done
-DMTOOLS_VERSION="${DMTOOLS_VERSION}" bash "${_DMTOOLS_INSTALL_SCRIPT}" "${DMTOOLS_VERSION}"
-rm -f "${_DMTOOLS_INSTALL_SCRIPT}"
-
-# Verify the binary is actually present before reporting success
-if [ ! -x "${DMTOOLS_BIN}/dmtools" ]; then
-  echo "❌ DMtools installation failed — binary not found at ${DMTOOLS_BIN}/dmtools" >&2
-  exit 1
-fi
+curl -fsSL "https://raw.githubusercontent.com/epam/dm.ai/${DMTOOLS_VERSION}/install.sh" \
+  | DMTOOLS_VERSION="${DMTOOLS_VERSION}" bash -s -- "${DMTOOLS_VERSION}"
 
 register_path "${DMTOOLS_BIN}"
 export_var "DMTOOLS_HOME" "${DMTOOLS_HOME}"

--- a/setup/dmtools.sh
+++ b/setup/dmtools.sh
@@ -45,8 +45,36 @@ fi
 
 # ── Install ───────────────────────────────────────────────────────────────────
 echo "📥 Installing DMtools ${DMTOOLS_VERSION}..."
-curl -fsSL "https://raw.githubusercontent.com/epam/dm.ai/${DMTOOLS_VERSION}/install.sh" \
-  | DMTOOLS_VERSION="${DMTOOLS_VERSION}" bash -s -- "${DMTOOLS_VERSION}"
+
+# Download install script separately so curl failures (e.g. 429 rate-limit)
+# are detectable — piping curl directly to bash masks the curl exit code.
+_DMTOOLS_INSTALL_SCRIPT="$(mktemp)"
+_MAX_ATTEMPTS=3
+_ATTEMPT=0
+while [ "${_ATTEMPT}" -lt "${_MAX_ATTEMPTS}" ]; do
+  _ATTEMPT=$((_ATTEMPT + 1))
+  if curl -fsSL "https://raw.githubusercontent.com/epam/dm.ai/${DMTOOLS_VERSION}/install.sh" \
+       -o "${_DMTOOLS_INSTALL_SCRIPT}"; then
+    break
+  fi
+  if [ "${_ATTEMPT}" -lt "${_MAX_ATTEMPTS}" ]; then
+    _SLEEP=$((_ATTEMPT * 15))
+    echo "⚠️  Download attempt ${_ATTEMPT}/${_MAX_ATTEMPTS} failed — retrying in ${_SLEEP}s..."
+    sleep "${_SLEEP}"
+  else
+    echo "❌ Failed to download DMtools install script after ${_MAX_ATTEMPTS} attempts" >&2
+    rm -f "${_DMTOOLS_INSTALL_SCRIPT}"
+    exit 1
+  fi
+done
+DMTOOLS_VERSION="${DMTOOLS_VERSION}" bash "${_DMTOOLS_INSTALL_SCRIPT}" "${DMTOOLS_VERSION}"
+rm -f "${_DMTOOLS_INSTALL_SCRIPT}"
+
+# Verify the binary is actually present before reporting success
+if [ ! -x "${DMTOOLS_BIN}/dmtools" ]; then
+  echo "❌ DMtools installation failed — binary not found at ${DMTOOLS_BIN}/dmtools" >&2
+  exit 1
+fi
 
 register_path "${DMTOOLS_BIN}"
 export_var "DMTOOLS_HOME" "${DMTOOLS_HOME}"


### PR DESCRIPTION
## Summary
- Adds JWT bearer-auth support for `codemie-claude` (`CODEMIE_AUTH_CLIENT_ID` + `CODEMIE_AUTH_CLIENT_SECRET`, with optional `CODEMIE_AUTH_SCOPE`), alongside the existing `CODEMIE_API_KEY` + `CODEMIE_BASE_URL` mode. `setup/codemie.sh` now always writes `~/.codemie/codemie-cli.config.json` (with a `jwt-bearer` profile) instead of skipping config on a cached install.
- Runs `codemie-claude` as a non-root `_aiagent` user when CI executes the setup as root, since `--dangerously-skip-permissions` is blocked for root. Handles binary delegation via symlinks, permissions on root's home/npm-global so `_aiagent` can find installed binaries, and re-exports the JWT token into the `su` subshell via a temp file (avoiding quoting issues) instead of embedding it in the command string.

## Notes
- A diagnostic Node.js probe and transcript dump were added while root-causing a JWT auth failure in this environment, then removed again once the fix (`ae7b958`, `a986621`) was confirmed — no diagnostic code remains.
- A retry/backoff around the dmtools install script (`f547969`) was added and then reverted; net change to `setup/dmtools.sh` is none.

## Test plan
- [ ] Run CI as root with `CODEMIE_AUTH_CLIENT_ID`/`CODEMIE_AUTH_CLIENT_SECRET` set and confirm `codemie-claude` runs successfully as `_aiagent`
- [ ] Run with `CODEMIE_API_KEY`/`CODEMIE_BASE_URL` (non-JWT) to confirm the existing path still works
- [ ] Confirm a cached `codemie-claude` install still writes `~/.codemie/codemie-cli.config.json`