### PR TITLE
feat(discovery): read and reply to inline comments across the whole page tree

### DIFF
--- a/discovery.json
+++ b/discovery.json
@@ -23,6 +23,7 @@
       "./agents/instructions/discovery/modes.md",
       "./agents/instructions/discovery/output_rules.md",
       "./agents/instructions/discovery/formatting_rules.md",
+      "./agents/instructions/discovery/confluence_comments.md",
       "./agents/instructions/common/dmtools_cli.md",
       "./agents/prompts/bash_tools.md"
     ],

--- a/instructions/discovery/confluence_comments.md
+++ b/instructions/discovery/confluence_comments.md
@@ -1,0 +1,45 @@
+# Confluence inline comments (discovery page tree)
+
+Same principle as the story_solution/story_description agents' Confluence output flow, adapted for a discovery run's whole page tree (not just one page).
+
+## Reading comments
+
+On an iteration run, `input/<ticket>/discovery_comments.md` and `.json` (if present) list the inline (annotation) comments collected from **every page already published for this ticket** — the ticket's own page and every child/descendant page, at any depth (not just the source pages referenced by the ticket). Each entry carries `pageId`, `pageTitle`, `resolved`, `author`, and `body`. Match `pageTitle` against the file you are editing in `outputs/discovery/` (same title, same sanitized filename) to know which comment belongs to which of your output files.
+
+- Treat **unresolved** comments as review feedback: if a comment points out a mistake, asks a clarifying question, disagrees with a conclusion, or requests a change — go through **every single one**, not just the ones that are easiest to address. Don't silently skip a comment because it doesn't fit neatly into the current delta; if it's genuinely out of scope for this run, still leave a factual reply (see below) explaining that rather than leaving it unanswered.
+- Already **resolved** comments need no action, but may provide useful context.
+- If a comment is itself a question the reader is asking you (not just feedback on a conclusion), answer it directly — both in the updated page content (if the answer belongs there) and in your reply (see below).
+
+## Inline comment anchors (`[[ic:...]]` placeholders)
+
+Each snapshotted file under `outputs/discovery/` may contain placeholders like `[[ic:550e8400-e29b-41d4-a716-446655440000]]anchored text[[/ic]]`. Each one marks the text fragment an inline comment is anchored to on the published page. On publish, the Confluence Markdown sync converts these placeholders back into real page anchors; if you drop or mangle them, the comment loses its anchor and disappears from the page.
+
+Rules:
+
+- **Always preserve** every `[[ic:REF]]...[[/ic]]` placeholder, wrapped around the same text it currently marks.
+- If you rephrase the anchored text, **move the placeholder** so it wraps the new equivalent fragment.
+- On headings, place the placeholder **inside** the heading, after the `#` markers — `## [[ic:REF]]Purpose[[/ic]]`, never `[[ic:REF]]## Purpose[[/ic]]` (wrapping the `#` prefix breaks heading rendering).
+- The same applies to list items and quotes: keep `-`, `1.`, `>` outside the placeholder.
+- Remove a placeholder only when you intentionally remove the commented content itself.
+- Never invent new `[[ic:...]]` refs — only the ones already present are valid.
+
+## Replying to comments
+
+When your update directly addresses an unresolved comment — whether by changing the content, or by explicitly explaining why you didn't — add a reply entry to `outputs/confluence_replies.json`. The file must be a JSON array, and can contain replies to comments on **any page in the tree**, not just the root:
+
+```json
+[
+  {
+    "pageId": "12345678",
+    "commentId": "98765432",
+    "body": "Updated the recommendation to account for this — see the Recommendations page."
+  }
+]
+```
+
+Rules:
+
+- `pageId` and `commentId` must come from `input/<ticket>/discovery_comments.md`/`.json` — never invented.
+- Reply to every unresolved comment you addressed this run, even briefly — a comment left silently unanswered looks ignored to the reader even if you did act on it elsewhere in the page tree.
+- Keep replies concise and professional. If the comment asked a direct question, the reply should contain the actual answer (or point to the exact section that does), not just "addressed."
+- If no comment needs a reply, omit the file or write an empty array `[]`.

--- a/js/prepareDiscoveryContext.js
+++ b/js/prepareDiscoveryContext.js
@@ -28,11 +28,24 @@
  *     and the existing page id (if found) — read by the matching postJSAction
  *     (publishDiscoveryToConfluence.js) so both steps agree on where to publish
  *     without re-resolving config or re-querying Confluence twice.
+ *  4. Same principle as the story_solution/story_description agents' Confluence
+ *     output flow (see js/common/contentOutput.js): while snapshotting each page
+ *     in the tree, also (a) re-expose that page's inline comment anchors as
+ *     [[ic:REF]]...[[/ic]] placeholders directly inside its snapshotted
+ *     Markdown file, and (b) collect that page's inline comments into a single
+ *     input/<ticket>/discovery_comments.md + .json across the WHOLE tree (not
+ *     just the ticket's own root page) — the discovery agent instructions
+ *     (instructions/discovery/confluence_comments.md) tell the CLI agent to
+ *     treat these as review feedback and reply via
+ *     outputs/confluence_replies.json, which publishDiscoveryToConfluence.js
+ *     then posts back with contentOutput.publishCommentReplies() after sync.
  */
 
 var configLoader = require('./configLoader.js');
+var contentOutput = require('./common/contentOutput.js');
 
 var DISCOVERY_OUTPUT_DIR = 'outputs/discovery';
+var COMMENTS_BASE_NAME = 'discovery_comments';
 
 function sanitizeFileName(title) {
     return String(title || 'untitled').replace(/[\\/:*?"<>|]/g, '-').trim();
@@ -54,6 +67,43 @@ function findTicketPage(children, ticketKey) {
 }
 
 /**
+ * Re-expose a page's inline comment anchors as [[ic:REF]]...[[/ic]]
+ * placeholders inside its Markdown body (same mechanism as
+ * fetchConfluenceOutputContext.js for story_solution/story_description — see
+ * contentOutput.js's "Inline comment anchors" section). Storage-format markers
+ * are stripped by the Markdown conversion, so this re-derives them from a
+ * separate storage-format fetch. Non-fatal: returns the body unchanged on any
+ * failure (e.g. page has no comments, or the lookup itself fails).
+ */
+function injectCommentAnchors(pageId, body) {
+    try {
+        var storage = confluence_content_by_id({ contentId: pageId });
+        var storageBody = storage && storage.body && storage.body.storage && storage.body.storage.value;
+        var anchors = contentOutput.extractInlineCommentMarkers(storageBody);
+        if (anchors.length === 0) return body;
+        var injected = contentOutput.injectCommentPlaceholders(body, anchors);
+        return injected.content;
+    } catch (e) {
+        console.warn('prepareDiscoveryContext: inline comment anchor extraction failed for page ' + pageId + ' (non-fatal):', e);
+        return body;
+    }
+}
+
+/**
+ * Fetch a page's inline comments and append them to the shared accumulator
+ * (see snapshotPageTree). Non-fatal: logs and leaves the accumulator
+ * untouched on failure.
+ */
+function collectPageComments(pageId, pageTitle, allComments) {
+    try {
+        var comments = contentOutput.fetchPageInlineComments(pageId, pageTitle, 100);
+        Array.prototype.push.apply(allComments, comments);
+    } catch (e) {
+        console.warn('prepareDiscoveryContext: failed to fetch inline comments for page ' + pageId + ' (non-fatal):', e);
+    }
+}
+
+/**
  * Recursively snapshot an existing discovery page + all of its descendants
  * (any depth) as Markdown files directly into outputs/discovery/ (see module
  * docstring): index.md for a page's own body at each level, one file (or, if
@@ -62,17 +112,27 @@ function findTicketPage(children, ticketKey) {
  * itself produces when publishing (see output_rules.md), so a round-trip
  * (publish → seed next run → publish again) is lossless.
  *
+ * Also, for every page visited (root + every descendant, any depth): injects
+ * [[ic:REF]]...[[/ic]] inline comment anchor placeholders into its snapshotted
+ * body, and appends its inline comments to allComments — see module docstring
+ * point 4 and instructions/discovery/confluence_comments.md.
+ *
  * @param {Object} page - Confluence content object (needs .id)
  * @param {string} targetDir - local directory to write this page's own
  *     index.md into (its children go into named subfolders/files here)
+ * @param {Array} allComments - shared accumulator; every visited page's
+ *     inline comments are appended here (pageId/pageTitle-tagged, see
+ *     contentOutput.fetchPageInlineComments)
  * @returns {number} total number of descendant pages snapshotted (all depths)
  */
-function snapshotPageTree(page, targetDir) {
+function snapshotPageTree(page, targetDir, allComments) {
     var total = 0;
     try {
         var rootMd = confluence_content_by_id({ contentId: page.id, format: 'md' });
         var rootBody = (rootMd && rootMd.body && rootMd.body.storage && rootMd.body.storage.value) || '';
+        rootBody = injectCommentAnchors(page.id, rootBody);
         file_write(targetDir + '/index.md', rootBody || '_(existing page had no body)_');
+        collectPageComments(page.id, page.title, allComments);
 
         var children = confluence_get_children_by_id({ contentId: page.id, format: 'md' }) || [];
         children.forEach(function(child) {
@@ -90,11 +150,13 @@ function snapshotPageTree(page, targetDir) {
                 // This child has its own descendants — recurse into a subfolder
                 // named after it, matching the sync tool's folder-with-index.md
                 // convention for a page that itself has children.
-                total += snapshotPageTree(child, targetDir + '/' + fileName);
+                total += snapshotPageTree(child, targetDir + '/' + fileName, allComments);
             } else {
                 // Leaf page — a single Markdown file is enough.
                 var childBody = (child.body && child.body.storage && child.body.storage.value) || '';
+                childBody = injectCommentAnchors(child.id, childBody);
                 file_write(targetDir + '/' + fileName + '.md', childBody || '_(existing page had no body)_');
+                collectPageComments(child.id, child.title, allComments);
             }
         });
 
@@ -146,10 +208,24 @@ function action(params) {
 
         meta.existingPageId = existing.id;
         console.log('Found existing discovery page for ' + ticketKey + ': ' + existing.id + ' ("' + existing.title + '") — seeding ' + DISCOVERY_OUTPUT_DIR + ' with its current content (full tree, recursively) for in-place editing.');
-        var snapshotted = snapshotPageTree(existing, DISCOVERY_OUTPUT_DIR);
+        var allComments = [];
+        var snapshotted = snapshotPageTree(existing, DISCOVERY_OUTPUT_DIR, allComments);
         file_write(folder + '/discovery_meta.json', JSON.stringify(meta, null, 2));
 
-        return { success: true, action: 'iteration', ticketKey: ticketKey, existingPageId: existing.id, snapshottedPages: snapshotted };
+        if (folder && allComments.length > 0) {
+            contentOutput.writeCommentsFiles(folder, allComments, COMMENTS_BASE_NAME);
+            console.log('Collected ' + allComments.length + ' inline comment(s) across the discovery page tree (' +
+                (snapshotted + 1) + ' page(s)) into input/' + ticketKey + '/' + COMMENTS_BASE_NAME + '.md');
+        }
+
+        return {
+            success: true,
+            action: 'iteration',
+            ticketKey: ticketKey,
+            existingPageId: existing.id,
+            snapshottedPages: snapshotted,
+            commentsCount: allComments.length
+        };
     } catch (error) {
         console.error('Error in prepareDiscoveryContext:', error);
         try {
@@ -162,5 +238,5 @@ function action(params) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { action, findTicketPage, sanitizeFileName, snapshotPageTree, DISCOVERY_OUTPUT_DIR };
+    module.exports = { action, findTicketPage, sanitizeFileName, snapshotPageTree, injectCommentAnchors, collectPageComments, DISCOVERY_OUTPUT_DIR, COMMENTS_BASE_NAME };
 }

--- a/js/publishDiscoveryToConfluence.js
+++ b/js/publishDiscoveryToConfluence.js
@@ -16,12 +16,18 @@
  *  3. Sync outputs/discovery/ under that page via
  *     confluence_sync_markdown_directory (index.md becomes the page's own
  *     body; every other .md file becomes a child page).
- *  4. Post a Jira comment linking to the page, plus the usual token-usage
+ *  4. Post replies to any inline comments the CLI agent directly addressed
+ *     (outputs/confluence_replies.json — same mechanism as
+ *     story_solution/story_description, see contentOutput.js), using
+ *     confluence_reply_to_inline_comment via
+ *     contentOutput.publishCommentReplies().
+ *  5. Post a Jira comment linking to the page, plus the usual token-usage
  *     comment.
  */
 
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
+var contentOutput = require('./common/contentOutput.js');
 
 var DISCOVERY_OUTPUT_DIR = 'outputs/discovery';
 
@@ -143,9 +149,24 @@ function action(params) {
         var pageUrl = resolvePageUrl(page);
         var syncedCount = (syncSummary.syncedPages && syncSummary.syncedPages.length) || 0;
 
+        // Same principle as story_solution/story_description (contentOutput.js):
+        // the CLI agent may have written outputs/confluence_replies.json when it
+        // directly addressed one of the inline comments collected by
+        // prepareDiscoveryContext.js (discovery_comments.md/json). Post those
+        // replies now that the sync has happened, so pageId/commentId still
+        // point at pages the sync just (re)published.
+        var replyResult = { posted: 0, failed: 0 };
+        try {
+            replyResult = contentOutput.publishCommentReplies();
+        } catch (replyError) {
+            console.warn('Failed to publish inline comment replies:', replyError);
+        }
+
         var comment = 'h3. 📚 Discovery published to Confluence\n\n' +
             (pageUrl ? 'Page: ' + pageUrl + '\n\n' : '') +
-            'Synced *' + syncedCount + '* page(s) from `' + DISCOVERY_OUTPUT_DIR + '`.';
+            'Synced *' + syncedCount + '* page(s) from `' + DISCOVERY_OUTPUT_DIR + '`.' +
+            (replyResult.posted > 0 ? '\n\nReplied to *' + replyResult.posted + '* inline comment(s).' : '') +
+            (replyResult.failed > 0 ? ' (' + replyResult.failed + ' reply attempt(s) failed — see job log.)' : '');
         try {
             jira_post_comment({ key: ticketKey, comment: comment });
         } catch (commentError) {
@@ -158,14 +179,17 @@ function action(params) {
             console.warn('Failed to post token usage comments:', e);
         }
 
-        console.log('✅ Published discovery for ' + ticketKey + ' to Confluence page ' + page.id);
+        console.log('✅ Published discovery for ' + ticketKey + ' to Confluence page ' + page.id +
+            (replyResult.posted > 0 ? ' (' + replyResult.posted + ' comment repl(y/ies) posted)' : ''));
         return {
             success: true,
             action: 'published',
             ticketKey: ticketKey,
             pageId: page.id,
             pageUrl: pageUrl,
-            syncedPages: syncedCount
+            syncedPages: syncedCount,
+            commentRepliesPosted: replyResult.posted,
+            commentRepliesFailed: replyResult.failed
         };
     } catch (error) {
         console.error('Error in publishDiscoveryToConfluence:', error);

--- a/js/unit-tests/test_prepareDiscoveryContext.js
+++ b/js/unit-tests/test_prepareDiscoveryContext.js
@@ -6,6 +6,7 @@ function loadPrepareDiscoveryContext(mocks, discoveryConfig) {
     var defaults = {
         confluence_get_children_by_id: function() { return []; },
         confluence_content_by_id: function() { return { body: { storage: { value: '' } } }; },
+        confluence_get_page_inline_comments: function() { return '{}'; },
         file_write: function() {}
     };
 
@@ -14,13 +15,17 @@ function loadPrepareDiscoveryContext(mocks, discoveryConfig) {
             return { discovery: discoveryConfig || {} };
         }
     };
+    var globals = Object.assign({}, defaults, mocks || {});
 
     return loadModule(
         'js/prepareDiscoveryContext.js',
         makeRequire({
-            './configLoader.js': configLoaderMock
+            './configLoader.js': configLoaderMock,
+            './common/contentOutput.js': loadModule('js/common/contentOutput.js',
+                makeRequire({ '../configLoader.js': { loadProjectConfig: function() { return {}; } } }),
+                globals)
         }),
-        Object.assign({}, defaults, mocks || {})
+        globals
     );
 }
 
@@ -148,6 +153,89 @@ suite('prepareDiscoveryContext', function() {
         assert.equal(writes['outputs/discovery/Topic Area/index.md'], '# Topic Area\nintro');
         // ... and its own child becomes a leaf file inside that subfolder.
         assert.equal(writes['outputs/discovery/Topic Area/Detail Page.md'], '# Detail Page\nnested content');
+    });
+
+    test('iteration — collects inline comments across the whole tree into discovery_comments.md/json', function() {
+        var writes = {};
+        var mod = loadPrepareDiscoveryContext({
+            confluence_get_children_by_id: function(args) {
+                if (args.contentId === '123') {
+                    return [{ id: '456', title: 'PROJ-2 Some feature' }];
+                }
+                if (args.contentId === '456') {
+                    return [{ id: '457', title: 'PRD', body: { storage: { value: '# PRD\ncontent' } } }];
+                }
+                return [];
+            },
+            confluence_content_by_id: function(args) {
+                return { body: { storage: { value: '' } } };
+            },
+            confluence_get_page_inline_comments: function(args) {
+                if (args.pageId === '456') {
+                    return JSON.stringify({ results: [{ id: 'c1', resolutionStatus: 'open', body: 'Root comment' }] });
+                }
+                if (args.pageId === '457') {
+                    return JSON.stringify({ results: [{ id: 'c2', resolutionStatus: 'open', body: 'PRD comment' }] });
+                }
+                return '{}';
+            },
+            file_write: function(p, c) { writes[p] = c; }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.action, 'iteration');
+        assert.equal(result.commentsCount, 2);
+        var commentsJson = JSON.parse(writes['input/PROJ-2/discovery_comments.json']);
+        assert.equal(commentsJson.comments.length, 2);
+        assert.equal(commentsJson.comments[0].pageId, '456');
+        assert.equal(commentsJson.comments[0].commentId, 'c1');
+        assert.equal(commentsJson.comments[1].pageId, '457');
+        assert.equal(commentsJson.comments[1].commentId, 'c2');
+        assert.contains(writes['input/PROJ-2/discovery_comments.md'], 'Root comment');
+        assert.contains(writes['input/PROJ-2/discovery_comments.md'], 'PRD comment');
+    });
+
+    test('iteration — no comments anywhere in the tree does not write discovery_comments files', function() {
+        var writes = {};
+        var mod = loadPrepareDiscoveryContext({
+            confluence_get_children_by_id: function(args) {
+                if (args.contentId === '123') return [{ id: '456', title: 'PROJ-2 Some feature' }];
+                return [];
+            },
+            confluence_get_page_inline_comments: function() { return '{}'; },
+            file_write: function(p, c) { writes[p] = c; }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        mod.action(makeParams());
+
+        assert.equal(writes['input/PROJ-2/discovery_comments.json'], undefined);
+        assert.equal(writes['input/PROJ-2/discovery_comments.md'], undefined);
+    });
+
+    test('iteration — inline comment anchors are re-exposed as [[ic:REF]] placeholders in the snapshotted body', function() {
+        var writes = {};
+        var REF = 'a40ec14d-0d73-4f55-9a69-7026900b6623';
+        var mod = loadPrepareDiscoveryContext({
+            confluence_get_children_by_id: function(args) {
+                if (args.contentId === '123') return [{ id: '456', title: 'PROJ-2 Some feature' }];
+                return [];
+            },
+            confluence_content_by_id: function(args) {
+                // First call (format:'md') returns the Markdown body; the second,
+                // format-less call (from injectCommentAnchors) returns the storage
+                // XML carrying the actual marker.
+                if (args.format === 'md') {
+                    return { body: { storage: { value: '# Index\nSome important text here.' } } };
+                }
+                return { body: { storage: { value: '<p>Some <ac:inline-comment-marker ac:ref="' + REF + '">important text</ac:inline-comment-marker> here.</p>' } } };
+            },
+            file_write: function(p, c) { writes[p] = c; }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        mod.action(makeParams());
+
+        assert.contains(writes['outputs/discovery/index.md'], '[[ic:' + REF + ']]important text[[/ic]]');
     });
 
     test('ticket-key prefix matching ignores tickets with the key as a substring elsewhere', function() {

--- a/js/unit-tests/test_publishDiscoveryToConfluence.js
+++ b/js/unit-tests/test_publishDiscoveryToConfluence.js
@@ -9,6 +9,8 @@ function loadPublishDiscovery(mocks, discoveryConfig) {
         confluence_update_page: function(args) { return { id: args.contentId, title: args.title, _links: { webui: '/wiki/spaces/DISC/pages/1', base: 'https://confluence.example.com' } }; },
         confluence_content_by_id: function(args) { return { id: args.contentId, _links: { webui: '/wiki/spaces/DISC/pages/1', base: 'https://confluence.example.com' } }; },
         confluence_sync_markdown_directory: function() { return JSON.stringify({ syncedPages: ['index', 'prd'] }); },
+        confluence_reply_to_inline_comment: function() {},
+        file_read: function() { throw new Error('no replies file'); },
         jira_post_comment: function() {}
     };
 
@@ -17,14 +19,18 @@ function loadPublishDiscovery(mocks, discoveryConfig) {
             return { discovery: discoveryConfig || {} };
         }
     };
+    var globals = Object.assign({}, defaults, mocks || {});
 
     return loadModule(
         'js/publishDiscoveryToConfluence.js',
         makeRequire({
             './configLoader.js': configLoaderMock,
-            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
+            './common/contentOutput.js': loadModule('js/common/contentOutput.js',
+                makeRequire({ '../configLoader.js': { loadProjectConfig: function() { return {}; } } }),
+                globals)
         }),
-        Object.assign({}, defaults, mocks || {})
+        globals
     );
 }
 
@@ -203,6 +209,49 @@ suite('publishDiscoveryToConfluence', function() {
         assert.equal(result.action, 'error');
         assert.equal(comments.length, 1);
         assert.contains(comments[0].comment, 'publish failed');
+    });
+
+    test('posts replies from outputs/confluence_replies.json after sync (same principle as story_solution)', function() {
+        var comments = [];
+        var replies = [];
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            },
+            file_read: function(opts) {
+                var path = opts && (opts.path || opts);
+                if (path === 'outputs/confluence_replies.json') {
+                    return JSON.stringify([
+                        { pageId: '457', commentId: 'c2', body: 'Addressed in the PRD update.' }
+                    ]);
+                }
+                throw new Error('not found: ' + path);
+            },
+            confluence_reply_to_inline_comment: function(args) { replies.push(args); },
+            jira_post_comment: function(args) { comments.push(args); }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.success, true);
+        assert.equal(result.commentRepliesPosted, 1);
+        assert.equal(replies.length, 1);
+        assert.equal(replies[0].pageId, '457');
+        assert.equal(replies[0].commentId, 'c2');
+        assert.contains(comments[0].comment, 'Replied to *1* inline comment');
+    });
+
+    test('no replies file — publishes normally with commentRepliesPosted 0', function() {
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(result.success, true);
+        assert.equal(result.commentRepliesPosted, 0);
     });
 
 });


### PR DESCRIPTION
## Problem
The discovery agent's Confluence output flow only ever **read** comments as generic ticket context (from externally-referenced source pages) — it never looked at comments left on the pages it itself produces (the discovery page tree: root + Recommendations/PRD/analysis sub-pages etc.), and it had no way to reply to a reader's clarifying question left as an inline comment. This is inconsistent with story_solution/story_description, which already have a full read-and-reply loop for their single Confluence output page (see `js/common/contentOutput.js`).

## Fix
Same principle as story_solution/story_description, extended to a whole page **tree** instead of a single page:

- `prepareDiscoveryContext.js`: while snapshotting each page in the tree (root + every descendant, any depth) for an iteration run, also:
  - re-expose that page's inline comment anchors as `[[ic:REF]]...[[/ic]]` placeholders directly inside its snapshotted Markdown file (same mechanism as `fetchConfluenceOutputContext.js`)
  - collect its inline comments into a single `input/<ticket>/discovery_comments.md` + `.json` spanning the whole tree
- `publishDiscoveryToConfluence.js`: after syncing, post any replies the CLI agent wrote to `outputs/confluence_replies.json` back via `contentOutput.publishCommentReplies()`
- New `instructions/discovery/confluence_comments.md`: a tree-aware variant of `instructions/common/confluence_comments.md` — tells the CLI agent to go through **every** unresolved comment on **every** page in the tree (not just the easy ones), answer clarifying questions directly, and reply referencing the correct page's `pageId`

## Testing
- Added regression tests: multi-page comment collection, anchor injection, reply-posting, no-replies-file case.
- Full `js/unit-tests` suite: 798 passed (up from 793 baseline), same 42 pre-existing/unrelated failures as baseline (confirmed via `git stash` diff — no new failures).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>