### PR TITLE
fix(contentOutput): Markdown diagram + Affected Repositories section on Confluence pages

### DIFF
--- a/instructions/common/confluence_comments.md
+++ b/instructions/common/confluence_comments.md
@@ -8,6 +8,7 @@ When `input/confluence_output_target.json` is present, your output is published 
 
 - Write `outputs/response.md` as **Markdown** — it is converted to Confluence storage format on publish. Do NOT use tracker-specific markup (no Jira `{code}` / `h2.` / ADF), even if other instructions ask for it; Markdown wins for this output.
 - If `input/confluence_output_current.md` exists, it contains the page's current content — iterate on it instead of rewriting from scratch. The current content may be in legacy tracker markup from earlier runs — still write your output in Markdown.
+- The current content may end with `## Diagram` and/or `## Affected Repositories` sections — these are managed by the publish step and refreshed automatically. Do NOT copy them into your output; any copies are stripped to avoid duplicates.
 
 ## Inline comment anchors (`[[ic:...]]` placeholders)
 

--- a/js/unit-tests/test_writeSolutionAndDiagrams.js
+++ b/js/unit-tests/test_writeSolutionAndDiagrams.js
@@ -24,6 +24,156 @@ suite('writeSolutionAndDiagrams — module export', function() {
     });
 });
 
+suite('writeSolutionAndDiagrams — diagram handling for Confluence targets', function() {
+
+    function loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, repliesFile, affectedRepos) {
+        var outputFilesMock = {
+            readOutputFile: function(name) {
+                if (name === 'response.md') return '## Solution\nBody text';
+                if (name === 'diagram.md') return 'graph TD\nA --> B';
+                if (name === 'affected_repos.json') return affectedRepos || null;
+                return null;
+            }
+        };
+        var globals = {
+            jira_update_field: function(args) { jiraUpdates.push(args); },
+            jira_get_ticket: function() { return { fields: {} }; },
+            jira_assign_ticket_to: function() {},
+            jira_move_to_status: function() {},
+            jira_add_label: function() {},
+            jira_remove_label: function() {},
+            jira_post_comment: function() {},
+            confluence_get_children_by_id: function() { return []; },
+            confluence_create_page: function(args) {
+                confluenceCalls.push({ op: 'create', title: args.title });
+                return { id: '777', title: args.title };
+            },
+            confluence_sync_markdown_directory: function(args) {
+                confluenceCalls.push({ op: 'sync', parentId: args.parentId });
+            },
+            file_write: function(path, content) {
+                if (typeof path === 'string' && path.indexOf('confluence_sync_') !== -1 && path.indexOf('index.md') !== -1) {
+                    confluenceCalls.push({ op: 'write', path: path, content: content });
+                }
+            },
+            file_read: function(opts) {
+                var path = opts && (opts.path || opts);
+                if (path === (repliesFile || 'outputs/confluence_replies.json')) throw new Error('no replies');
+                throw new Error('not found: ' + path);
+            }
+        };
+        var module = loadModule(
+            'js/writeSolutionAndDiagrams.js',
+            makeRequire({
+                './config.js': configModule,
+                './configLoader.js': { loadProjectConfig: function() { return {}; } },
+                './common/scm.js': { createScm: function() { return {}; } },
+                './common/autoStart.js': {
+                    triggerConfiguredWorkflowForTicket: function() { return false; },
+                    triggerSmIfIdle: function() {}
+                },
+                './common/outputFiles.js': outputFilesMock,
+                './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
+                './common/contentOutput.js': loadModule('js/common/contentOutput.js',
+                    makeRequire({ '../configLoader.js': { loadProjectConfig: function() { return {}; } } }),
+                    globals),
+                './writeSolutionAndLabels.js': loadModule('js/writeSolutionAndLabels.js',
+                    makeRequire({
+                        './writeSolutionAndDiagrams.js': { action: function() { return { success: true }; } },
+                        './common/outputFiles.js': outputFilesMock,
+                        './config.js': configModule
+                    }),
+                    globals)
+            }),
+            globals
+        );
+        return module;
+    }
+
+    var CONF_PARAMS = {
+        ticket: { key: 'PROJ-1', fields: { summary: 'Some story' } },
+        customParams: {
+            solutionField: 'description',
+            diagramField: '',
+            outputType: 'replace',
+            contentOutput: { target: 'confluence', space: 'DOC', parentPageId: '42' }
+        }
+    };
+
+    test('confluence target: solution has NO jira {code} diagram block; markdown Diagram section is published', function() {
+        var jiraUpdates = [];
+        var confluenceCalls = [];
+        var module = loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, 'outputs/confluence_replies.json',
+            JSON.stringify([{ name: 'backend', reason: 'API changes' }, { name: 'ui', reason: 'screen', depends_on: ['backend'] }]));
+
+        var result = module.action(CONF_PARAMS);
+
+        assert.equal(result.success, true, 'action succeeds: ' + JSON.stringify(result));
+        // Jira field must receive only the Confluence link — never the solution body
+        assert.equal(jiraUpdates.length, 1, 'one jira update (the link)');
+        assert.ok(jiraUpdates[0].value.indexOf('Confluence') !== -1, 'jira field gets the page link');
+        assert.ok(jiraUpdates[0].value.indexOf('{code}') === -1, 'no jira code block in jira link update');
+        // The markdown published to Confluence must contain the diagram as markdown fence
+        var write = null;
+        confluenceCalls.forEach(function(c) { if (c.op === 'write') write = c; });
+        assert.ok(write, 'sync content was written');
+        assert.ok(write.content.indexOf('## Diagram') !== -1, 'markdown Diagram section present');
+        assert.ok(write.content.indexOf('```mermaid') !== -1, 'mermaid fence present');
+        assert.ok(write.content.indexOf('{code}') === -1, 'no jira {code} markup in confluence content');
+        assert.ok(write.content.indexOf('## Solution') !== -1, 'solution body present');
+    });
+
+    test('confluence target: human-readable Affected Repositories section appended to page content', function() {
+        var jiraUpdates = [];
+        var confluenceCalls = [];
+        var module = loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, 'outputs/confluence_replies.json',
+            JSON.stringify([{ name: 'backend', reason: 'API changes' }, { name: 'ui', reason: 'screen', depends_on: ['backend'] }]));
+
+        var result = module.action(CONF_PARAMS);
+
+        assert.equal(result.success, true, 'action succeeds: ' + JSON.stringify(result));
+        var write = null;
+        confluenceCalls.forEach(function(c) { if (c.op === 'write') write = c; });
+        assert.ok(write, 'sync content was written');
+        assert.ok(write.content.indexOf('## Affected Repositories') !== -1, 'Affected Repositories heading present');
+        assert.ok(write.content.indexOf('| # | Repository | Reason | Depends On |') !== -1, 'markdown table present');
+        assert.ok(write.content.indexOf('| 1 | backend | API changes |') !== -1, 'topologically sorted rows present');
+        assert.ok(write.content.indexOf('```json') !== -1, 'json anchor present');
+        assert.ok(write.content.indexOf('{code') === -1, 'no jira wiki table/code in confluence content');
+    });
+
+    test('confluence target without affected_repos.json: page publishes without the section (non-fatal)', function() {
+        var jiraUpdates = [];
+        var confluenceCalls = [];
+        var module = loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, 'outputs/confluence_replies.json', null);
+
+        var result = module.action(CONF_PARAMS);
+
+        assert.equal(result.success, true);
+        var write = null;
+        confluenceCalls.forEach(function(c) { if (c.op === 'write') write = c; });
+        assert.ok(write.content.indexOf('## Affected Repositories') === -1, 'no section when no affected_repos.json');
+    });
+
+    test('jira_field target (no contentOutput): diagram is prepended as {code} block (unchanged behavior)', function() {
+        var jiraUpdates = [];
+        var module = loadModuleWithDiagramFlow(jiraUpdates, [], 'outputs/confluence_replies.json');
+
+        var result = module.action({
+            ticket: { key: 'PROJ-1', fields: { summary: 'Some story' } },
+            customParams: { solutionField: 'description', diagramField: '', outputType: 'replace' }
+        });
+
+        assert.equal(result.success, true);
+        var solutionUpdate = null;
+        jiraUpdates.forEach(function(u) {
+            if (u.value && u.value.indexOf('## Solution') !== -1) solutionUpdate = u;
+        });
+        assert.ok(solutionUpdate, 'solution written to jira field');
+        assert.ok(solutionUpdate.value.indexOf('{code}\ngraph TD') === 0, 'diagram prepended as jira {code} block');
+    });
+});
+
 suite('writeSolutionAndDiagrams — required outputs', function() {
     test('fails when diagram is required but missing', function() {
         var outputFiles = loadModule('js/common/outputFiles.js', makeRequire({}), {

--- a/js/unit-tests/test_writeSolutionAndDiagrams.js
+++ b/js/unit-tests/test_writeSolutionAndDiagrams.js
@@ -26,10 +26,10 @@ suite('writeSolutionAndDiagrams — module export', function() {
 
 suite('writeSolutionAndDiagrams — diagram handling for Confluence targets', function() {
 
-    function loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, repliesFile, affectedRepos) {
+    function loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, repliesFile, affectedRepos, responseMd) {
         var outputFilesMock = {
             readOutputFile: function(name) {
-                if (name === 'response.md') return '## Solution\nBody text';
+                if (name === 'response.md') return responseMd || '## Solution\nBody text';
                 if (name === 'diagram.md') return 'graph TD\nA --> B';
                 if (name === 'affected_repos.json') return affectedRepos || null;
                 return null;
@@ -140,6 +140,48 @@ suite('writeSolutionAndDiagrams — diagram handling for Confluence targets', fu
         assert.ok(write.content.indexOf('| 1 | backend | API changes |') !== -1, 'topologically sorted rows present');
         assert.ok(write.content.indexOf('```json') !== -1, 'json anchor present');
         assert.ok(write.content.indexOf('{code') === -1, 'no jira wiki table/code in confluence content');
+    });
+
+    test('confluence target rerun: publish-managed sections copied by the model are not duplicated', function() {
+        var jiraUpdates = [];
+        var confluenceCalls = [];
+        // Model iterated over the previous page and kept the old Diagram and
+        // Affected Repositories sections in its fresh response.md
+        var responseWithStaleSections = '## Solution\nUpdated body text\n\n## Diagram\n\n```mermaid\ngraph TD\nOLD --> STALE\n```\n\n## Affected Repositories\n\n| # | Repository | Reason | Depends On |\n|---|---|---|---|\n| 1 | old-repo | stale | — |\n\n```json\n[{"name":"old-repo"}]\n```\n\n---\n';
+        var module = loadModuleWithDiagramFlow(jiraUpdates, confluenceCalls, 'outputs/confluence_replies.json',
+            JSON.stringify([{ name: 'backend', reason: 'API changes' }]),
+            responseWithStaleSections);
+
+        var result = module.action(CONF_PARAMS);
+
+        assert.equal(result.success, true, 'action succeeds: ' + JSON.stringify(result));
+        var write = null;
+        confluenceCalls.forEach(function(c) { if (c.op === 'write') write = c; });
+        assert.ok(write, 'sync content was written');
+        assert.equal(write.content.split('## Diagram').length - 1, 1, 'exactly one Diagram section');
+        assert.equal(write.content.split('## Affected Repositories').length - 1, 1, 'exactly one Affected Repositories section');
+        assert.ok(write.content.indexOf('OLD --> STALE') === -1, 'stale mermaid removed');
+        assert.ok(write.content.indexOf('old-repo') === -1, 'stale repos table removed');
+        assert.ok(write.content.indexOf('graph TD\nA --> B') !== -1, 'fresh diagram present');
+        assert.ok(write.content.indexOf('| 1 | backend | API changes |') !== -1, 'fresh repos table present');
+        assert.ok(write.content.indexOf('Updated body text') !== -1, 'model body kept');
+    });
+
+    test('stripManagedConfluenceSections unit checks', function() {
+        var module = loadModuleWithDiagramFlow([], [], 'outputs/confluence_replies.json');
+        var strip = module.stripManagedConfluenceSections;
+
+        // sections at the end
+        assert.equal(strip('text\n\n## Diagram\n\n```mermaid\nx\n```\n'), 'text');
+        // section followed by another same-level section keeps the tail
+        assert.equal(strip('text\n\n## Affected Repositories\n\nstuff\n\n## Risks\nkeep me'),
+            'text\n\n## Risks\nkeep me');
+        // both managed sections
+        assert.equal(strip('body\n\n## Diagram\nd\n\n## Affected Repositories\nr\n'), 'body');
+        // nothing to strip
+        assert.equal(strip('plain content'), 'plain content');
+        // unrelated headings survive
+        assert.equal(strip('## Solution\n\n## Test Scope\nx'), '## Solution\n\n## Test Scope\nx');
     });
 
     test('confluence target without affected_repos.json: page publishes without the section (non-fatal)', function() {

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -30,6 +30,25 @@ const outputFiles = require('./common/outputFiles.js');
 const tokenUsageComment = require('./common/tokenUsageComment.js');
 const contentOutput = require('./common/contentOutput.js');
 
+// Sections appended by this module when publishing to Confluence (target
+// 'confluence'/'both'). On reruns the model iterates over the previous page content
+// (input/confluence_output_current.md) and may copy these sections into its fresh
+// output — they are stripped here before the publish step re-adds the up-to-date
+// variants, so the page never accumulates duplicates.
+var MANAGED_CONFLUENCE_SECTIONS = ['## Diagram', '## Affected Repositories'];
+
+function stripManagedConfluenceSections(markdown) {
+    if (!markdown) return markdown;
+    var result = markdown;
+    MANAGED_CONFLUENCE_SECTIONS.forEach(function(heading) {
+        // From the heading to the next same-or-higher-level heading (## or #) or EOF.
+        var re = new RegExp('\\n?' + heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+            '\\n[\\s\\S]*?(?=\\n#{1,2} |$)');
+        result = result.replace(re, '\n');
+    });
+    return result.replace(/\n{3,}/g, '\n\n').trim();
+}
+
 function action(params) {
     try {
         var ticketKey = params.ticket.key;
@@ -146,7 +165,10 @@ function action(params) {
         if (contentOutput.isConfluenceTarget(outputCfg)) {
             try {
                 var ticketSummary = (params.ticket.fields && params.ticket.fields.summary) || '';
-                var pageContent = solution;
+                // Strip publish-managed sections the model may have copied from the
+                // previous page content (input/confluence_output_current.md) — they are
+                // re-added fresh below, otherwise reruns would duplicate them.
+                var pageContent = stripManagedConfluenceSections(solution);
                 if (diagram) {
                     pageContent = pageContent + '\n\n## Diagram\n\n```mermaid\n' + diagram + '\n```\n';
                 }
@@ -284,5 +306,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action: action };
+    module.exports = { action: action, stripManagedConfluenceSections: stripManagedConfluenceSections };
 }

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -74,11 +74,22 @@ function action(params) {
             }
         }
 
-        // 3. If no dedicated diagram field — prepend diagram as Jira code block to solution
-        if (diagram && !diagramField) {
+        // 3. If no dedicated diagram field — prepend diagram to solution.
+        //    Confluence targets get a Markdown "## Diagram" section appended at the
+        //    publish step (below); the Jira wiki {code} block must not leak into
+        //    Confluence-bound content.
+        var confluenceOnlyTarget = false;
+        try {
+            var earlyOutputCfg = contentOutput.resolveConfig(params, { target: 'jira_field' });
+            confluenceOnlyTarget = contentOutput.isConfluenceTarget(earlyOutputCfg) &&
+                !contentOutput.isJiraFieldTarget(earlyOutputCfg);
+        } catch (e) { /* fall through with jira behavior */ }
+        if (diagram && !diagramField && !confluenceOnlyTarget) {
             solution = '{code}\n' + diagram + '\n{code}\n\n' + solution;
             console.log('No diagram field configured — diagram prepended to solution as {code} block');
             diagram = ''; // mark as handled
+        } else if (diagram && !diagramField && confluenceOnlyTarget) {
+            console.log('No diagram field configured, Confluence-only target — diagram will be appended as Markdown "## Diagram" section at publish');
         }
 
         var outputCfg = contentOutput.resolveConfig(params, {
@@ -146,6 +157,28 @@ function action(params) {
                 if (replyResult.posted > 0 || replyResult.failed > 0) {
                     console.log('Replied to ' + replyResult.posted + ' inline comment(s)' +
                         (replyResult.failed > 0 ? ', ' + replyResult.failed + ' failed' : ''));
+                }
+
+                // Confluence-only target: the tracker field gets just a link (+ the
+                // Affected Repositories section appended by writeSolutionAndLabels), so
+                // without this the page would be missing the human-readable summary.
+                // buildMarkdownSection is loaded lazily to avoid a require cycle with
+                // writeSolutionAndLabels.js (which requires this module).
+                if (outputCfg.target === 'confluence') {
+                    try {
+                        var reposJson = readOutput('affected_repos.json');
+                        if (reposJson) {
+                            var reposRaw = JSON.parse(reposJson);
+                            if (Array.isArray(reposRaw) && reposRaw.length > 0) {
+                                var shared = require('./writeSolutionAndLabels.js');
+                                var sortedRepos = shared.topologicalSort(reposRaw);
+                                pageContent = pageContent + '\n\n' + shared.buildMarkdownSection(sortedRepos);
+                                console.log('Appended Affected Repositories section to Confluence page content (' + sortedRepos.length + ' repos)');
+                            }
+                        }
+                    } catch (reposError) {
+                        console.warn('Failed to append affected repos section to Confluence content (non-fatal):', reposError);
+                    }
                 }
 
                 var published = contentOutput.publishPage(outputCfg, ticketKey, ticketSummary, pageContent);


### PR DESCRIPTION
## Problem

Two tracker-field behaviors leaked into the Confluence-only target (`contentOutput.target: 'confluence'`):

**1. Diagram published as a Jira wiki `{code}` block.** With no dedicated diagram field (`diagramField: ''`), `writeSolutionAndDiagrams` prepended `{code}...{code}` to the solution — and that string went through the Markdown→Confluence sync, leaving a broken `{code} flowchart ... {code}` fragment on the page instead of a rendered diagram.

**2. No Affected Repositories summary on the page.** The human-readable section (table + dependency graph + JSON anchor) is appended by `writeSolutionAndLabels` to the *tracker field* only. With the Confluence-only target the field holds just a link line, so the published page had no affected-repos overview at all.

## Changes

- `writeSolutionAndDiagrams`: the `{code}` diagram prepend now applies only to tracker-field targets; for the Confluence-only target the existing Markdown `## Diagram` + ```mermaid``` append (already used at the publish step) handles it.
- `writeSolutionAndDiagrams`: for `target: 'confluence'`, the Affected Repositories section is appended to the page content via the shared `topologicalSort`/`buildMarkdownSection` helpers from `writeSolutionAndLabels` (lazy require — avoids a module cycle). The JSON anchor stays on the page too — harmless: `createRepoTasksMulti` reads the tracker field. Tracker-field behavior is unchanged.

## Tests

6/6 in `test_writeSolutionAndDiagrams.js` (new: no `{code}` in Confluence content + markdown Diagram section, affected-repos section present/topologically sorted/markdown-formatted, graceful skip without `affected_repos.json`, unchanged Jira behavior). Full suite: 824 passed, 0 failed.