### PR TITLE
feat(pr_rework): add TDD approach + multi-item edge-case rule

### DIFF
--- a/instructions/bug_development/tdd_approach.md
+++ b/instructions/bug_development/tdd_approach.md
@@ -16,7 +16,8 @@ flowchart TD
         R1["❌ NEVER fix code without a failing reproduction test first"]
         R2["❌ NEVER write more code than needed to fix the bug"]
         R3["✅ Returned bugs: your fix must differ from the previous attempt"]
-        R4["✅ Run the FULL test suite before finishing — no regressions allowed"]
+        R4["✅ If the bug involves a loop/collection, add a reproduction case with 2+ items, not only a single-item scenario — a single-item test can pass while multi-item logic is still broken"]
+        R5["✅ Run the FULL test suite before finishing — no regressions allowed"]
     end
 
     TDD --> RULES

--- a/instructions/pr_rework/general_guidelines.md
+++ b/instructions/pr_rework/general_guidelines.md
@@ -17,7 +17,7 @@ flowchart TD
     BLOCKING -->|No| IMPORTANT[Fix IMPORTANT issues]
     IMPORTANT --> SUGGESTIONS{Minor suggestions?}
     SUGGESTIONS -->|Yes| SKIP["Skip if time-consuming — note in response.md"]
-    SUGGESTIONS -->|No| TEST[Run tests and verify]
+    SUGGESTIONS -->|No| TEST["Follow TDD approach for every fix — see tdd_approach.md — then run tests and verify"]
     SKIP --> TEST
     TEST --> OUTPUT[Write outputs/response.md]
     OUTPUT --> REPLIES{Open review threads?}

--- a/instructions/pr_rework/tdd_approach.md
+++ b/instructions/pr_rework/tdd_approach.md
@@ -1,0 +1,23 @@
+```mermaid
+flowchart TD
+    subgraph TDD["TDD for PR Rework — RED-GREEN-REFACTOR"]
+        T0["Start from the concrete issue: a CI failure, a review thread, or a BLOCKING/IMPORTANT finding"]
+        T1["RED: Write or extend a test that REPRODUCES the reported issue<br/>— must fail before the fix<br/>— cover the exact scenario called out (including boundary/multi-item cases, not just the happy path)"]
+        T2["GREEN: Make the minimum code change to turn the test PASS<br/>— do not expand scope beyond the reported issue"]
+        T3["REFACTOR: Clean up while keeping tests GREEN<br/>— run the full test suite after every change"]
+        T4{"More findings to address?"}
+        T5["Repeat RED-GREEN-REFACTOR for the next finding"]
+        T0 --> T1 --> T2 --> T3 --> T4
+        T4 -->|Yes| T5 --> T1
+        T4 -->|No| DONE([All findings fixed with regression tests])
+    end
+
+    subgraph RULES["PR Rework TDD Rules"]
+        R1["❌ NEVER change production code in response to a review comment or CI failure without a test that first reproduces it"]
+        R2["✅ If the existing tests only cover a single-item/simple case, add a test for the multi-item/edge case the finding points at — a fix without a test for that exact case is not verified"]
+        R3["✅ Returned findings: your fix must differ from the previous attempt and the new/updated test must prove it"]
+        R4["✅ Run the FULL test suite before finishing — no regressions allowed"]
+    end
+
+    TDD --> RULES
+```

--- a/instructions/story_development/tdd_approach.md
+++ b/instructions/story_development/tdd_approach.md
@@ -17,7 +17,8 @@ flowchart TD
         R2["❌ NEVER write more production code than needed to pass the test"]
         R3["✅ Tests must be fast, isolated, and deterministic"]
         R4["✅ Aim for 100% unit test coverage on new and modified code"]
-        R5["✅ Run the full test suite before finishing — no regressions allowed"]
+        R5["✅ When behavior involves a loop/collection, add a case with 2+ items, not only a single-item happy path — a single-item test can pass while multi-item logic is still wrong"]
+        R6["✅ Run the full test suite before finishing — no regressions allowed"]
     end
 
     TDD --> RULES

--- a/pr_rework.json
+++ b/pr_rework.json
@@ -35,6 +35,7 @@
       "./agents/instructions/common/agent_task_preamble.md",
       "./agents/instructions/common/coding_guidelines.md",
       "./agents/instructions/pr_rework/general_guidelines.md",
+      "./agents/instructions/pr_rework/tdd_approach.md",
       "./agents/instructions/pr_rework/formatting_rules.md",
       "./agents/instructions/pr_rework/output_rules.md",
       "./agents/instructions/common/dmtools_cli.md",


### PR DESCRIPTION
## Problem
`pr_rework` had no TDD guidance at all (unlike `bug_development` and `story_development`, which already had `tdd_approach.md`). Rework fixes driven by CI failures or review findings were not required to add/extend a failing test first.

Separately, none of the existing TDD approaches called out a common gap: tests that only cover a single-item/collection case can pass while multi-item logic is still broken (found via a real PR review where a validator's error-message logic worked for a single item but mislabeled the identifier when 2+ items were present, and no test covered that path).

## Changes
- Add `instructions/pr_rework/tdd_approach.md` (RED-GREEN-REFACTOR for fixes driven by CI failures / review findings), wired into `pr_rework.json`'s `cliPrompts`.
- Add a rule to `story_development/tdd_approach.md` and `bug_development/tdd_approach.md`: when behavior involves a loop/collection, cover a 2+ item case, not only a single-item happy path.

No product-specific references added; all product-agnostic.