### PR TITLE
docs(confluence): placeholder placement rules for headings and lists

### DIFF
--- a/instructions/common/confluence_comments.md
+++ b/instructions/common/confluence_comments.md
@@ -17,6 +17,8 @@ Rules:
 
 - **Always preserve** every `[[ic:REF]]...[[/ic]]` placeholder, wrapped around the same text it currently marks.
 - If you rephrase the anchored text, **move the placeholder** so it wraps the new equivalent fragment.
+- On headings, place the placeholder **inside** the heading, after the `#` markers — `## [[ic:REF]]Purpose[[/ic]]`, never `[[ic:REF]]## Purpose[[/ic]]` (wrapping the `#` prefix breaks heading rendering).
+- The same applies to list items and quotes: keep `-`, `1.`, `>` outside the placeholder.
 - Remove a placeholder only when you intentionally remove the commented content itself.
 - Never invent new `[[ic:...]]` refs — only the ones already present are valid.
 


### PR DESCRIPTION
Companion to epam/dm.ai#499 (which repairs heading breakage at the storage level). Teaches the agent to place `[[ic:REF]]` placeholders **inside** Markdown structural prefixes — `## [[ic:REF]]Purpose[[/ic]]`, never `[[ic:REF]]## Purpose[[/ic]]` — same for list markers and blockquote signs. Prevents the heading-conversion breakage at the source instead of relying on the repair.