### PR TITLE
fix(setup): bound setup-failure error messages before posting to the tracker

### DIFF
--- a/js/common/setupCommands.js
+++ b/js/common/setupCommands.js
@@ -32,6 +32,29 @@
  *    cli_execute_command, not the contents of a script it runs.
  */
 
+// Required setup command failures embed the raw tool output (e.g. full `mvn`/`gradle`
+// console output, which can run into megabytes) in the thrown Error's message. Callers
+// (preCliDevelopmentSetup.js, preCliReworkSetup.js) post that message straight into a
+// Jira/tracker comment; trackers reject oversized comments (e.g. Jira's ~350000 char
+// limit) and the resulting post failure can end up silently swallowed, leaving the
+// ticket with zero visibility into why setup failed. Cap the embedded output here, at
+// the source, so every consumer of this error automatically gets a bounded message.
+var MAX_SETUP_ERROR_CHARS = 8000;
+
+function truncateSetupError(text) {
+    if (typeof text !== 'string' || text.length <= MAX_SETUP_ERROR_CHARS) {
+        return text;
+    }
+    // Keep the head (command/context) and tail (usually the actual failure/exception)
+    // since Maven/Gradle failures are typically reported at the very end of the output.
+    var headLen = Math.floor(MAX_SETUP_ERROR_CHARS * 0.4);
+    var tailLen = MAX_SETUP_ERROR_CHARS - headLen;
+    var omitted = text.length - headLen - tailLen;
+    return text.slice(0, headLen) +
+        '\n... [truncated ' + omitted + ' char(s) — see CLI logs for full output] ...\n' +
+        text.slice(text.length - tailLen);
+}
+
 function runSetupCommands(customParams, defaultWorkingDir) {
     var commands = (customParams && customParams.setupCommands) || [];
     if (!Array.isArray(commands) || commands.length === 0) {
@@ -60,7 +83,7 @@ function runSetupCommands(customParams, defaultWorkingDir) {
             console.warn('Setup command "' + name + '" failed:', errorText);
             results.push({ name: name, success: false, error: errorText });
             if (allowFailure === false) {
-                throw new Error('Required setup command failed: ' + name + ' — ' + errorText);
+                throw new Error('Required setup command failed: ' + name + ' — ' + truncateSetupError(errorText));
             }
         }
     }
@@ -68,5 +91,6 @@ function runSetupCommands(customParams, defaultWorkingDir) {
 }
 
 module.exports = {
-    runSetupCommands: runSetupCommands
+    runSetupCommands: runSetupCommands,
+    truncateSetupError: truncateSetupError
 };

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -303,13 +303,18 @@ function checkoutBranch(ticketKey, config, ticket, customParams) {
     }
 }
 
+// Defensive cap on Jira/tracker comment length — see setupCommands.truncateSetupError
+// for rationale (Jira rejects comments over ~350000 chars; unbounded error messages
+// here could silently fail to post, leaving the ticket with no failure visibility).
+var truncateForComment = setupCommands.truncateSetupError;
+
 function postSetupErrorToJira(ticketKey, stage, errorMessage) {
     try {
         jira_post_comment({
             key: ticketKey,
             comment: 'h3. *Development Setup Error*\n\n' +
                 '*Stage:* ' + stage + '\n' +
-                '*Error:* {code}' + errorMessage + '{code}\n\n' +
+                '*Error:* {code}' + truncateForComment(errorMessage) + '{code}\n\n' +
                 'Development was stopped before code generation because the target git branch could not be prepared.'
         });
     } catch (commentError) {

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -54,6 +54,14 @@ function syncBaseBranchIfConfigured(baseBranch, customParams, config) {
     }
 }
 
+// Defensive cap on Jira/tracker comment length for any failSetup() caller. The
+// setupCommands module already truncates its own embedded command output at the
+// source (see truncateSetupError), but other failure messages here (e.g. branch
+// checkout errors) could still, in principle, be arbitrarily long — Jira rejects
+// comments over ~350000 characters, and previously that rejection was silently
+// swallowed, leaving the ticket with no visible failure reason at all.
+var truncateForComment = setupCommands.truncateSetupError;
+
 function failSetup(ticketKey, inputFolder, message) {
     try {
         file_write({
@@ -66,9 +74,11 @@ function failSetup(ticketKey, inputFolder, message) {
     try {
         jira_post_comment({
             key: ticketKey,
-            comment: 'h3. ❌ Rework Setup Failed\n\n' + message
+            comment: 'h3. ❌ Rework Setup Failed\n\n' + truncateForComment(message)
         });
-    } catch (e) {}
+    } catch (e) {
+        console.error('Failed to post rework setup failure comment to ' + ticketKey + ':', e && e.toString ? e.toString() : String(e));
+    }
     throw new Error(message);
 }
 
@@ -225,14 +235,16 @@ function action(params) {
             if (ticketKey) {
                 jira_post_comment({
                     key: ticketKey,
-                    comment: 'h3. ❌ Rework Setup Error\n\n{code}' + error.toString() + '{code}'
+                    comment: 'h3. ❌ Rework Setup Error\n\n{code}' + truncateForComment(error.toString()) + '{code}'
                 });
             }
-        } catch (e) {}
+        } catch (e) {
+            console.error('Failed to post rework setup error comment:', e && e.toString ? e.toString() : String(e));
+        }
         return { success: false, error: error.toString() };
     }
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, syncBaseBranchIfConfigured };
+    module.exports = { action, syncBaseBranchIfConfigured, truncateForComment };
 }

--- a/js/unit-tests/test_preCliReworkSetup.js
+++ b/js/unit-tests/test_preCliReworkSetup.js
@@ -37,7 +37,10 @@ function loadPreCliReworkSetup(configLoaderStub, mocks) {
             './fetchQuestionsToInput.js': NOOP_MODULE,
             './fetchParentContextToInput.js': NOOP_MODULE,
             './restoreFromReleases.js': NOOP_MODULE,
-            './common/setupCommands.js': NOOP_MODULE
+            // Real module (not a no-op stub): preCliReworkSetup.js reads
+            // setupCommands.truncateSetupError at load time to build its own
+            // truncateForComment() helper, so the stub must actually export it.
+            './common/setupCommands.js': loadModule('js/common/setupCommands.js')
         }),
         mocks || {}
     );
@@ -155,6 +158,22 @@ suite('preCliReworkSetup.syncBaseBranchIfConfigured', function() {
 
         assert.equal(hookLoadCalls.length, 1, 'loadHookFn is still consulted');
         assert.equal(cliCalls.length, 0, 'nothing runs when loadHookFn returns null');
+    });
+
+});
+
+suite('preCliReworkSetup.truncateForComment', function() {
+
+    test('is wired to setupCommands.truncateSetupError so failSetup() reuses the same bound', function() {
+        var mod = loadPreCliReworkSetup(makeConfigLoaderStub(null, []), { __ghStub: makeGhStub() });
+
+        assert.equal(mod.truncateForComment('short'), 'short');
+
+        var huge = 'Y'.repeat(500000);
+        var truncated = mod.truncateForComment(huge);
+        assert.ok(truncated.length < 10000,
+            'huge setup-failure output must be bounded before being embedded in a Jira comment, got ' + truncated.length);
+        assert.ok(truncated.indexOf('truncated') !== -1, 'truncated message should say so');
     });
 
 });

--- a/js/unit-tests/test_setupCommands.js
+++ b/js/unit-tests/test_setupCommands.js
@@ -117,4 +117,40 @@ suite('setupCommands helper', function() {
         assert.equal(result.ran, 0);
         assert.deepEqual(loaded.commands, []);
     });
+
+    test('required setup command failure with huge output is truncated in the thrown message', function() {
+        // Regression test: a required setup command (e.g. `mvn clean verify`) can fail
+        // with megabytes of console output embedded in the error message. That message
+        // is later posted verbatim as a Jira/tracker comment by callers of
+        // runSetupCommands (preCliDevelopmentSetup.js, preCliReworkSetup.js); trackers
+        // reject oversized comments (e.g. Jira's ~350000 char limit), and previously
+        // that posting failure was silently swallowed — leaving the ticket with zero
+        // visibility into why setup failed. The thrown error must stay bounded.
+        var hugeOutput = 'X'.repeat(500000);
+        var loaded = loadSetupCommands({
+            cli_execute_command: function() { throw new Error(hugeOutput); }
+        });
+
+        var threw = false;
+        try {
+            loaded.mod.runSetupCommands({
+                setupCommands: [
+                    { name: 'build-test-database-image', command: 'mvn clean verify', allowFailure: false }
+                ]
+            }, './dependencies/repo');
+        } catch (e) {
+            threw = true;
+            assert.ok(e.message.length < 10000, 'thrown message must be bounded, got ' + e.message.length + ' chars');
+            assert.ok(e.message.indexOf('build-test-database-image') !== -1, 'error should mention the failing step name');
+            assert.ok(e.message.indexOf('truncated') !== -1, 'truncated message should say so');
+        }
+
+        assert.equal(threw, true, 'should throw when a required setup command fails');
+    });
+
+    test('short error messages pass through truncateSetupError unchanged', function() {
+        var loaded = loadSetupCommands();
+        assert.equal(loaded.mod.truncateSetupError('short message'), 'short message');
+        assert.equal(loaded.mod.truncateSetupError(undefined), undefined);
+    });
 });


### PR DESCRIPTION
## Problem
A required `setupCommands` entry (e.g. a build/verify step run before an agent starts) can fail with a huge amount of raw CLI output embedded in the thrown error message. That message is posted verbatim as a tracker comment by `preCliReworkSetup.js` / `preCliDevelopmentSetup.js`. Some trackers reject oversized comments outright — and that rejection was previously **silently swallowed**, leaving the ticket with zero indication that setup had even failed.

## Fix
- `js/common/setupCommands.js`: add `truncateSetupError()`, a small head(40%)+tail(60%) bound (build-tool failures are conventionally reported at the very end of the output) applied to the `Required setup command failed: ...` message before it's thrown. Exported for reuse.
- `js/preCliReworkSetup.js` / `js/preCliDevelopmentSetup.js`: reuse the shared `truncateSetupError()` before embedding a setup-failure message into a tracker comment, and **log** (instead of silently swallowing) failures to post that comment.
- Added unit tests covering the truncation behavior and the newly exported helpers.

## Testing
- `dmtools run js/unit-tests/run_all.json`: 828 passed / 2 failed (both pre-existing on `main`, unrelated to this change — verified by running the same suite against a clean checkout without this branch's changes: identical 2 failures, same counts minus the 3 new tests added here).
