### PR TITLE
fix(sm): correct removeLabel names and add missing cleanup for story_solution

### DIFF
--- a/bug_development.json
+++ b/bug_development.json
@@ -17,7 +17,7 @@
     "preCliJSAction": "agents/js/preCliDevelopmentSetup.js",
     "postJSAction": "agents/js/developBugAndCreatePR.js",
     "customParams": {
-      "removeLabel": "sm_bug_dev_triggered"
+      "removeLabel": "sm_bug_development_triggered"
     },
     "inputJql": "key = PROJ-74",
     "cliPrompts": [

--- a/docs/agents/generated/bug_development.md
+++ b/docs/agents/generated/bug_development.md
@@ -76,7 +76,7 @@ _Develop Bug and Create PR Post-Action_
 
 ## Custom params
 
-- `removeLabel`: `"sm_bug_dev_triggered"`
+- `removeLabel`: `"sm_bug_development_triggered"`
 - `checkOpenPR` _(used by JS action)_
 - `branchCreateFnPath` _(used by JS action)_
 - `targetRepository.workingDir` _(used by JS action)_

--- a/docs/agents/generated/story_development.md
+++ b/docs/agents/generated/story_development.md
@@ -102,7 +102,7 @@ _Timer JS Action — Auto-commit, push, and save session artefacts_
 
 ## Custom params
 
-- `removeLabel`: `"sm_story_dev_triggered"`
+- `removeLabel`: `"sm_story_development_triggered"`
 - `checkOpenPR` _(used by JS action)_
 - `branchCreateFnPath` _(used by JS action)_
 - `targetRepository.workingDir` _(used by JS action)_

--- a/docs/agents/generated/story_solution.md
+++ b/docs/agents/generated/story_solution.md
@@ -89,6 +89,7 @@ _Write Solution and Diagrams Post-Action_
   - `contentOutput`
   - `diagramField`
   - `outputType`
+  - `removeLabel`
   - `requireDiagram`
   - `solutionField`
 
@@ -100,6 +101,7 @@ _Write Solution and Diagrams Post-Action_
 
 ## Custom params
 
+- `removeLabel`: `"sm_story_solution_triggered"`
 - `checkOpenPR` _(used by JS action)_
 - `autoStartDevelopment` _(used by JS action)_
 - `autoStartDevelopmentConfigFile` _(used by JS action)_

--- a/js/writeSolutionAndDiagrams.js
+++ b/js/writeSolutionAndDiagrams.js
@@ -292,6 +292,17 @@ function action(params) {
             }
         }
 
+        // 10. Remove SM trigger label so a crash-recovered ticket can be re-triggered
+        var smTriggerLabel = customParams.removeLabel;
+        if (smTriggerLabel) {
+            try {
+                jira_remove_label({ key: ticketKey, label: smTriggerLabel });
+                console.log('Removed SM trigger label "' + smTriggerLabel + '" from ' + ticketKey);
+            } catch (e) {
+                console.warn('Failed to remove SM trigger label:', e);
+            }
+        }
+
         var autoStartDevelopment = customParams.autoStartDevelopment === true ||
             customParams.autoStartDevelopment === 'true';
         var developmentConfigFile = customParams.autoStartDevelopmentConfigFile;

--- a/story_development.json
+++ b/story_development.json
@@ -22,7 +22,7 @@
     "preCliJSAction": "agents/js/preCliDevelopmentSetup.js",
     "postJSAction": "agents/js/developTicketAndCreatePR.js",
     "customParams": {
-      "removeLabel": "sm_story_dev_triggered"
+      "removeLabel": "sm_story_development_triggered"
     },
     "inputJql": "key in (JD-82)",
     "cliPrompts": [

--- a/story_solution.json
+++ b/story_solution.json
@@ -16,6 +16,9 @@
     "preJSAction": "agents/js/checkWipLabel.js",
     "preCliJSAction": "agents/js/preCliSolutionSetup.js",
     "postJSAction": "agents/js/writeSolutionAndDiagrams.js",
+    "customParams": {
+      "removeLabel": "sm_story_solution_triggered"
+    },
     "inputJql": "key = JD-82",
     "cliPrompts": [
       "Senior Software Architect",


### PR DESCRIPTION
## Problem

The SM adds a `skipIfLabel` / `addLabel` pair on every dispatch so the same ticket is not re-triggered in the same cycle. Each agent is responsible for removing the label after it completes, so the ticket can be triggered again when it re-enters the same status.

Three agents had defects in this cleanup:

### 1 & 2 — Wrong label names (`story_development`, `bug_development`)

The SM adds:
- `sm_story_development_triggered`
- `sm_bug_development_triggered`

The agents removed:
- `sm_story_dev_triggered` ← does not exist on the ticket
- `sm_bug_dev_triggered`   ← does not exist on the ticket

The stale labels were therefore never removed, so any Story or Bug that returned to "Ready for Development" (e.g. after a failing test run) was permanently blocked from being picked up again.

### 3 — No cleanup at all (`story_solution`)

`story_solution.json` had no `customParams` and `writeSolutionAndDiagrams.js` did not handle `removeLabel`. If the agent job crashed while a ticket was in "Technical Solution" status, `sm_story_solution_triggered` was left permanently on the ticket, blocking all future attempts.

## Changes

| File | Change |
|---|---|
| `story_development.json` | `removeLabel` value: `sm_story_dev_triggered` → `sm_story_development_triggered` |
| `bug_development.json` | `removeLabel` value: `sm_bug_dev_triggered` → `sm_bug_development_triggered` |
| `story_solution.json` | Added `customParams.removeLabel: "sm_story_solution_triggered"` |
| `js/writeSolutionAndDiagrams.js` | Added step 10: remove `customParams.removeLabel` after WIP label cleanup |

## Testing

- Verify a Story/Bug that cycles back to "Ready for Development" is re-triggered by the SM on the next cycle (labels `sm_story_development_triggered` / `sm_bug_development_triggered` should be absent after the development agent completes).
- Verify a Story that successfully completes `story_solution` no longer has `sm_story_solution_triggered` in its label set.