### PR TITLE
feat(discovery): resume CLI session when final bookkeeping output is missing

### DIFF
--- a/instructions/discovery/output_rules.md
+++ b/instructions/discovery/output_rules.md
@@ -97,3 +97,16 @@ This applies equally to `index.md`'s own "pages produced this run" table (see th
 ⚠️ **On an iteration run, `outputs/discovery/` is NOT empty when you start** — the pre-CLI step seeds it with the last published Confluence content, recursively at every depth of the existing page tree (same file/subfolder naming as the table above), before you run. **Read what's already there first, including any nested subfolders.** Then **edit the same file in place** with the merged result (old content + this run's delta) rather than deleting it and starting fresh — this keeps the same Confluence page updated instead of creating a duplicate tree, and guarantees nothing you didn't intend to touch gets silently dropped. This applies to `recommendations.md` too: re-affirm, sharpen, or revise the recommendation based on any new artefact — don't leave a stale recommendation unexamined.
 
 **Exception — append-only files:** `decisions-log.md` and `references.md` are never rewritten wholesale on iteration, even though they're seeded the same way as everything else. Read their existing rows, then only **append** new rows for what this run actually added — see their own sections above for why (they're a historical record, not current-state).
+
+## Before you finish — mandatory final checklist
+
+A long discovery session can run out of time/turns right before these last, cheap steps — do them **as your very last actions**, even if you are running low on budget, since skipping them silently discards work you already did:
+
+1. **`outputs/response.md`** — write a short (a few sentences) summary of what you did this run (which mode(s) ran, the headline recommendation, whether any inline comments were addressed). This file is required by the runner framework regardless of `outputType` — if it is missing, the ticket update is skipped and an error is posted instead, even when every `outputs/discovery/*` file above is correct.
+2. **`outputs/confluence_replies.json`** — if you addressed (or explicitly declined to address) any unresolved comment from `input/<ticket>/discovery_comments.json`, this file must list a reply for it (see `confluence_comments.md`). A missing file is silently treated as "no replies to post" — it will NOT surface as an error, so double-check it yourself before finishing.
+
+Verify both before finishing:
+```bash
+ls -la outputs/ outputs/discovery/ && head -3 outputs/response.md && echo "OK: response.md exists"
+```
+If either file is missing, create it now — do not leave it for a future run.

--- a/js/common/feedbackLoop.js
+++ b/js/common/feedbackLoop.js
@@ -120,7 +120,13 @@ function resumeAgent(options) {
     attempt += 1;
     setAttempt(markerPath, attempt);
 
-    var prompt = buildFeedbackPrompt({
+    // `buildFeedbackPrompt()` bakes in dev-flow assumptions ("do not push; the
+    // post-action will commit and push after you finish") that don't apply to
+    // every caller (e.g. a publish-only post-action that never pushes code).
+    // Callers with a different resume flow can pass `promptOverride` with the
+    // full prompt text instead — attempt tracking / non-recoverable-error
+    // detection / the `--continue` resume mechanics stay identical either way.
+    var prompt = options.promptOverride || buildFeedbackPrompt({
         ticketKey: options.ticketKey,
         stage: options.stage,
         attempt: attempt,

--- a/js/publishDiscoveryToConfluence.js
+++ b/js/publishDiscoveryToConfluence.js
@@ -28,8 +28,62 @@
 var configLoader = require('./configLoader.js');
 var tokenUsageComment = require('./common/tokenUsageComment.js');
 var contentOutput = require('./common/contentOutput.js');
+var feedbackLoop = require('./common/feedbackLoop.js');
 
 var DISCOVERY_OUTPUT_DIR = 'outputs/discovery';
+var RESPONSE_FILE = 'outputs/response.md';
+
+/**
+ * On a very long/near-budget-limit discovery run, the CLI agent can do all the
+ * substantive work (address every inline comment, update every page) and still
+ * skip its last, cheapest steps: writing outputs/response.md and/or
+ * outputs/confluence_replies.json (see instructions/discovery/output_rules.md's
+ * "Before you finish" checklist). A missing outputs/response.md is a strong,
+ * low-noise signal for this specific failure mode — after the prompt fix above,
+ * a well-behaved run always writes it, so its absence is not a normal "nothing
+ * to report" outcome. Give the agent one more chance to finish those steps by
+ * resuming the SAME session (feedbackLoop.resumeAgent()) rather than publishing
+ * whatever partial bookkeeping exists and moving on.
+ */
+function isResponseFileMissing() {
+    try {
+        var raw = file_read({ path: RESPONSE_FILE });
+        return !raw || !raw.trim();
+    } catch (e) {
+        return true;
+    }
+}
+
+function tryResumeForMissingFinalOutput(params, ticketKey, customParams) {
+    try {
+        return feedbackLoop.resumeAgent({
+            ticketKey: ticketKey,
+            customParams: customParams,
+            section: 'postAction',
+            stage: 'discovery_final_output',
+            error: '`' + RESPONSE_FILE + '` is missing or empty after the CLI run finished. ' +
+                'This usually means the run ran out of turns/budget right before its last steps.',
+            promptOverride: [
+                'Your previous discovery run for ' + ticketKey + ' finished without writing two required bookkeeping files.',
+                '',
+                'Do the following now, in the SAME repository/session, before anything else:',
+                '1. Write `' + RESPONSE_FILE + '` — a short (a few sentences) summary of what you did last run ' +
+                    '(which mode(s) ran, the headline recommendation, whether any inline comments were addressed).',
+                '2. If you addressed (or explicitly declined to address) any unresolved inline comment last run, ' +
+                    'make sure `outputs/confluence_replies.json` lists a reply for it — see ' +
+                    'instructions/discovery/confluence_comments.md for the exact format. If nothing needs a reply, ' +
+                    'it is fine to omit this file or leave it as an empty array `[]`.',
+                '3. Do not redo work that is already correctly reflected in `outputs/discovery/` — only fill in the ' +
+                    'missing bookkeeping above.',
+                '',
+                'Do not push or run any git commands; this is a documentation-only publishing step with no repository changes to commit.'
+            ].join('\n')
+        }).attempted;
+    } catch (resumeError) {
+        console.error('tryResumeForMissingFinalOutput: feedbackLoop.resumeAgent failed unexpectedly — publishing with whatever output exists:', resumeError);
+        return false;
+    }
+}
 
 function findTicketPage(children, ticketKey) {
     if (!children || !Array.isArray(children)) return null;
@@ -160,6 +214,21 @@ function action(params) {
             replyResult = contentOutput.publishCommentReplies();
         } catch (replyError) {
             console.warn('Failed to publish inline comment replies:', replyError);
+        }
+
+        if (isResponseFileMissing()) {
+            var _customParams = (params.jobParams && params.jobParams.customParams) || params.customParams;
+            console.warn('publishDiscoveryToConfluence: ' + RESPONSE_FILE + ' is missing/empty for ' + ticketKey +
+                ' — attempting to resume the CLI session to finish the run\'s final bookkeeping steps.');
+            if (tryResumeForMissingFinalOutput(params, ticketKey, _customParams)) {
+                // Resumed successfully — the agent should now have written the missing
+                // file(s). Re-run this whole post-action from the top so the freshly
+                // written outputs/discovery/ and outputs/confluence_replies.json get
+                // (re-)synced/posted, same recursive-retry pattern as
+                // developTicketAndCreatePR.js's resumeDevelopmentAgent() call sites.
+                return action(params);
+            }
+            console.warn('publishDiscoveryToConfluence: resume not attempted/available (disabled, exhausted, or non-recoverable) — publishing with whatever output exists.');
         }
 
         var comment = 'h3. 📚 Discovery published to Confluence\n\n' +

--- a/js/unit-tests/test_publishDiscoveryToConfluence.js
+++ b/js/unit-tests/test_publishDiscoveryToConfluence.js
@@ -10,7 +10,15 @@ function loadPublishDiscovery(mocks, discoveryConfig) {
         confluence_content_by_id: function(args) { return { id: args.contentId, _links: { webui: '/wiki/spaces/DISC/pages/1', base: 'https://confluence.example.com' } }; },
         confluence_sync_markdown_directory: function() { return JSON.stringify({ syncedPages: ['index', 'prd'] }); },
         confluence_reply_to_inline_comment: function() {},
-        file_read: function() { throw new Error('no replies file'); },
+        file_read: function(args) {
+            var path = (args && args.path) || args;
+            // Default to "well-behaved run": response.md exists (so tests unrelated to the
+            // new resume-on-missing-response.md check don't trigger it); everything else
+            // (e.g. outputs/confluence_replies.json, called as a bare string by
+            // contentOutput.js) still behaves like "file not found".
+            if (path === 'outputs/response.md') return 'Discovery run summary.';
+            throw new Error('no replies file');
+        },
         jira_post_comment: function() {}
     };
 
@@ -26,6 +34,7 @@ function loadPublishDiscovery(mocks, discoveryConfig) {
         makeRequire({
             './configLoader.js': configLoaderMock,
             './common/tokenUsageComment.js': { postTokenUsageComments: function() {} },
+            './common/feedbackLoop.js': (mocks && mocks.__feedbackLoop) || { resumeAgent: function() { return { attempted: false, reason: 'disabled' }; } },
             './common/contentOutput.js': loadModule('js/common/contentOutput.js',
                 makeRequire({ '../configLoader.js': { loadProjectConfig: function() { return {}; } } }),
                 globals)
@@ -254,4 +263,70 @@ suite('publishDiscoveryToConfluence', function() {
         assert.equal(result.commentRepliesPosted, 0);
     });
 
+    test('outputs/response.md missing — resumes the CLI session and re-publishes once the retry succeeds', function() {
+        var resumeCalls = [];
+        var syncCalls = 0;
+        var responseWritten = false;
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            },
+            confluence_sync_markdown_directory: function() {
+                syncCalls += 1;
+                return JSON.stringify({ syncedPages: ['index'] });
+            },
+            file_read: function(opts) {
+                var path = opts && (opts.path || opts);
+                if (path === 'outputs/response.md') {
+                    return responseWritten ? 'Discovery run summary.' : '';
+                }
+                throw new Error('not found: ' + path);
+            },
+            __feedbackLoop: {
+                resumeAgent: function(options) {
+                    resumeCalls.push(options);
+                    responseWritten = true; // simulate the resumed CLI run writing the missing file
+                    return { attempted: true, attempts: 1 };
+                }
+            }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(resumeCalls.length, 1);
+        assert.equal(resumeCalls[0].stage, 'discovery_final_output');
+        assert.equal(resumeCalls[0].ticketKey, 'PROJ-2');
+        assert.contains(resumeCalls[0].promptOverride, 'outputs/response.md');
+        assert.contains(resumeCalls[0].promptOverride, 'confluence_replies.json');
+        assert.equal(syncCalls, 2); // once before resume, once on the recursive retry
+        assert.equal(result.success, true);
+    });
+
+    test('outputs/response.md missing but resume not attempted (disabled/exhausted) — still publishes with what exists', function() {
+        var syncCalls = 0;
+        var mod = loadPublishDiscovery({
+            confluence_get_children_by_id: function() {
+                return [{ id: '456', title: 'PROJ-2 Some feature', body: { storage: { value: '' } } }];
+            },
+            confluence_sync_markdown_directory: function() {
+                syncCalls += 1;
+                return JSON.stringify({ syncedPages: ['index'] });
+            },
+            file_read: function(opts) {
+                var path = opts && (opts.path || opts);
+                throw new Error('not found: ' + path);
+            },
+            __feedbackLoop: {
+                resumeAgent: function() { return { attempted: false, reason: 'disabled' }; }
+            }
+        }, { space: 'DISC', parentPageId: '123' });
+
+        var result = mod.action(makeParams());
+
+        assert.equal(syncCalls, 1); // no recursive retry
+        assert.equal(result.success, true);
+        assert.equal(result.commentRepliesPosted, 0);
+    });
+
 });
+


### PR DESCRIPTION
## Problem

On a very long discovery run, the CLI agent can correctly address every inline comment and update every Confluence page, but still run out of turns/budget right before its last, cheapest steps: writing `outputs/response.md` and/or `outputs/confluence_replies.json`.

- A missing `outputs/response.md` causes the tracker field update to be skipped and an error comment posted instead — even though the actual discovery content is correct.
- A missing `outputs/confluence_replies.json` is silently treated as "nothing to reply to" (per the agent's own instructions, this is a valid outcome on its own) — so it doesn't surface as an error, but a reviewer's comment is left unanswered even though it was actually addressed in the page content.

## Fix

1. **Prompt hardening** (`instructions/discovery/output_rules.md`): added a mandatory "before you finish" checklist reminding the agent to write `response.md` every run (previously never mentioned anywhere in the discovery prompt set, even though the runner framework requires it) and to double-check `confluence_replies.json`.
2. **Safety net** (`js/publishDiscoveryToConfluence.js`): if `outputs/response.md` is still missing/empty after the CLI run, resume the *same* Copilot session (via the existing `feedbackLoop.resumeAgent()` mechanism already used by developer jobs) with a discovery-specific corrective prompt, then retry the whole post-action so the freshly written files get synced/posted. Bounded by the existing attempt-marker mechanism (default 2 attempts); falls through to publishing with whatever exists if resuming is disabled, exhausted, or the failure looks non-recoverable.
3. `feedbackLoop.resumeAgent()` now accepts an optional `promptOverride` so callers whose resume flow doesn't match the generic dev-oriented prompt (e.g. "do not push") can supply their own — existing dev callers are unaffected (no `promptOverride` passed).

## Tests

- `js/unit-tests/test_publishDiscoveryToConfluence.js`: 2 new tests (resume-and-retry succeeds; resume unavailable degrades gracefully) — full file: 12/12 passing.
- `js/unit-tests/test_feedbackLoop.js`: unchanged, still 10/10 passing (verifies `promptOverride` doesn't break existing callers).
- Full `js/unit-tests/run_all.json` suite: 867 passed, 9 pre-existing failures unrelated to this change (checkWipLabel/smAgent/validateInputJql/agentDocsCoverage).