### PR TITLE
fix(quality-gates): resolve real base branch for versioned-branch repos

### DIFF
--- a/js/common/baseBranchMarker.js
+++ b/js/common/baseBranchMarker.js
@@ -1,0 +1,45 @@
+/**
+ * Persists the job's resolved base branch to a well-known output file so that
+ * quality-gate shell commands can read it back.
+ *
+ * Why this exists: `customParams.feedbackLoop.qualityGates.gates[].command` is a
+ * static shell string baked into a project's JSON config at authoring time — it
+ * cannot reference `config.git.baseBranch` (resolved at runtime, e.g. via
+ * `baseBranchResolverFnPath` keyed off the ticket's fixVersion, or a PR's own
+ * actual base ref) because there is no templating/interpolation step between the
+ * JSON config and the shell command string. In practice this means gate scripts
+ * that need a "diff against the base branch" ref (e.g. a SpotBugs or coverage
+ * new-code scan) end up with a single hardcoded literal like "origin/master" —
+ * which silently produces wrong (too-broad or empty) results for any repo/ticket
+ * that releases via a non-default branch (e.g. a versioned "develop/{version}"
+ * branch), instead of failing loudly.
+ *
+ * The fix: write the ACTUAL resolved base branch name (no "origin/" prefix) to
+ * `outputs/pr_base_branch.txt` once it's known (from a preCliJSAction hook), so a
+ * gate script can read it back and use `origin/<content>` instead of a hardcoded
+ * ref, falling back to its own default candidates if the file is absent/empty/stale.
+ *
+ * Written to `outputs/` (the job root), NOT inside `config.workingDir` (the target
+ * repo's own git checkout) — so it can never be accidentally picked up by a later
+ * `git add .`/`git add -A` in the target repo and leak into a commit. Gate commands
+ * run with `workingDirectory` set to `config.workingDir` (conventionally 2 directory
+ * levels below the job root, e.g. "./dependencies/<repo>") and already reference the
+ * job root via a "../../..." relative prefix (e.g. "../../agents/scripts/foo.sh") —
+ * scripts consuming this marker file should follow the same "../../outputs/..." convention.
+ *
+ * @param {string} baseBranch - the resolved base branch name, WITHOUT any "origin/"
+ *                              prefix (e.g. "master", "develop/3.9.0"). No-op if falsy.
+ */
+function writeBaseBranchMarker(baseBranch) {
+    if (!baseBranch) return;
+    try {
+        file_write({ path: 'outputs/pr_base_branch.txt', content: String(baseBranch) });
+    } catch (e) {
+        console.warn('writeBaseBranchMarker: failed to write outputs/pr_base_branch.txt (non-fatal):',
+            e && e.toString ? e.toString() : String(e));
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { writeBaseBranchMarker };
+}

--- a/js/preCliDevelopmentSetup.js
+++ b/js/preCliDevelopmentSetup.js
@@ -16,6 +16,7 @@ const fetchLinkedTestsToInput = require('./fetchLinkedTestsToInput.js');
 const fetchParentContextToInput = require('./fetchParentContextToInput.js');
 var restoreFromReleases = require('./restoreFromReleases.js');
 var setupCommands = require('./common/setupCommands.js');
+var baseBranchMarker = require('./common/baseBranchMarker.js');
 
 // Universal working-directory-aware wrapper for cli_execute_command.
 // When config.workingDir is set (via customParams.targetRepository.workingDir),
@@ -334,6 +335,13 @@ function action(params) {
         var config = configLoader.loadProjectConfig(configLoader.paramsForConfigLoad(params));
         var customParams = (params.jobParams && params.jobParams.customParams) || actualParams.customParams;
         var statuses = resolveStatuses(customParams);
+
+        // Persist the resolved base branch to outputs/pr_base_branch.txt so that
+        // quality-gate shell commands (static strings in the job's JSON config, unable
+        // to reference config.git.baseBranch at runtime) can read the actual branch
+        // this ticket develops against instead of relying on a hardcoded literal like
+        // "origin/master" — see js/common/baseBranchMarker.js docblock for the rationale.
+        baseBranchMarker.writeBaseBranchMarker(config.git.baseBranch);
 
         // Restore configured artefacts (e.g. cosmo test reports) from GitHub Release — non-fatal
         try { restoreFromReleases.action(params); } catch (e) { console.warn('⚠️ restoreFromReleases failed (non-fatal):', e); }

--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -17,6 +17,7 @@ const fetchQuestionsToInput = require('./fetchQuestionsToInput.js');
 const fetchParentContextToInput = require('./fetchParentContextToInput.js');
 var restoreFromReleases = require('./restoreFromReleases.js');
 var setupCommands = require('./common/setupCommands.js');
+var baseBranchMarker = require('./common/baseBranchMarker.js');
 
 /**
  * Optionally syncs the PR's base branch with its own upstream (config.git.baseBranch)
@@ -145,6 +146,13 @@ function action(params) {
         }
 
         const baseBranch = prDetails.base ? prDetails.base.ref : config.git.baseBranch;
+
+        // Persist the PR's real base branch to outputs/pr_base_branch.txt so that
+        // quality-gate shell commands (static strings in the job's JSON config, unable
+        // to reference config.git.baseBranch at runtime) can read the actual target
+        // branch instead of relying on a hardcoded literal like "origin/master" — see
+        // js/common/baseBranchMarker.js docblock for the full rationale.
+        baseBranchMarker.writeBaseBranchMarker(baseBranch);
 
         // Step 4.4: Optionally sync the PR's base branch with its own upstream — see
         // syncBaseBranchIfConfigured() docblock for the rationale.

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -5,6 +5,7 @@
     "jobParams": {
       "testFiles": [
         "js/unit-tests/test_checkWipLabel.js",
+        "js/unit-tests/test_baseBranchMarker.js",
         "js/unit-tests/test_configLoader.js",
         "js/unit-tests/test_fetchQuestionsToInput.js",
         "js/unit-tests/test_createQuestionsAndAssignForReview.js",

--- a/js/unit-tests/run_baseBranchMarker.json
+++ b/js/unit-tests/run_baseBranchMarker.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_baseBranchMarker.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_baseBranchMarker.js
+++ b/js/unit-tests/test_baseBranchMarker.js
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for js/common/baseBranchMarker.js
+ *
+ * Uses: loadModule(), makeRequire(), assert, test(), suite()
+ */
+
+function loadBaseBranchMarker(mocks) {
+    return loadModule('js/common/baseBranchMarker.js', makeRequire({}), mocks || {});
+}
+
+suite('baseBranchMarker.writeBaseBranchMarker', function() {
+
+    test('writes the branch name to outputs/pr_base_branch.txt', function() {
+        var writeCalls = [];
+        var mod = loadBaseBranchMarker({
+            file_write: function(opts) { writeCalls.push(opts); }
+        });
+
+        mod.writeBaseBranchMarker('develop/3.9.0');
+
+        assert.equal(writeCalls.length, 1);
+        assert.equal(writeCalls[0].path, 'outputs/pr_base_branch.txt');
+        assert.equal(writeCalls[0].content, 'develop/3.9.0');
+    });
+
+    test('coerces a non-string branch value to a string', function() {
+        var writeCalls = [];
+        var mod = loadBaseBranchMarker({
+            file_write: function(opts) { writeCalls.push(opts); }
+        });
+
+        mod.writeBaseBranchMarker(123);
+
+        assert.equal(writeCalls.length, 1);
+        assert.equal(writeCalls[0].content, '123');
+    });
+
+    test('is a no-op when baseBranch is falsy', function() {
+        var writeCalls = [];
+        var mod = loadBaseBranchMarker({
+            file_write: function(opts) { writeCalls.push(opts); }
+        });
+
+        mod.writeBaseBranchMarker(null);
+        mod.writeBaseBranchMarker(undefined);
+        mod.writeBaseBranchMarker('');
+
+        assert.equal(writeCalls.length, 0);
+    });
+
+    test('swallows file_write errors (non-fatal)', function() {
+        var mod = loadBaseBranchMarker({
+            file_write: function() { throw new Error('disk full'); }
+        });
+
+        // Should not throw.
+        mod.writeBaseBranchMarker('master');
+    });
+
+});

--- a/js/unit-tests/test_preCliDevelopmentSetup.js
+++ b/js/unit-tests/test_preCliDevelopmentSetup.js
@@ -44,7 +44,8 @@ function loadPreCliDevelopmentSetup(configLoaderStub, mocks) {
             './fetchLinkedTestsToInput.js': NOOP_MODULE,
             './fetchParentContextToInput.js': NOOP_MODULE,
             './restoreFromReleases.js': NOOP_MODULE,
-            './common/setupCommands.js': NOOP_MODULE
+            './common/setupCommands.js': NOOP_MODULE,
+            './common/baseBranchMarker.js': { writeBaseBranchMarker: function() {} }
         }),
         mocks || {}
     );

--- a/js/unit-tests/test_preCliReworkSetup.js
+++ b/js/unit-tests/test_preCliReworkSetup.js
@@ -40,7 +40,8 @@ function loadPreCliReworkSetup(configLoaderStub, mocks) {
             // Real module (not a no-op stub): preCliReworkSetup.js reads
             // setupCommands.truncateSetupError at load time to build its own
             // truncateForComment() helper, so the stub must actually export it.
-            './common/setupCommands.js': loadModule('js/common/setupCommands.js')
+            './common/setupCommands.js': loadModule('js/common/setupCommands.js'),
+            './common/baseBranchMarker.js': { writeBaseBranchMarker: function() {} }
         }),
         mocks || {}
     );

--- a/scripts/spotbugs_diff_scope.sh
+++ b/scripts/spotbugs_diff_scope.sh
@@ -15,8 +15,10 @@
 # instead, so pre-existing findings elsewhere in the module no longer block the gate.
 #
 # How it works:
-#   1. Diff HEAD against a base ref (arg 3, or auto-detected origin/master / origin/main)
-#      to find changed *.java files.
+#   1. Diff HEAD against a base ref (arg 3; or, if omitted, the branch named in
+#      ../../outputs/pr_base_branch.txt — see js/common/baseBranchMarker.js — used as
+#      "origin/<that branch>" if it resolves; or auto-detected origin/master /
+#      origin/main as a last resort) to find changed *.java files.
 #   2. Map each changed file to its Maven module (nearest ancestor pom.xml).
 #   3. Run `mvn spotbugs:spotbugs` (report-only — does NOT fail the build) scoped to
 #      those modules (NOT -am, matching the compile gate's convention of installing
@@ -53,6 +55,21 @@ set -euo pipefail
 MAVEN_ROOT="${1:?maven root required, e.g. tools-app}"
 SETTINGS_PATH="${2:?settings path (relative to the working directory, e.g. mvn/settings.xml) required}"
 BASE_REF="${3:-}"
+
+# If no explicit base ref was passed, check the marker file written by
+# js/common/baseBranchMarker.js (via preCliReworkSetup.js / preCliDevelopmentSetup.js)
+# before falling back to the origin/master / origin/main auto-detect below. This lets
+# repos/tickets that release via a non-default branch (e.g. a versioned
+# "develop/{version}" branch) get scoped correctly instead of silently diffing against
+# the wrong ref. Path is relative to this script's cwd (the target repo checkout root,
+# conventionally 2 directory levels below the job root — same convention already used
+# to invoke this very script, e.g. "../../agents/scripts/spotbugs_diff_scope.sh").
+if [ -z "${BASE_REF}" ] && [ -f "../../outputs/pr_base_branch.txt" ]; then
+  MARKER_BRANCH="$(tr -d '[:space:]' < "../../outputs/pr_base_branch.txt")"
+  if [ -n "${MARKER_BRANCH}" ] && git rev-parse --verify "origin/${MARKER_BRANCH}" >/dev/null 2>&1; then
+    BASE_REF="origin/${MARKER_BRANCH}"
+  fi
+fi
 
 if [ -z "${BASE_REF}" ]; then
   for candidate in origin/master origin/main; do


### PR DESCRIPTION
## Problem

The \`spotbugs\`/\`coverage\` quality-gate commands are static shell strings baked into a project's JSON config (`customParams.feedbackLoop.qualityGates.gates[].command`) — they cannot reference `config.git.baseBranch` or a PR's actual resolved base ref at runtime, since there's no templating step between the JSON config and the shell command string. Some project configs hardcode a single literal diff base ref (e.g. `origin/master`).

For any repo/ticket that releases via a non-default branch (e.g. a versioned `develop/{version}` branch instead of `master`), this silently diffs against the wrong ref — scoping SpotBugs/coverage checks across hundreds of unrelated files from other commits, causing spurious gate failures and unnecessary feedback-loop churn (extra AI credits/runtime spent "fixing" false findings).

## Fix

- New shared helper `js/common/baseBranchMarker.js`: `writeBaseBranchMarker(baseBranch)` persists the resolved base branch to `outputs/pr_base_branch.txt` (job-root level — deliberately OUTSIDE `config.workingDir`, so it can never be swept up by a later broad `git add` in the target repo checkout and leak into a customer PR).
- `preCliReworkSetup.js` calls it with the PR's own real base ref (`prDetails.base.ref`) once resolved.
- `preCliDevelopmentSetup.js` calls it with `config.git.baseBranch` (the ticket's resolved dev-target branch) early in `action()`.
- `spotbugs_diff_scope.sh` now checks this marker file (`../../outputs/pr_base_branch.txt`, relative to the gate script's cwd — same `../../` convention already used to invoke it) as a `BASE_REF` fallback, before its existing `origin/master`/`origin/main` auto-detect, and only uses it if `origin/<branch>` actually resolves.
- No JSON config schema changes required — a project can simply drop the hardcoded 3rd arg from its gate `command` to let auto-detection (now marker-aware) do the right thing.

## Tests

- New `js/unit-tests/test_baseBranchMarker.js` (4 tests: writes correctly, coerces non-string input, no-ops on falsy input, swallows write errors).
- Updated `test_preCliReworkSetup.js` / `test_preCliDevelopmentSetup.js` to stub the new `require('./common/baseBranchMarker.js')` — all existing tests still pass.
- Manually verified the shell fallback logic resolves `origin/develop/3.9.0` correctly from a marker file in an isolated throwaway git repo.
- `docs-freshness`: ran `node js/agentDocGenerator.js` — no diff produced.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>