### PR TITLE
fix(smAgent): re-throw Jira MCP errors instead of swallowing them

### DIFF
--- a/js/smAgent.js
+++ b/js/smAgent.js
@@ -555,7 +555,7 @@ function processRuleLocally(rule, globalRepoInfo, ruleIndex) {
         tickets = jira_search_by_jql({ jql: interpolatedJql, fields: ['key', 'labels'] }) || [];
     } catch (e) {
         console.error('  ❌ Jira query failed: ' + (e.message || e));
-        return { processedKeys: [], skippedKeys: [] };
+        throw e;
     }
 
     if (typeof rule.limit === 'number' && tickets.length > rule.limit) {
@@ -665,7 +665,7 @@ function processRule(rule, globalRepoInfo, ruleIndex, workflowBudget) {
         tickets = jira_search_by_jql({ jql: interpolatedJql, fields: ['key', 'labels'] }) || [];
     } catch (e) {
         console.error('  ❌ Jira query failed: ' + (e.message || e));
-        return { processedKeys: [], skippedKeys: [] };
+        throw e;
     }
 
     // Computed once per rule (not per ticket) — see ruleTargetSelfManagesLabel() and its


### PR DESCRIPTION
## Bug

**Background:**
The SM agent JS script wraps every `jira_search_by_jql` call in a try/catch. When Jira is misconfigured or unavailable, the error is caught, logged as `❌ Jira query failed: ...`, and execution continues. The script ultimately returns `{"success":true,"processed":0}`, so the pipeline step exits with code 0 and GitHub Actions marks the job as passed — even though nothing was actually done.

**Affected call sites in `js/smAgent.js`:**
- `runLocalExecution()` — JQL query before local action dispatch
- `processRule()` — JQL query before workflow/localTeammate dispatch

## Root Cause

Both catch blocks used `return { processedKeys: [], skippedKeys: [] }` after logging the error. The `action()` caller accumulated zero keys across all rules and returned `{ success: true, processed: 0 }`, giving the parent process a zero exit code.

## Fix

Replace the silent `return` in both catch blocks with `throw e`. The exception now propagates to the dmtools GraalJS runtime and produces a non-zero exit code, causing the GitHub Actions step to fail visibly when Jira is broken.

```js
// before
} catch (e) {
    console.error('  ❌ Jira query failed: ' + (e.message || e));
    return { processedKeys: [], skippedKeys: [] };
}

// after
} catch (e) {
    console.error('  ❌ Jira query failed: ' + (e.message || e));
    throw e;
}
```