### PR TITLE
feat(setup): surface non-fatal setup command failures to the CLI agent

### DIFF
--- a/js/common/setupCommands.js
+++ b/js/common/setupCommands.js
@@ -90,7 +90,49 @@ function runSetupCommands(customParams, defaultWorkingDir) {
     return { ran: results.length, results: results };
 }
 
+/**
+ * Builds a markdown summary of any non-fatal ("allowFailure" — the default) setup
+ * command failures from a runSetupCommands() result, or null if none failed.
+ *
+ * Non-fatal failures are, by design, only logged to the CI console (see
+ * runSetupCommands() above) — the CLI coding agent never sees them unless the caller
+ * writes this out to an input file. Without that, a step like "build the project's
+ * Docker test image" can fail for a genuine, agent-fixable content reason (e.g. a bad
+ * migration file) and the agent will start working on the ticket with zero awareness
+ * that anything is wrong, only to hit a confusing downstream failure later (or worse,
+ * silently ship a broken fix). Callers should write this to e.g. `setup_warnings.md` in
+ * the input folder whenever it returns non-null, so the CLI agent can read it as context
+ * and attempt a fix, the same way it already does for merge_conflicts.md.
+ */
+function buildSetupWarningsMarkdown(runResult) {
+    var results = (runResult && runResult.results) || [];
+    var failures = results.filter(function(r) { return r && r.success === false; });
+    if (failures.length === 0) {
+        return null;
+    }
+    var lines = [
+        '# Setup Command Warnings',
+        '',
+        'The following setup command(s) failed but were configured as non-fatal ' +
+            '(allowFailure is not set to false), so environment setup continued. ' +
+            'If this failure is caused by a fixable issue in the code (e.g. a bad ' +
+            'migration, a broken test, a compile error), please investigate and fix it ' +
+            'as part of this task.',
+        ''
+    ];
+    for (var i = 0; i < failures.length; i++) {
+        lines.push('## ' + failures[i].name);
+        lines.push('');
+        lines.push('```');
+        lines.push(truncateSetupError(failures[i].error || ''));
+        lines.push('```');
+        lines.push('');
+    }
+    return lines.join('\n');
+}
+
 module.exports = {
     runSetupCommands: runSetupCommands,
-    truncateSetupError: truncateSetupError
+    truncateSetupError: truncateSetupError,
+    buildSetupWarningsMarkdown: buildSetupWarningsMarkdown
 };

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -366,7 +366,16 @@ function action(params) {
         // 3.5. Run project-specific prerequisite/setup commands (e.g. install JDK/Maven,
         // verify build credentials) before the CLI agent starts coding.
         try {
-            setupCommands.runSetupCommands(customParams, config.workingDir);
+            var setupResult = setupCommands.runSetupCommands(customParams, config.workingDir);
+            var setupWarnings = setupCommands.buildSetupWarningsMarkdown(setupResult);
+            if (setupWarnings) {
+                try {
+                    file_write({ path: folder + '/setup_warnings.md', content: setupWarnings });
+                    console.log('⚠️ Wrote setup_warnings.md (non-fatal setup command failure(s))');
+                } catch (writeErr) {
+                    console.warn('Failed to write setup_warnings.md:', writeErr);
+                }
+            }
         } catch (e) {
             var setupError = e && e.toString ? e.toString() : String(e);
             console.error('Setup commands failed:', setupError);

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -169,7 +169,16 @@ function action(params) {
         // Step 4.6: Run project-specific prerequisite/setup commands (e.g. install
         // JDK/Maven, verify build credentials) before the CLI agent starts fixing code.
         try {
-            setupCommands.runSetupCommands(customParams, config.workingDir);
+            var setupResult = setupCommands.runSetupCommands(customParams, config.workingDir);
+            var setupWarnings = setupCommands.buildSetupWarningsMarkdown(setupResult);
+            if (setupWarnings) {
+                try {
+                    file_write({ path: inputFolder + '/setup_warnings.md', content: setupWarnings });
+                    console.log('⚠️ Wrote setup_warnings.md (non-fatal setup command failure(s))');
+                } catch (writeErr) {
+                    console.warn('Failed to write setup_warnings.md:', writeErr);
+                }
+            }
         } catch (e) {
             failSetup(ticketKey, inputFolder, 'Environment setup failed: ' + (e && e.toString ? e.toString() : String(e)));
         }

--- a/js/unit-tests/test_setupCommands.js
+++ b/js/unit-tests/test_setupCommands.js
@@ -154,3 +154,92 @@ suite('setupCommands helper', function() {
         assert.equal(loaded.mod.truncateSetupError(undefined), undefined);
     });
 });
+
+suite('setupCommands buildSetupWarningsMarkdown', function() {
+
+    test('returns null when there are no failures', function() {
+        var loaded = loadSetupCommands();
+        var result = loaded.mod.runSetupCommands({
+            setupCommands: ['bash agents/setup/java.sh 25']
+        }, './dependencies/repo');
+
+        assert.equal(loaded.mod.buildSetupWarningsMarkdown(result), null);
+    });
+
+    test('returns null for an empty/undefined result', function() {
+        var loaded = loadSetupCommands();
+        assert.equal(loaded.mod.buildSetupWarningsMarkdown(undefined), null);
+        assert.equal(loaded.mod.buildSetupWarningsMarkdown({}), null);
+    });
+
+    test('summarizes a non-fatal (default allowFailure) command failure', function() {
+        // Regression test for: a setup command like "build-test-database-image" can be
+        // downgraded from allowFailure:false (hard job-stopping) to the default
+        // non-fatal behavior once its underlying infra prerequisite (e.g. Docker/
+        // Testcontainers reachability) is already verified by an earlier, separate
+        // required step. Non-fatal failures are otherwise only logged to the CI
+        // console (see runSetupCommands) — the CLI coding agent never sees them unless
+        // the caller writes this markdown out to an input file (e.g.
+        // setup_warnings.md), so the agent can notice and attempt a fix instead of
+        // working on the ticket with zero awareness that setup found a real problem.
+        var loaded = loadSetupCommands({
+            cli_execute_command: function(args) {
+                if (args.command === 'mvn clean verify') {
+                    throw new Error('Found more than one migration with version 2026.08.31.11.00');
+                }
+                return 'ok';
+            }
+        });
+
+        var result = loaded.mod.runSetupCommands({
+            setupCommands: [
+                { name: 'build-test-database-image', command: 'mvn clean verify' }
+            ]
+        }, './dependencies/repo');
+
+        var markdown = loaded.mod.buildSetupWarningsMarkdown(result);
+        assert.ok(markdown, 'should produce a markdown summary');
+        assert.ok(markdown.indexOf('build-test-database-image') !== -1, 'should mention the failing step name');
+        assert.ok(markdown.indexOf('Found more than one migration') !== -1, 'should include the underlying error');
+    });
+
+    test('summarizes multiple non-fatal failures and skips successful commands', function() {
+        var loaded = loadSetupCommands({
+            cli_execute_command: function(args) {
+                if (args.command === 'fails-one') throw new Error('error one');
+                if (args.command === 'fails-two') throw new Error('error two');
+                return 'ok';
+            }
+        });
+
+        var result = loaded.mod.runSetupCommands({
+            setupCommands: [
+                { name: 'step-ok', command: 'succeeds' },
+                { name: 'step-one', command: 'fails-one' },
+                { name: 'step-two', command: 'fails-two' }
+            ]
+        }, './dependencies/repo');
+
+        var markdown = loaded.mod.buildSetupWarningsMarkdown(result);
+        assert.ok(markdown.indexOf('step-one') !== -1);
+        assert.ok(markdown.indexOf('error one') !== -1);
+        assert.ok(markdown.indexOf('step-two') !== -1);
+        assert.ok(markdown.indexOf('error two') !== -1);
+        assert.equal(markdown.indexOf('step-ok'), -1, 'should not mention successful commands');
+    });
+
+    test('truncates huge error output embedded in the markdown', function() {
+        var hugeOutput = 'Y'.repeat(500000);
+        var loaded = loadSetupCommands({
+            cli_execute_command: function() { throw new Error(hugeOutput); }
+        });
+
+        var result = loaded.mod.runSetupCommands({
+            setupCommands: [{ name: 'flaky-step', command: 'flaky' }]
+        }, './dependencies/repo');
+
+        var markdown = loaded.mod.buildSetupWarningsMarkdown(result);
+        assert.ok(markdown.length < 10000, 'markdown must stay bounded, got ' + markdown.length + ' chars');
+        assert.ok(markdown.indexOf('truncated') !== -1);
+    });
+});

--- a/js/unit-tests/test_workingDir.js
+++ b/js/unit-tests/test_workingDir.js
@@ -66,7 +66,7 @@ function loadPreCli(workingDir) {
             './fetchQuestionsToInput.js': { action: function() {} },
             './fetchLinkedTestsToInput.js': { action: function() {} },
             './restoreFromReleases.js': { action: function() {} },
-            './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; } }
+            './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; }, buildSetupWarningsMarkdown: function() { return null; } }
         }),
         {
             cli_execute_command: mockCli,
@@ -185,7 +185,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './fetchQuestionsToInput.js': { action: function() {} },
                 './fetchLinkedTestsToInput.js': { action: function() {} },
                 './restoreFromReleases.js': { action: function() {} },
-                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; } }
+                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; }, buildSetupWarningsMarkdown: function() { return null; } }
             }),
             {
                 cli_execute_command: mockCli,
@@ -258,7 +258,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './fetchQuestionsToInput.js': { action: function() {} },
                 './fetchLinkedTestsToInput.js': { action: function() {} },
                 './restoreFromReleases.js': { action: function() {} },
-                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; } }
+                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; }, buildSetupWarningsMarkdown: function() { return null; } }
             }),
             {
                 cli_execute_command: mockCli,
@@ -335,7 +335,7 @@ suite('preCliDevelopmentSetup > runCmd workingDir', function() {
                 './fetchQuestionsToInput.js': { action: function() {} },
                 './fetchLinkedTestsToInput.js': { action: function() {} },
                 './restoreFromReleases.js': { action: function() {} },
-                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; } }
+                './common/setupCommands.js': { runSetupCommands: function() { return { ran: 0, results: [] }; }, buildSetupWarningsMarkdown: function() { return null; } }
             }),
             {
                 cli_execute_command: mockCli,


### PR DESCRIPTION
## Problem
setupCommands.runSetupCommands() already has an `allowFailure` flag (default `true`) to make a setup step non-fatal instead of aborting the whole job. But non-fatal failures were only `console.warn`'d — the return value of runSetupCommands() is discarded by both callers (preCliDevelopmentSetup.js, preCliReworkSetup.js), so neither the tracker comment nor the CLI coding agent's input context ever surfaces them.

This matters because a step can legitimately be downgraded from `allowFailure: false` to non-fatal once its actual infra prerequisite is independently verified by an earlier required step (e.g. a Docker/Testcontainers-reachability check already runs and hard-fails separately, so a subsequent 'build the project's test image' step failing is now almost certainly a content problem — a bad migration file, a broken test — not an infra one). Without this change, downgrading such a step means the CLI agent starts working on the ticket completely unaware that setup already found a concrete, likely-fixable problem.

## Fix
Add `setupCommands.buildSetupWarningsMarkdown(runResult)`: builds a markdown summary of any non-fatal command failures, or returns `null` if none. Both `preCliDevelopmentSetup.js` and `preCliReworkSetup.js` now call it after `runSetupCommands()` and write the result to `setup_warnings.md` in the input folder — the same pattern already used for `merge_conflicts.md` — so the CLI agent can read it and attempt a fix as part of its task.

## Testing
- Added unit tests in `test_setupCommands.js` covering: no failures → null, empty/undefined result → null, single non-fatal failure summarized with step name + error, multiple failures summarized while successful commands are excluded, huge error output truncated.
- Fixed two now-stale `setupCommands.js` mocks in `test_workingDir.js` that only stubbed `runSetupCommands` (missing the new `buildSetupWarningsMarkdown`), which broke 3 pre-existing tests that exercise `preCliDevelopmentSetup.js`'s full `action()` flow.
- Full suite: 833 passed, 2 failed — same 2 pre-existing/unrelated failures as on `main` before this change (smAgent label-adding test, agentDocsCoverage doc-gen check).