### PR TITLE
feat(copilot): native loop-guard for stuck agents

### DIFF
--- a/scripts/loop_guard.py
+++ b/scripts/loop_guard.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Loop-guard watcher for CLI coding-agent transcripts (Copilot CLI, Claude Code,
+Cursor, etc. — anything that logs tool calls in the "bullet block" format
+these CLIs use).
+
+Why this exists
+----------------
+Real-world CI runs have observed a coding-agent CLI get stuck issuing the
+SAME tool call over and over — e.g. hundreds of identical `grep` calls
+returning "No matches found", or hundreds of identical shell calls
+re-running the same command. The model can even self-label each repeat with
+an incrementing ordinal ("again", "third time", ...) — aware it kept
+repeating, but never breaking out on its own. Left unchecked, the job just
+burns CI minutes until someone notices the log and cancels it by hand (CI
+job timeouts are typically hours, not minutes).
+
+What this script does
+----------------------
+Polls a live transcript log file, parses it into an ordered list of tool-call
+"signatures" (tool type + normalized command/args — deliberately NOT
+including the bullet's free-text label, since that's exactly the part the
+model varies on every repeat with its ordinal counting), and checks whether
+the same signature appears >= --threshold times *consecutively* at the tail
+of the transcript. If so, it sends SIGTERM to the given pid (graceful, so a
+resumable CLI session/state is preserved) and writes a small JSON marker
+describing what was detected, for the caller to react to (see
+run_copilot_once_guarded() in scripts/providers/copilot.sh, which retries on
+the SAME model/session rather than switching models — a stuck model is not
+assumed to be a bad model, just a model that needs an explicit nudge that
+it's repeating itself).
+
+This script has no dependency on any particular CLI's internals — only on
+the common "bullet block" transcript rendering shape:
+
+    ● <free text label, e.g. an ordinal-numbered description> (<tool-type>)
+      │ <detail line 1>
+      │ <detail line 2>
+      └ <result summary>
+
+(the leading glyph is "●" for a completed/rendered call or "/" for one still
+in flight when the log was captured mid-stream; both are treated the same).
+"""
+import argparse
+import json
+import os
+import re
+import signal
+import sys
+import time
+
+HEADER_GLYPHS = ("\u25cf", "/")  # "●" (completed) or "/" (in-flight snapshot)
+DETAIL_RE = re.compile(r"^\s*\u2502\s?(?P<content>.*)$")  # "│ ..."
+FOOTER_RE = re.compile(r"^\s*\u2514\s?(?P<summary>.*)$")  # "└ ..."
+TRAILING_TYPE_RE = re.compile(r"\(([a-zA-Z][a-zA-Z0-9_-]*)\)\s*$")
+
+
+def parse_blocks(text):
+    """Parse a transcript into an ordered list of (tool_type, signature) tuples.
+
+    `tool_type` is the parenthesized word at the end of the bullet's header
+    line (e.g. "shell", "grep"), or "unknown" if there wasn't one. `signature`
+    is the normalized, whitespace-collapsed concatenation of the block's
+    "│ ..." detail lines — this is what actually distinguishes one tool call
+    from another; the header's free-text label is intentionally ignored.
+    """
+    blocks = []
+    lines = text.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped[:1] in HEADER_GLYPHS:
+            label = stripped[1:].strip()
+            type_match = TRAILING_TYPE_RE.search(label)
+            tool_type = type_match.group(1) if type_match else "unknown"
+            details = []
+            i += 1
+            while i < n:
+                detail_match = DETAIL_RE.match(lines[i])
+                if detail_match:
+                    details.append(detail_match.group("content").strip())
+                    i += 1
+                    continue
+                footer_match = FOOTER_RE.match(lines[i])
+                if footer_match:
+                    i += 1
+                break
+            signature = re.sub(r"\s+", " ", " ".join(details)).strip()
+            blocks.append((tool_type, signature))
+            continue
+        i += 1
+    return blocks
+
+
+def trailing_repeat(blocks, ignore_types=frozenset()):
+    """Return (repeat_count, (tool_type, signature)) for the run of identical
+    signatures at the END of `blocks`, skipping any block whose tool_type is
+    in `ignore_types` (e.g. a "wait"/"read-output" style call that's expected
+    to repeat harmlessly while a long-running shell command is polled).
+    Blocks with an EMPTY signature are never counted as a repeat (nothing
+    meaningful to compare — most commonly a parse artifact, not a real call).
+    """
+    filtered = [b for b in blocks if b[0] not in ignore_types and b[1]]
+    if not filtered:
+        return 0, None
+    last = filtered[-1]
+    count = 0
+    for b in reversed(filtered):
+        if b == last:
+            count += 1
+        else:
+            break
+    return count, last
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _kill_process_group(pid, sig):
+    """Best-effort: signal the whole process group led by `pid` if possible
+    (so a shell pipeline's children die too), falling back to just `pid`.
+    """
+    try:
+        os.killpg(os.getpgid(pid), sig)
+        return
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        os.kill(pid, sig)
+    except OSError:
+        pass
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-file", required=True, help="transcript file to poll")
+    parser.add_argument("--pid", required=True, type=int, help="process (group) to terminate on detection")
+    parser.add_argument("--marker-file", required=True, help="path to write a JSON detection marker to")
+    parser.add_argument("--threshold", type=int, default=int(os.environ.get("COPILOT_LOOP_GUARD_THRESHOLD", "5")))
+    parser.add_argument("--poll-interval", type=float, default=float(os.environ.get("COPILOT_LOOP_GUARD_POLL_SECONDS", "20")))
+    parser.add_argument(
+        "--ignore-types",
+        default=os.environ.get("COPILOT_LOOP_GUARD_IGNORE_TYPES", ""),
+        help="comma-separated tool types excluded from repeat detection (e.g. types that legitimately poll)",
+    )
+    args = parser.parse_args(argv)
+
+    ignore_types = frozenset(t.strip() for t in args.ignore_types.split(",") if t.strip())
+
+    while _pid_alive(args.pid):
+        time.sleep(args.poll_interval)
+        if not _pid_alive(args.pid):
+            break
+        if not os.path.exists(args.log_file):
+            continue
+        try:
+            with open(args.log_file, "r", errors="replace") as handle:
+                text = handle.read()
+        except OSError:
+            continue
+
+        blocks = parse_blocks(text)
+        count, signature = trailing_repeat(blocks, ignore_types=ignore_types)
+        if signature is not None and count >= args.threshold:
+            tool_type, normalized = signature
+            detail = {
+                "detected_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "pid": args.pid,
+                "repeat_count": count,
+                "threshold": args.threshold,
+                "tool_type": tool_type,
+                "command": normalized[:2000],
+            }
+            try:
+                with open(args.marker_file, "w", encoding="utf-8") as marker:
+                    json.dump(detail, marker, indent=2)
+            except OSError:
+                pass
+            _kill_process_group(args.pid, signal.SIGTERM)
+            return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/providers/copilot.sh
+++ b/scripts/providers/copilot.sh
@@ -158,6 +158,103 @@ run_copilot() {
     return "$status"
   }
 
+  # Runs `run_copilot_once` watched by scripts/loop_guard.py, which detects a
+  # stuck agent — the exact same tool call repeated over and over in the
+  # transcript (observed in real CI runs: the model can even self-label each
+  # repeat with an incrementing ordinal — "again", "third time", ... — aware
+  # it kept repeating, but never breaking out on its own). If detected,
+  # terminates the agent gracefully (SIGTERM, not SIGKILL, to preserve a
+  # resumable session) and retries a bounded number of times WITHOUT
+  # switching models: a stuck model is not assumed to be a *bad* model, just
+  # one that needs an explicit nudge that it repeated itself, and
+  # COPILOT_SESSION_NAME's own --resume logic (see setup/copilot-session.sh)
+  # means simply re-invoking transparently picks the same session back up.
+  #
+  # `set -m` gives the backgrounded subshell its own process group using
+  # nothing but standard bash job control — no external `setsid` binary
+  # needed — and, unlike re-invoking a fresh `bash -c '...'`, a plain
+  # subshell preserves this function's full variable/array state
+  # (copilot_cmd, copilot_session_args, PROMPT, ...), so run_copilot_once
+  # itself needs no changes at all.
+  #
+  # Creates its own transcript log file(s) (one per internal retry) via
+  # new_agent_log_file and appends each to the caller's copilot_log_files
+  # array, and updates $copilot_log to point at the LAST one used — relying
+  # on the same dynamic scoping retry_copilot_session_selection below
+  # already uses to mutate the caller's locals (copilot_log_files/exit_code
+  # are `local` to run_copilot(), and any function called while those locals
+  # are in scope sees and can assign them, same as any other bash function).
+  run_copilot_once_guarded() {
+    local label="$1"
+    local model="$2"
+
+    copilot_log="$(new_agent_log_file "${label}")"
+    copilot_log_files+=("$copilot_log")
+
+    if [ "${COPILOT_LOOP_GUARD_ENABLED:-true}" = "false" ] || ! command -v python3 >/dev/null 2>&1; then
+      run_copilot_once "$copilot_log" "$model"
+      return $?
+    fi
+
+    local guard_max_retries="${COPILOT_LOOP_GUARD_MAX_RETRIES:-2}"
+    local guard_attempt=0
+    local guard_status=1
+
+    while :; do
+      local marker
+      marker="$(mktemp)"
+      rm -f "${marker}"
+
+      # Preserve/restore whatever monitor-mode state this shell already had
+      # (run-agent.sh runs everything under `set -euo pipefail`, without
+      # `-m`) rather than assuming it was off.
+      local was_monitor_mode=0
+      case $- in *m*) was_monitor_mode=1 ;; esac
+      set -m
+      ( run_copilot_once "${copilot_log}" "${model}" ) &
+      local run_pid=$!
+      [ "${was_monitor_mode}" -eq 1 ] || set +m
+
+      python3 "${script_dir}/../loop_guard.py" \
+        --log-file "${copilot_log}" \
+        --pid "${run_pid}" \
+        --marker-file "${marker}" \
+        --threshold "${COPILOT_LOOP_GUARD_THRESHOLD:-5}" \
+        --poll-interval "${COPILOT_LOOP_GUARD_POLL_SECONDS:-20}" \
+        --ignore-types "${COPILOT_LOOP_GUARD_IGNORE_TYPES:-}" \
+        >/dev/null 2>&1 &
+      local guard_pid=$!
+
+      set +e
+      wait "${run_pid}"
+      guard_status=$?
+      set -e
+      kill "${guard_pid}" 2>/dev/null || true
+      wait "${guard_pid}" 2>/dev/null || true
+
+      if [ ! -s "${marker}" ]; then
+        rm -f "${marker}"
+        break
+      fi
+
+      echo ""
+      echo "🔁 loop-guard: $(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(f\"detected {d['repeat_count']} consecutive identical {d['tool_type']} calls (threshold {d['threshold']}): {d['command'][:200]}\")" "${marker}" 2>/dev/null || echo "detected a stuck repeat")"
+      rm -f "${marker}"
+
+      if [ "${guard_attempt}" -ge "${guard_max_retries}" ]; then
+        echo "🔁 loop-guard: repeat limit (${guard_max_retries} retries) exhausted without breaking the loop; giving up on this attempt so it fails visibly instead of running until the CI timeout" >&2
+        break
+      fi
+
+      guard_attempt=$((guard_attempt + 1))
+      echo "🔁 loop-guard: terminated the agent gracefully; retrying ${guard_attempt}/${guard_max_retries} on the SAME model/session (no fallback model — the CLI's own session-resume will pick this up automatically)"
+      copilot_log="$(new_agent_log_file "${label}-loopguard${guard_attempt}")"
+      copilot_log_files+=("$copilot_log")
+    done
+
+    return "${guard_status}"
+  }
+
   retry_copilot_session_selection() {
     local log_file="$1"
     local model="$2"
@@ -216,10 +313,8 @@ run_copilot() {
 
   while [ "$attempt" -le "$max_attempts" ]; do
     local copilot_log
-    copilot_log="$(new_agent_log_file "copilot-attempt${attempt}")"
-    copilot_log_files+=("$copilot_log")
     set +e
-    run_copilot_once "$copilot_log" "$copilot_model_value"
+    run_copilot_once_guarded "copilot-attempt${attempt}" "$copilot_model_value"
     exit_code=$?
     set -e
 
@@ -240,10 +335,8 @@ run_copilot() {
         COPILOT_SESSION_NAME="${COPILOT_SESSION_NAME}-r$(date +%s)"
         copilot_session_args=(--name "${COPILOT_SESSION_NAME}")
         copilot_session_mode="name"
-        copilot_log="$(new_agent_log_file "copilot-attempt${attempt}-fresh")"
-        copilot_log_files+=("$copilot_log")
         set +e
-        run_copilot_once "$copilot_log" "$copilot_model_value"
+        run_copilot_once_guarded "copilot-attempt${attempt}-fresh" "$copilot_model_value"
         exit_code=$?
         set -e
       fi
@@ -258,10 +351,8 @@ run_copilot() {
       echo ""
       echo "Copilot model ${copilot_model_value} is unavailable; retrying with ${copilot_default_model}"
       record_codegraph_usage "$copilot_log"
-      copilot_log="$(new_agent_log_file "copilot-attempt${attempt}-fallback")"
-      copilot_log_files+=("$copilot_log")
       set +e
-      run_copilot_once "$copilot_log" "$copilot_default_model"
+      run_copilot_once_guarded "copilot-attempt${attempt}-fallback" "$copilot_default_model"
       exit_code=$?
       set -e
       copilot_model_value="$copilot_default_model"

--- a/scripts/providers/tests/test_copilot_loop_guard.sh
+++ b/scripts/providers/tests/test_copilot_loop_guard.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Exercises run_copilot_once_guarded()'s job-control-based loop detection and
+# recovery (see scripts/loop_guard.py and the run_copilot_once_guarded()
+# comment block in ../copilot.sh for the full rationale). Uses a fake
+# `copilot` binary that repeats the same tool-call block forever until
+# killed, to simulate the real-world stuck-agent transcripts that motivated
+# this feature (see loop_guard.py's module docstring).
+set -euo pipefail
+
+PROVIDERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+source "${PROVIDERS_DIR}/_common.sh"
+source "${PROVIDERS_DIR}/copilot.sh"
+
+# Writes a fake `copilot` binary that:
+#  - on --help, behaves like the real CLI (needed by copilot-session.sh probing)
+#  - otherwise increments a shared attempt counter (persisted in a file, so it
+#    survives across the separate process invocations the guard's retries are)
+#  - keeps repeating the identical "stuck" tool-call block forever until its
+#    attempt number reaches SUCCEED_ON_ATTEMPT, at which point it prints a
+#    normal successful transcript + usage footer and exits 0
+write_fake_copilot() {
+  local fake_bin="$1"
+  local attempt_marker="$2"
+  local succeed_on_attempt="$3"
+  cat > "${fake_bin}/copilot" << BINEOF
+#!/bin/bash
+if [ "\${1:-}" = "--help" ]; then
+  echo "  --session-id"
+  exit 0
+fi
+attempt=1
+if [ -f "${attempt_marker}" ]; then
+  attempt=\$(( \$(cat "${attempt_marker}") + 1 ))
+fi
+echo "\${attempt}" > "${attempt_marker}"
+
+if [ "\${attempt}" -ge "${succeed_on_attempt}" ]; then
+  echo "● Read some_file.java (read)"
+  echo "  │ some_file.java"
+  echo "  └ ok"
+  printf 'Changes    +1 -1\nAI Credits 1 (1s)\nTokens     \u2191 10 (0 cached) \u2022 \u2193 5 (0 reasoning)\n'
+  exit 0
+fi
+
+while true; do
+  echo "● Checking again (shell)"
+  echo "  │ echo stuck"
+  echo "  └ stuck"
+  sleep 0.2
+done
+BINEOF
+  chmod +x "${fake_bin}/copilot"
+}
+
+run_case_env() {
+  local case_dir="$1"
+  local fake_bin="${case_dir}/bin"
+  export HOME="${case_dir}"
+  export PATH="${fake_bin}:${PATH}"
+  export COPILOT_HOME="${case_dir}/copilot-home"
+  export COPILOT_GITHUB_TOKEN="test-token"
+  export COPILOT_SESSION_ENABLED="false"
+  export AI_AGENT_USAGE_NAME="story_development"
+  export DMTOOLS_CLI_LOG_DIR="${case_dir}/logs"
+  # Isolate this test from the outer rate-limit/model-fallback retry loop
+  # (a completely separate concept from the loop-guard) so only the guard's
+  # own internal retries are exercised.
+  export COPILOT_RATE_LIMIT_RETRIES=1
+  export COPILOT_LOOP_GUARD_THRESHOLD=3
+  export COPILOT_LOOP_GUARD_POLL_SECONDS=0.3
+  unset COPILOT_SESSION_ID COPILOT_USD_PER_CREDIT
+  PROMPT_ARG="test prompt"
+  PROMPT="test prompt"
+  PROMPT_BYTES=11
+  PASS_ARGS=()
+}
+
+# Case 1: a stuck agent is detected and killed, then recovers on retry #1 on
+# the SAME model (no fallback) -- overall run_copilot must still succeed, and
+# every attempt (including the loop-guard's own extra retry) must leave a
+# transcript file behind.
+test_recovers_on_retry() {
+  local case_dir="${TEST_ROOT}/recovers"
+  mkdir -p "${case_dir}/bin" "${case_dir}/outputs"
+  write_fake_copilot "${case_dir}/bin" "${case_dir}/.attempts" 2
+
+  (
+    cd "${case_dir}"
+    run_case_env "${case_dir}"
+    export COPILOT_LOOP_GUARD_MAX_RETRIES=2
+
+    output="$(run_copilot 2>&1)"
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+      echo "[recovers-on-retry] expected run_copilot to succeed, got exit ${status}" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    if ! grep -q "loop-guard: .*detected" <<< "$output"; then
+      echo "[recovers-on-retry] expected a loop-guard detection message" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    if ! grep -q "retrying 1/2 on the SAME model" <<< "$output"; then
+      echo "[recovers-on-retry] expected a same-model retry message" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    if ! find logs -name '*loopguard1*' | grep -q .; then
+      echo "[recovers-on-retry] expected a *-loopguard1* transcript file" >&2
+      exit 1
+    fi
+    # The attempt that finally succeeded must have real activity in its log,
+    # not the stuck-loop content.
+    if ! grep -rl "some_file.java" logs > /dev/null; then
+      echo "[recovers-on-retry] expected the successful attempt's transcript to be preserved" >&2
+      exit 1
+    fi
+  )
+}
+
+# Case 2: the agent never recovers -- the guard must give up after its
+# configured retry budget and return a non-zero exit code (so the job fails
+# visibly) rather than looping until the CI timeout.
+test_gives_up_after_max_retries() {
+  local case_dir="${TEST_ROOT}/gives-up"
+  mkdir -p "${case_dir}/bin" "${case_dir}/outputs"
+  write_fake_copilot "${case_dir}/bin" "${case_dir}/.attempts" 999
+
+  (
+    cd "${case_dir}"
+    run_case_env "${case_dir}"
+    export COPILOT_LOOP_GUARD_MAX_RETRIES=1
+
+    output="$(run_copilot 2>&1)" && status=0 || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      echo "[gives-up-after-max-retries] expected a non-zero exit code" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    if ! grep -q "repeat limit (1 retries) exhausted" <<< "$output"; then
+      echo "[gives-up-after-max-retries] expected the give-up message" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    # Exactly the initial attempt + 1 retry worth of transcripts, no more.
+    attempt_count="$(cat .attempts)"
+    if [ "${attempt_count}" -ne 2 ]; then
+      echo "[gives-up-after-max-retries] expected exactly 2 copilot invocations, saw ${attempt_count}" >&2
+      exit 1
+    fi
+  )
+}
+
+# Case 3: with the guard disabled, behavior must be a plain passthrough to
+# run_copilot_once -- a single invocation, no guard messages, no marker
+# files, regardless of how "stuck" the agent looks.
+test_disabled_is_passthrough() {
+  local case_dir="${TEST_ROOT}/disabled"
+  mkdir -p "${case_dir}/bin" "${case_dir}/outputs"
+  write_fake_copilot "${case_dir}/bin" "${case_dir}/.attempts" 1
+
+  (
+    cd "${case_dir}"
+    run_case_env "${case_dir}"
+    export COPILOT_LOOP_GUARD_ENABLED="false"
+
+    output="$(run_copilot 2>&1)"
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+      echo "[disabled-is-passthrough] expected run_copilot to succeed, got exit ${status}" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    if grep -q "loop-guard" <<< "$output"; then
+      echo "[disabled-is-passthrough] loop-guard must not engage when disabled" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    attempt_count="$(cat .attempts)"
+    if [ "${attempt_count}" -ne 1 ]; then
+      echo "[disabled-is-passthrough] expected exactly 1 copilot invocation, saw ${attempt_count}" >&2
+      exit 1
+    fi
+  )
+}
+
+test_recovers_on_retry
+test_gives_up_after_max_retries
+test_disabled_is_passthrough
+
+echo "Copilot loop-guard tests passed"


### PR DESCRIPTION
## Why

Real-world CI runs have observed a coding-agent CLI (Copilot CLI, in this case) get stuck repeating the exact same tool call hundreds of times without ever breaking out on its own — even while self-labelling each repeat with an incrementing ordinal ("again", "third time", ...). Left unchecked, the job just burns CI minutes until someone notices the log and cancels it by hand.

This mechanism was first prototyped as an external wrapper script (a `cliCommands` override) in a downstream product repo, then found to have no product-specific logic at all — it only depends on the common "bullet block" transcript shape these CLIs render tool calls in. This PR ports it natively into `copilot.sh` so every repo using this submodule gets the protection automatically, no per-repo config needed.

## What

- `scripts/loop_guard.py` — polls a live transcript, detects `>= N` consecutive identical tool-call blocks at the tail (normalized on the detail lines, deliberately ignoring the free-text label since that's exactly what a stuck model varies via its ordinal counting), and sends `SIGTERM` (graceful — preserves a resumable CLI session) + writes a small JSON marker for the caller.
- `scripts/providers/copilot.sh` — new `run_copilot_once_guarded()` wraps each `run_copilot_once` invocation. Uses bash job control (`set -m` + backgrounded subshell) instead of the external `setsid` binary to isolate the run into its own process group — this keeps it a plain subshell fork, so all the calling function's local arrays (`copilot_cmd`, `copilot_session_args`, ...) stay intact and `run_copilot_once` itself needs zero changes. On detection, retries a bounded number of times on the **same** model/session (no fallback model — a stuck model isn't assumed *bad*, just repeating; the CLI's own `--resume` logic picks the session back up transparently).
- New env vars (all optional, sensible defaults): `COPILOT_LOOP_GUARD_ENABLED` (default `true`), `COPILOT_LOOP_GUARD_THRESHOLD` (`5`), `COPILOT_LOOP_GUARD_POLL_SECONDS` (`20`), `COPILOT_LOOP_GUARD_MAX_RETRIES` (`2`), `COPILOT_LOOP_GUARD_IGNORE_TYPES` (`''`).
- `scripts/providers/tests/test_copilot_loop_guard.sh` — new suite (fake `copilot` binary that loops until killed) covering: recovery within the retry budget, giving up after the budget is exhausted (non-zero exit instead of running forever), and passthrough when disabled.

## Testing

- New suite passes reliably (3x consecutive runs, no orphan processes left behind afterward).
- Confirmed via `bash -x` diff that the existing `scripts/providers/tests/test_copilot_provider.sh` suite behaves byte-identically before/after this change (same 3 cases pass; one pre-existing, unrelated `transcript-fallback` case fails identically in this sandbox both before and after this change — a locale/extractor quirk, not introduced here).
