### PR TITLE
fix(preCliDevelopmentSetup): create new base-branch tracking ref before checkout

### DIFF
--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -26,6 +26,14 @@ function runCmd(args) {
     return cli_execute_command(args);
 }
 
+// Adapter matching the (command, workingDir) signature expected by
+// common/pullRequest.js helpers (e.g. ensureRemoteBranchRef) — workingDir is
+// captured via the module-level _workingDir closure by runCmd already, so the
+// second argument here is accepted but unused.
+function runCommandStr(command) {
+    return runCmd({ command: command });
+}
+
 /**
  * Clean command output from script wrapper artifacts
  * @param {string} output - Raw command output
@@ -218,7 +226,7 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
                 runCmd({ command: 'git checkout ' + branchName });
             } catch (fetchCheckoutErr) {
                 console.warn('fetch+checkout failed, resetting local branch from origin:', fetchCheckoutErr);
-                runCmd({ command: prHelper.buildOriginFetchCommand(branchName) });
+                prHelper.ensureRemoteBranchRef(runCommandStr, _workingDir, branchName);
                 runCmd({ command: 'git checkout -B ' + branchName + ' origin/' + branchName });
             }
             alignBranchWithBase(ticketKey, branchName, rebaseBase);
@@ -255,8 +263,14 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
                         runCmd({ command: 'git checkout -b ' + featureBranchName + ' origin/' + featureBranchName });
                     } else {
                         console.log('Two-branch mode: creating feature branch from', config.git.baseBranch + ':', featureBranchName);
-                        runCmd({ command: 'git checkout ' + config.git.baseBranch });
-                        runCmd({ command: 'git pull origin ' + config.git.baseBranch });
+                        // ensureRemoteBranchRef fetches with an explicit destination refspec
+                        // (+refs/heads/<b>:refs/remotes/origin/<b>) so origin/<baseBranch> exists
+                        // even in a shallow/single-branch CI clone that never checked this branch
+                        // out before (e.g. a fixVersion-derived "develop/3.9.0") — a plain
+                        // `git checkout <baseBranch>` would otherwise fail with "pathspec ...
+                        // did not match any file(s) known to git".
+                        prHelper.ensureRemoteBranchRef(runCommandStr, _workingDir, config.git.baseBranch);
+                        runCmd({ command: 'git checkout -B ' + config.git.baseBranch + ' origin/' + config.git.baseBranch });
                         runCmd({ command: 'git checkout -b ' + featureBranchName });
                         runCmd({ command: 'git push -u origin ' + featureBranchName });
                     }
@@ -269,12 +283,16 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
                 console.log('Two-branch mode: dev branch will be created from feature branch:', featureBranchName);
             }
             console.log('Creating new branch from', branchBase + ':', branchName);
-            // Explicitly fetch the base branch so origin/<branchBase> is available locally.
-            // git fetch origin --prune (done earlier) may not populate it in a shallow clone
-            // (e.g. cloned with --depth 1 --branch main, so only refs/heads/main exists locally).
-            runCmd({ command: prHelper.buildOriginFetchCommand(branchBase) });
-            runCmd({ command: 'git checkout ' + branchBase });
-            runCmd({ command: 'git pull origin ' + branchBase });
+            // ensureRemoteBranchRef fetches with an explicit destination refspec so
+            // origin/<branchBase> actually exists locally before checkout — a plain
+            // `git fetch origin <branchBase>` (no destination refspec) only updates
+            // FETCH_HEAD, so a subsequent `git checkout <branchBase>` fails with
+            // "pathspec ... did not match any file(s) known to git" whenever branchBase
+            // was never checked out in this clone before (e.g. a fresh/shallow CI clone,
+            // or a fixVersion-derived base branch like "develop/3.9.0" seen for the first
+            // time on this runner/cache).
+            prHelper.ensureRemoteBranchRef(runCommandStr, _workingDir, branchBase);
+            runCmd({ command: 'git checkout -B ' + branchBase + ' origin/' + branchBase });
             runCmd({ command: 'git checkout -b ' + branchName });
         }
     }

--- a/js/unit-tests/test_preCliDevelopmentSetup.js
+++ b/js/unit-tests/test_preCliDevelopmentSetup.js
@@ -18,6 +18,18 @@ var NOOP_CONFIG_JS = { GIT_CONFIG: {}, STATUSES: {}, resolveStatuses: function()
 var DEFAULT_PR_HELPER_STUB = {
     buildOriginFetchCommand: function(refSpec) {
         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+    },
+    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+        if (!branchName) return false;
+        try {
+            runCommand(
+                'git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName,
+                workingDir
+            );
+            return true;
+        } catch (e) {
+            return false;
+        }
     }
 };
 
@@ -218,7 +230,7 @@ suite('preCliDevelopmentSetup.checkoutBranch — generated .codegraph index guar
 
         var stashRmIdx = calls.indexOf(STASH_RM_CMD);
         var stashMvIdx = calls.indexOf(STASH_MV_CMD);
-        var checkoutIdx = calls.indexOf('git checkout master');
+        var checkoutIdx = calls.indexOf('git checkout -B master origin/master');
         var restoreMvIdx = calls.lastIndexOf(RESTORE_MV_CMD);
 
         assert.ok(stashRmIdx !== -1, 'unstages .codegraph before branch setup');
@@ -305,12 +317,12 @@ suite('preCliDevelopmentSetup.checkoutBranch — base branch fetch before checko
             if (calls[i] && calls[i].indexOf('fetch origin') !== -1 && calls[i].indexOf('master') !== -1) {
                 fetchIdx = i;
             }
-            if (calls[i] === 'git checkout master') {
+            if (calls[i] === 'git checkout -B master origin/master') {
                 checkoutIdx = i;
             }
         }
         assert.ok(fetchIdx !== -1, 'git fetch origin master must run before checkout');
-        assert.ok(checkoutIdx !== -1, 'git checkout master must run');
+        assert.ok(checkoutIdx !== -1, 'git checkout -B master origin/master must run');
         assert.ok(fetchIdx < checkoutIdx, 'fetch must come before checkout (fetchIdx=' + fetchIdx + ', checkoutIdx=' + checkoutIdx + ')');
     });
 
@@ -338,12 +350,12 @@ suite('preCliDevelopmentSetup.checkoutBranch — base branch fetch before checko
             if (calls[i] && calls[i].indexOf('fetch origin') !== -1 && calls[i].indexOf('release/rc_mobile_proj-1') !== -1) {
                 fetchIdx = i;
             }
-            if (calls[i] === 'git checkout release/rc_mobile_proj-1') {
+            if (calls[i] === 'git checkout -B release/rc_mobile_proj-1 origin/release/rc_mobile_proj-1') {
                 checkoutIdx = i;
             }
         }
         assert.ok(fetchIdx !== -1, 'git fetch origin release/rc_mobile_proj-1 must run before checkout');
-        assert.ok(checkoutIdx !== -1, 'git checkout release/rc_mobile_proj-1 must run');
+        assert.ok(checkoutIdx !== -1, 'git checkout -B release/rc_mobile_proj-1 origin/release/rc_mobile_proj-1 must run');
         assert.ok(fetchIdx < checkoutIdx, 'fetch must come before checkout');
     });
 

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -51,6 +51,15 @@ function loadPreCli(workingDir) {
             './common/pullRequest.js': {
                 buildOriginFetchCommand: function(refSpec) {
                     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                },
+                ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                    if (!branchName) return false;
+                    try {
+                        runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                        return true;
+                    } catch (e) {
+                        return false;
+                    }
                 }
             },
             './fetchParentContextToInput.js': { action: function() {} },
@@ -161,6 +170,15 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './common/pullRequest.js': {
                     buildOriginFetchCommand: function(refSpec) {
                         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    },
+                    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                        if (!branchName) return false;
+                        try {
+                            runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
                     }
                 },
                 './fetchParentContextToInput.js': { action: function() {} },
@@ -225,6 +243,15 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './common/pullRequest.js': {
                     buildOriginFetchCommand: function(refSpec) {
                         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    },
+                    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                        if (!branchName) return false;
+                        try {
+                            runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
                     }
                 },
                 './fetchParentContextToInput.js': { action: function() {} },
@@ -293,6 +320,15 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './common/pullRequest.js': {
                     buildOriginFetchCommand: function(refSpec) {
                         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    },
+                    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                        if (!branchName) return false;
+                        try {
+                            runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
                     }
                 },
                 './fetchParentContextToInput.js': { action: function() {} },
@@ -360,6 +396,15 @@ function loadPreCliTestAutomation(workingDir) {
             './common/pullRequest.js': {
                 buildOriginFetchCommand: function(refSpec) {
                     return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                },
+                ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                    if (!branchName) return false;
+                    try {
+                        runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                        return true;
+                    } catch (e) {
+                        return false;
+                    }
                 }
             },
             './fetchLinkedBugsToInput.js': { action: function() {} }
@@ -443,6 +488,15 @@ suite('preCliTestAutomationSetup > workingDir', function() {
                 './common/pullRequest.js': {
                     buildOriginFetchCommand: function(refSpec) {
                         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    },
+                    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                        if (!branchName) return false;
+                        try {
+                            runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
                     }
                 },
                 './fetchLinkedBugsToInput.js': { action: function() {} }
@@ -503,6 +557,15 @@ suite('preCliTestAutomationSetup > workingDir', function() {
                 './common/pullRequest.js': {
                     buildOriginFetchCommand: function(refSpec) {
                         return 'git -c fetch.recurseSubmodules=no fetch origin' + (refSpec ? ' ' + refSpec : '');
+                    },
+                    ensureRemoteBranchRef: function(runCommand, workingDir, branchName) {
+                        if (!branchName) return false;
+                        try {
+                            runCommand('git -c fetch.recurseSubmodules=no fetch origin +refs/heads/' + branchName + ':refs/remotes/origin/' + branchName, workingDir);
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
                     }
                 },
                 './fetchLinkedBugsToInput.js': { action: function() {} }


### PR DESCRIPTION
## Problem

Job https://git.epam.com/gens-sup/ai-teammate/-/jobs/26853735 (story_development on a ticket whose fixVersion is `3.9.0`) failed at the "Git Branch Setup" stage:

```
java.lang.RuntimeException: Tool execution failed: Command execution failed: Command failed (exit code 1): git checkout develop/3.9.0
Output:
error: pathspec 'develop/3.9.0' did not match any file(s) known to git
```

`develop/3.9.0` genuinely exists on the remote (confirmed via the GitLab API, created back on 2026-08-14) — this was not a missing-branch issue.

## Root cause

`checkoutBranch()`'s "creating new branch from branchBase" step did:

```js
runCmd({ command: prHelper.buildOriginFetchCommand(branchBase) }); // git fetch origin develop/3.9.0
runCmd({ command: 'git checkout ' + branchBase });                  // git checkout develop/3.9.0
```

`git fetch origin <branch>` **without a destination refspec** only updates `FETCH_HEAD` — it never creates or updates `refs/heads/<branch>` or `refs/remotes/origin/<branch>`. So the following `git checkout <branch>` has nothing to check out whenever that branch was never fetched/checked-out before in this clone (true for any fixVersion-derived base branch on a fresh/shallow CI clone that only has the default branch locally).

This exact bug class was already identified and fixed once before, in `common/gitOps.js`'s `checkoutPRBranch()`, using `common/pullRequest.js`'s `ensureRemoteBranchRef()` (explicit `+refs/heads/<b>:refs/remotes/origin/<b>` refspec) + `git checkout -B <b> origin/<b>`. This PR applies that same established pattern to the remaining call sites in `preCliDevelopmentSetup.js` that still had it.

## Fix

- `preCliDevelopmentSetup.js`:
  - two-branch-mode "create feature branch from `config.git.baseBranch`" step
  - "create new dev branch from `branchBase`" step (the one that actually failed in production)
  - existing-remote-branch fallback catch block (same latent bug, not yet triggered here, fixed for consistency)
  - all three now call `prHelper.ensureRemoteBranchRef(...)` then `git checkout -B <branch> origin/<branch>` instead of a plain `git fetch <branch>` + `git checkout <branch>`.
  - added a small `runCommandStr` adapter so these call sites can reuse `ensureRemoteBranchRef`'s `(command, workingDir)` signature via the existing `runCmd({ command })` wrapper.
- Updated/extended unit tests accordingly — all 827 tests pass (`dmtools run js/unit-tests/run_all.json`).
