### PR TITLE
docs(instructions): require written distinct-items checklist before multi-task split decision

### DIFF
--- a/instructions/story_solution/affected_repos_multi_task_split.md
+++ b/instructions/story_solution/affected_repos_multi_task_split.md
@@ -35,9 +35,27 @@ tracking benefit.
 ### Mandatory self-check before writing the final `reason`
 
 A single "big" `reason` string is a smell, not automatically a valid single
-task. Before finalizing a repository entry, count the distinct new/changed
-classes, modules, endpoints, or components you are about to list for that
-repository (ignore config/wiring one-liners).
+task. Before finalizing a repository entry, **write out (in your reasoning,
+not in the JSON) a numbered list of the distinct new/changed classes, modules,
+endpoints, or components you identified for that repository** (ignore
+config/wiring one-liners), then state the verdict explicitly:
+
+```
+Repo: gens-igt
+Distinct items:
+  1. New workflow type PACBIO_FP_CREATION + WorkflowType enum branch
+  2. New step ID DEFINE_PACBIO_FC_POOL + processor
+  3. PairingService with max-weight matching algorithm
+  4. Dynamic pipetting volume calculator
+  5. File exports (PacBio Pipette Template, Standard Quant)
+  6. DB migrations + ConfigTableName keys
+Self-check: 6 items → split required (criteria: schema/migrations vs business
+logic vs algorithm are independently reviewable PRs)
+```
+
+Only after this written self-check, apply the rules below. Do not skip the
+listing step — if you cannot list the items, you have not analyzed the
+repository's scope.
 
 - **0–2 distinct items**, or all items are in the same file/class: keep it as
   one task — write the plain `reason`.


### PR DESCRIPTION
The mandatory self-check for repo-entry `tasks` splitting previously asked the model to silently count distinct new/changed items before deciding whether a repo entry needs a split. On GENSGENP-53552 the model produced a flat 1-1 mapping for `gens-igt` despite 6+ clearly separable architecture decisions (new workflow type, new step ID, pairing algorithm, dynamic pipetting calculator, file exports, DB migrations), because a silent count leaves no visible trace and can be skipped.

This change requires the model to externalize the check: write a numbered list of distinct items plus an explicit split/no-split verdict in its reasoning before finalizing the JSON, with a worked example based on the observed regression case.

No code changes — instructions-only.