### PR TITLE
fix(discovery): whitelist bash so the postAction feedback-loop resume actually runs

### DIFF
--- a/discovery.json
+++ b/discovery.json
@@ -5,6 +5,9 @@
       "./agents/scripts/run-agent.sh"
     ],
     "outputType": "none",
+    "envVariables": {
+      "CLI_ALLOWED_COMMANDS": "bash"
+    },
     "ticketContextDepth": 1,
     "attachResponseAsFile": false,
     "skipAIProcessing": true,


### PR DESCRIPTION
## Problem
#398 enabled `customParams.feedbackLoop.postAction`, which makes `publishDiscoveryToConfluence.js`'s `tryResumeForMissingFinalOutput()` call `feedbackLoop.resumeAgent()`, which internally runs:
```
bash agents/scripts/run-agent.sh --continue outputs/feedback/<key>.md
```
via `cli_execute_command`. That tool's whitelist defaults to `gh, gcloud, npm, docker, ansible, git, dmtools, kubectl, az, terraform, yarn, aws` — **no `bash`** — unless a job's `envVariables` sets `CLI_ALLOWED_COMMANDS` (as `pr_rework.json` already does: `"bash,mvn,mkdir"`). `discovery.json` never set this.

### Observed impact
Confirmed via CI log on GENSGENP-53556 (same run right after #398 was deployed):
```
Feedback loop: resuming agent for discovery_final_output attempt 1/1
[ERROR] CliCommandExecutor - Security violation: Command not whitelisted - bash agents/scripts/run-agent.sh --continue ...
tryResumeForMissingFinalOutput: feedbackLoop.resumeAgent failed unexpectedly — publishing with whatever output exists: ...SecurityException...
publishDiscoveryToConfluence: resume not attempted/available (disabled, exhausted, or non-recoverable) — publishing with whatever output exists.
```
So the resume attempt now fires (thanks to #398), but immediately fails on the whitelist check, silently falling back to publishing partial output (`commentRepliesPosted: 0`) — same end-user symptom as before #398, different root cause.

## Fix
Add `envVariables.CLI_ALLOWED_COMMANDS: "bash"` to the base `discovery.json`, matching the pattern already used by `pr_rework.json`. Verified this deep-merges correctly with `gens-agents/discovery.json`'s own `envVariables.COPILOT_MODEL` override (per the documented parent-config deep-merge rules — objects merge key-by-key, child wins per key, parent keys not present in child are kept).