### PR TITLE
loop_guard: detect near-duplicate calls that mask one varying token

### DIFF
--- a/scripts/loop_guard.py
+++ b/scripts/loop_guard.py
@@ -11,20 +11,36 @@ SAME tool call over and over — e.g. hundreds of identical `grep` calls
 returning "No matches found", or hundreds of identical shell calls
 re-running the same command. The model can even self-label each repeat with
 an incrementing ordinal ("again", "third time", ...) — aware it kept
-repeating, but never breaking out on its own. Left unchecked, the job just
-burns CI minutes until someone notices the log and cancels it by hand (CI
-job timeouts are typically hours, not minutes).
+repeating, but never breaking out on its own. A subtler variant has also
+been observed: the model embeds a fresh throwaway word *inside* the command
+text itself on every repeat (not just the free-text label), which defeats
+naive exact-match detection since every repeat's signature is technically
+unique. Left unchecked, the job just burns CI minutes until someone notices
+the log and cancels it by hand (CI job timeouts are typically hours, not
+minutes).
 
 What this script does
 ----------------------
 Polls a live transcript log file, parses it into an ordered list of tool-call
 "signatures" (tool type + normalized command/args — deliberately NOT
 including the bullet's free-text label, since that's exactly the part the
-model varies on every repeat with its ordinal counting), and checks whether
-the same signature appears >= --threshold times *consecutively* at the tail
-of the transcript. If so, it sends SIGTERM to the given pid (graceful, so a
+model varies on every repeat with its ordinal counting), and checks two
+things at the tail of the transcript:
+
+1. trailing_repeat(): does the exact same signature appear >= --threshold
+   times consecutively? (the classic case — byte-identical repeated calls)
+2. trailing_near_repeat(): do the last >= --near-threshold calls share the
+   same tool_type and token count, differing from the newest one by only a
+   handful of whitespace-split tokens? (catches a model that embeds a new
+   throwaway word *inside* the command on every repeat specifically to dodge
+   check 1 — near-threshold is deliberately much higher than --threshold to
+   avoid flagging legitimate repetitive-looking exploration such as reading
+   several different files with the same templated command)
+
+If either check fires, it sends SIGTERM to the given pid (graceful, so a
 resumable CLI session/state is preserved) and writes a small JSON marker
-describing what was detected, for the caller to react to (see
+describing what was detected (including which check fired, via
+`detection_kind`), for the caller to react to (see
 run_copilot_once_guarded() in scripts/providers/copilot.sh, which retries on
 the SAME model/session rather than switching models — a stuck model is not
 assumed to be a bad model, just a model that needs an explicit nudge that
@@ -115,6 +131,54 @@ def trailing_repeat(blocks, ignore_types=frozenset()):
     return count, last
 
 
+def _tokenize(signature):
+    return signature.split()
+
+
+def trailing_near_repeat(blocks, ignore_types=frozenset(), max_diff_tokens=3, max_diff_ratio=0.15):
+    """Return (repeat_count, (tool_type, signature)) for a run of NEAR-identical
+    signatures at the END of `blocks` — same tool_type, same token count, and
+    differing from the newest one in at most `max(max_diff_tokens,
+    round(max_diff_ratio * token_count))` whitespace-split tokens.
+
+    This exists because trailing_repeat() (exact match) can be evaded: a model
+    stuck in a loop can embed a *different* word inside the command text
+    itself on every repeat (not just in the free-text label, which is already
+    stripped before signature comparison) — e.g. re-running the same `git
+    diff ... | python3 -c "...print('...HEXAGON...', 'hexagon')"` over and
+    over with a new noun substituted in each time. The command is otherwise
+    byte-identical and accomplishes nothing new, but trailing_repeat() sees a
+    different signature every time and never fires.
+
+    Deliberately conservative (small token-diff budget) to avoid flagging
+    legitimate exploration, e.g. reading several different files with the same
+    templated command — those differ in a whole path token but are usually
+    interleaved with genuinely different follow-up actions, and callers should
+    pair this with a much larger --near-threshold than the exact-match
+    --threshold so only truly excessive repetition trips it.
+    """
+    filtered = [b for b in blocks if b[0] not in ignore_types and b[1]]
+    if not filtered:
+        return 0, None
+    last = filtered[-1]
+    last_tokens = _tokenize(last[1])
+    if not last_tokens:
+        return 0, None
+    allowed_diff = max(max_diff_tokens, round(max_diff_ratio * len(last_tokens)))
+    count = 0
+    for b in reversed(filtered):
+        if b[0] != last[0]:
+            break
+        tokens = _tokenize(b[1])
+        if len(tokens) != len(last_tokens):
+            break
+        diff = sum(1 for x, y in zip(tokens, last_tokens) if x != y)
+        if diff > allowed_diff:
+            break
+        count += 1
+    return count, last
+
+
 def _pid_alive(pid):
     try:
         os.kill(pid, 0)
@@ -144,6 +208,16 @@ def main(argv=None):
     parser.add_argument("--pid", required=True, type=int, help="process (group) to terminate on detection")
     parser.add_argument("--marker-file", required=True, help="path to write a JSON detection marker to")
     parser.add_argument("--threshold", type=int, default=int(os.environ.get("COPILOT_LOOP_GUARD_THRESHOLD", "5")))
+    parser.add_argument(
+        "--near-threshold",
+        type=int,
+        default=int(os.environ.get("COPILOT_LOOP_GUARD_NEAR_THRESHOLD", "15")),
+        help=(
+            "consecutive NEAR-identical (not necessarily byte-identical) calls required to trigger "
+            "trailing_near_repeat(); deliberately higher than --threshold since this check is fuzzier "
+            "and more prone to false positives on legitimate repetitive-looking exploration"
+        ),
+    )
     parser.add_argument("--poll-interval", type=float, default=float(os.environ.get("COPILOT_LOOP_GUARD_POLL_SECONDS", "20")))
     parser.add_argument(
         "--ignore-types",
@@ -168,13 +242,23 @@ def main(argv=None):
 
         blocks = parse_blocks(text)
         count, signature = trailing_repeat(blocks, ignore_types=ignore_types)
-        if signature is not None and count >= args.threshold:
+        detection_kind = "exact_duplicate"
+        detection_threshold = args.threshold
+        if not (signature is not None and count >= args.threshold):
+            # Fall back to the fuzzy check: same tool_type/token-count, only a
+            # couple of tokens differing (e.g. a model varying one embedded
+            # word per repeat to dodge the exact-match check above).
+            count, signature = trailing_near_repeat(blocks, ignore_types=ignore_types)
+            detection_kind = "near_duplicate"
+            detection_threshold = args.near_threshold
+        if signature is not None and count >= detection_threshold:
             tool_type, normalized = signature
             detail = {
                 "detected_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 "pid": args.pid,
                 "repeat_count": count,
-                "threshold": args.threshold,
+                "threshold": detection_threshold,
+                "detection_kind": detection_kind,
                 "tool_type": tool_type,
                 "command": normalized[:2000],
             }

--- a/scripts/loop_guard.py
+++ b/scripts/loop_guard.py
@@ -11,33 +11,41 @@ SAME tool call over and over — e.g. hundreds of identical `grep` calls
 returning "No matches found", or hundreds of identical shell calls
 re-running the same command. The model can even self-label each repeat with
 an incrementing ordinal ("again", "third time", ...) — aware it kept
-repeating, but never breaking out on its own. A subtler variant has also
-been observed: the model embeds a fresh throwaway word *inside* the command
-text itself on every repeat (not just the free-text label), which defeats
-naive exact-match detection since every repeat's signature is technically
-unique. Left unchecked, the job just burns CI minutes until someone notices
-the log and cancels it by hand (CI job timeouts are typically hours, not
-minutes).
+repeating, but never breaking out on its own. Two subtler variants have also
+been observed: (a) the model embeds a fresh throwaway word *inside* the
+command text itself on every repeat (not just the free-text label), which
+defeats naive exact-match detection since every repeat's signature is
+technically unique; (b) the model interleaves one genuinely different call
+between each repeat of an otherwise byte-identical command, so the repeat is
+never adjacent to itself and defeats any check that only looks at a
+consecutive run. Left unchecked, the job just burns CI minutes until someone
+notices the log and cancels it by hand (CI job timeouts are typically hours,
+not minutes).
 
 What this script does
 ----------------------
 Polls a live transcript log file, parses it into an ordered list of tool-call
 "signatures" (tool type + normalized command/args — deliberately NOT
 including the bullet's free-text label, since that's exactly the part the
-model varies on every repeat with its ordinal counting), and checks two
-things at the tail of the transcript:
+model varies on every repeat with its ordinal counting), and checks three
+things, falling through in order of strictness:
 
 1. trailing_repeat(): does the exact same signature appear >= --threshold
    times consecutively? (the classic case — byte-identical repeated calls)
 2. trailing_near_repeat(): do the last >= --near-threshold calls share the
    same tool_type and token count, differing from the newest one by only a
-   handful of whitespace-split tokens? (catches a model that embeds a new
-   throwaway word *inside* the command on every repeat specifically to dodge
-   check 1 — near-threshold is deliberately much higher than --threshold to
-   avoid flagging legitimate repetitive-looking exploration such as reading
-   several different files with the same templated command)
+   handful of whitespace-split tokens? (catches variant (a) above —
+   near-threshold is deliberately much higher than --threshold to avoid
+   flagging legitimate repetitive-looking exploration such as reading several
+   different files with the same templated command)
+3. windowed_repeat(): does the exact same signature appear >= --window-threshold
+   times within the last --window-size calls, WITHOUT requiring adjacency?
+   (catches variant (b) above — window-threshold is deliberately much higher
+   still, since counting non-adjacent occurrences is the most prone to
+   false-positiving on a legitimately-common single command re-run a handful
+   of times across a long session)
 
-If either check fires, it sends SIGTERM to the given pid (graceful, so a
+If any check fires, it sends SIGTERM to the given pid (graceful, so a
 resumable CLI session/state is preserved) and writes a small JSON marker
 describing what was detected (including which check fired, via
 `detection_kind`), for the caller to react to (see
@@ -179,6 +187,42 @@ def trailing_near_repeat(blocks, ignore_types=frozenset(), max_diff_tokens=3, ma
     return count, last
 
 
+def windowed_repeat(blocks, ignore_types=frozenset(), window=200):
+    """Return (repeat_count, (tool_type, signature)) for the signature that
+    repeats most often within the last `window` blocks — WITHOUT requiring
+    those repeats to be consecutive.
+
+    This exists because both trailing_repeat() and trailing_near_repeat()
+    only ever look at a contiguous run at the very END of the transcript. A
+    model can defeat that by repeating the exact same byte-identical call
+    over and over while interleaving one *different*, genuinely-distinct call
+    in between each repeat (e.g. re-running the same
+    `git diff ... SomeFile.java | head -50` ~2000 times across a long
+    transcript, each time preceded by a different one-off `git log`/`git
+    diff` investigating a different file) — the repeated call is never
+    adjacent to another copy of itself, so it never forms a "trailing run"
+    and both of the above checks stay silent no matter how many times it
+    repeats.
+
+    Only the single most-repeated signature in the window is reported (the
+    one most likely to be an actual stuck loop); legitimate exploration
+    naturally spreads calls across many distinct signatures instead of
+    concentrating on one.
+    """
+    filtered = [b for b in blocks if b[0] not in ignore_types and b[1]]
+    if not filtered:
+        return 0, None
+    recent = filtered[-window:]
+    counts = {}
+    for b in recent:
+        counts[b] = counts.get(b, 0) + 1
+    best_signature, best_count = None, 0
+    for signature, count in counts.items():
+        if count > best_count:
+            best_signature, best_count = signature, count
+    return best_count, best_signature
+
+
 def _pid_alive(pid):
     try:
         os.kill(pid, 0)
@@ -218,6 +262,22 @@ def main(argv=None):
             "and more prone to false positives on legitimate repetitive-looking exploration"
         ),
     )
+    parser.add_argument(
+        "--window-threshold",
+        type=int,
+        default=int(os.environ.get("COPILOT_LOOP_GUARD_WINDOW_THRESHOLD", "40")),
+        help=(
+            "occurrences of the SAME exact signature required within the last --window-size calls to "
+            "trigger windowed_repeat(), regardless of adjacency; catches a model that interleaves one "
+            "distinct call between each repeat specifically to dodge the trailing-run checks above"
+        ),
+    )
+    parser.add_argument(
+        "--window-size",
+        type=int,
+        default=int(os.environ.get("COPILOT_LOOP_GUARD_WINDOW_SIZE", "200")),
+        help="how many of the most recent calls windowed_repeat() considers",
+    )
     parser.add_argument("--poll-interval", type=float, default=float(os.environ.get("COPILOT_LOOP_GUARD_POLL_SECONDS", "20")))
     parser.add_argument(
         "--ignore-types",
@@ -251,6 +311,17 @@ def main(argv=None):
             count, signature = trailing_near_repeat(blocks, ignore_types=ignore_types)
             detection_kind = "near_duplicate"
             detection_threshold = args.near_threshold
+        if not (signature is not None and count >= detection_threshold):
+            # Fall back further to the windowed check: the same exact call
+            # repeating many times within a recent window even if it's never
+            # adjacent to itself (a model interleaving one distinct call
+            # between each repeat specifically to dodge the two trailing-run
+            # checks above).
+            count, signature = windowed_repeat(
+                blocks, ignore_types=ignore_types, window=args.window_size
+            )
+            detection_kind = "windowed_duplicate"
+            detection_threshold = args.window_threshold
         if signature is not None and count >= detection_threshold:
             tool_type, normalized = signature
             detail = {

--- a/scripts/tests/test_loop_guard.py
+++ b/scripts/tests/test_loop_guard.py
@@ -169,5 +169,51 @@ class TrailingNearRepeatTests(unittest.TestCase):
         self.assertIsNone(sig)
 
 
+class WindowedRepeatTests(unittest.TestCase):
+    def test_no_blocks_returns_zero(self):
+        count, sig = loop_guard.windowed_repeat([])
+        self.assertEqual(count, 0)
+        self.assertIsNone(sig)
+
+    def test_counts_non_adjacent_occurrences_within_the_window(self):
+        blocks = [("shell", "cmd A"), ("shell", "cmd B"), ("shell", "cmd A"), ("shell", "cmd C"), ("shell", "cmd A")]
+        count, sig = loop_guard.windowed_repeat(blocks)
+        self.assertEqual(count, 3)
+        self.assertEqual(sig, ("shell", "cmd A"))
+
+    def test_interleaved_identical_call_is_caught_even_though_never_adjacent(self):
+        # A model can repeat the exact same byte-identical command many times
+        # while interleaving one genuinely different investigative call
+        # between each repeat, so the repeat is never adjacent to itself and
+        # both trailing_repeat() and trailing_near_repeat() see count=1
+        # forever no matter how many times it repeats.
+        blocks = []
+        for i in range(50):
+            blocks.append(("shell", "git diff -- SomeFile.java | head -50"))
+            blocks.append(("shell", "git log --grep=TICKET -- File{0}.java | head -20".format(i)))
+
+        exact_count, _ = loop_guard.trailing_repeat(blocks)
+        self.assertEqual(exact_count, 1, "interleaving defeats the trailing exact-match check")
+
+        near_count, _ = loop_guard.trailing_near_repeat(blocks)
+        self.assertEqual(near_count, 1, "interleaving defeats the trailing near-match check too")
+
+        window_count, sig = loop_guard.windowed_repeat(blocks, window=200)
+        self.assertEqual(window_count, 50)
+        self.assertEqual(sig, ("shell", "git diff -- SomeFile.java | head -50"))
+
+    def test_only_considers_the_last_window_blocks(self):
+        blocks = [("shell", "cmd A")] * 3 + [("shell", "cmd B")] * 2
+        count, sig = loop_guard.windowed_repeat(blocks, window=2)
+        self.assertEqual(count, 2)
+        self.assertEqual(sig, ("shell", "cmd B"))
+
+    def test_ignore_types_excludes_matching_blocks(self):
+        blocks = [("wait", "poll")] * 10 + [("shell", "cmd A")] * 2
+        count, sig = loop_guard.windowed_repeat(blocks, ignore_types=frozenset({"wait"}))
+        self.assertEqual(count, 2)
+        self.assertEqual(sig, ("shell", "cmd A"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_loop_guard.py
+++ b/scripts/tests/test_loop_guard.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/loop_guard.py.
+
+These tests use only synthetic/generic transcript fragments — no
+project-specific paths, ticket references, or company code — per this
+repo's public-content policy.
+"""
+import os
+import sys
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, SCRIPTS_DIR)
+
+import loop_guard  # noqa: E402
+
+
+class ParseBlocksTests(unittest.TestCase):
+    def test_parses_shell_block_signature_ignoring_label(self):
+        text = (
+            "● Check something interesting (shell)\n"
+            "  │ echo hello\n"
+            "  └ 1 line\n"
+        )
+        blocks = loop_guard.parse_blocks(text)
+        self.assertEqual(blocks, [("shell", "echo hello")])
+
+    def test_different_ordinal_labels_do_not_affect_signature(self):
+        text = (
+            "● Retry the command again (shell)\n"
+            "  │ echo hello\n"
+            "  └ 1 line\n"
+            "● Retry the command a third time (shell)\n"
+            "  │ echo hello\n"
+            "  └ 1 line\n"
+        )
+        blocks = loop_guard.parse_blocks(text)
+        self.assertEqual(blocks, [("shell", "echo hello"), ("shell", "echo hello")])
+
+    def test_in_flight_slash_glyph_parsed_same_as_completed_bullet(self):
+        text = "/ Running something (shell)\n  │ echo hello\n"
+        blocks = loop_guard.parse_blocks(text)
+        self.assertEqual(blocks, [("shell", "echo hello")])
+
+    def test_multiline_detail_is_joined_and_whitespace_collapsed(self):
+        text = (
+            "● Read something (read)\n"
+            "  │ some/wrapped/path/that/spans/two/rendered\n"
+            "  │ /lines/because/it/is/long.java\n"
+            "  └ 33 lines read\n"
+        )
+        blocks = loop_guard.parse_blocks(text)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(
+            blocks[0][1],
+            "some/wrapped/path/that/spans/two/rendered /lines/because/it/is/long.java",
+        )
+
+    def test_block_without_parenthesized_type_is_unknown(self):
+        text = "● Do something with no type suffix\n  │ echo hello\n"
+        blocks = loop_guard.parse_blocks(text)
+        self.assertEqual(blocks, [("unknown", "echo hello")])
+
+
+class TrailingRepeatTests(unittest.TestCase):
+    def test_no_blocks_returns_zero(self):
+        count, sig = loop_guard.trailing_repeat([])
+        self.assertEqual(count, 0)
+        self.assertIsNone(sig)
+
+    def test_counts_consecutive_trailing_repeats_only(self):
+        blocks = [("shell", "cmd A"), ("shell", "cmd B"), ("shell", "cmd B"), ("shell", "cmd B")]
+        count, sig = loop_guard.trailing_repeat(blocks)
+        self.assertEqual(count, 3)
+        self.assertEqual(sig, ("shell", "cmd B"))
+
+    def test_a_different_block_in_between_resets_the_run(self):
+        blocks = [("shell", "cmd B"), ("shell", "cmd B"), ("shell", "cmd C"), ("shell", "cmd B")]
+        count, sig = loop_guard.trailing_repeat(blocks)
+        self.assertEqual(count, 1)
+        self.assertEqual(sig, ("shell", "cmd B"))
+
+    def test_empty_signature_blocks_never_count_as_a_repeat(self):
+        blocks = [("unknown", ""), ("unknown", "")]
+        count, sig = loop_guard.trailing_repeat(blocks)
+        self.assertEqual(count, 0)
+        self.assertIsNone(sig)
+
+    def test_ignore_types_excludes_matching_blocks_from_consideration(self):
+        blocks = [
+            ("shell", "cmd B"),
+            ("wait", "polling long-running command"),
+            ("wait", "polling long-running command"),
+            ("shell", "cmd B"),
+        ]
+        # Without ignoring "wait", the trailing run would be broken by the
+        # "shell"/"cmd B" at position -1 alone (count=1) since "wait" blocks
+        # sit at the tail... but filtering "wait" out first should reveal the
+        # true consecutive "cmd B" "shell" run underneath.
+        count, sig = loop_guard.trailing_repeat(blocks, ignore_types=frozenset({"wait"}))
+        self.assertEqual(count, 2)
+        self.assertEqual(sig, ("shell", "cmd B"))
+
+
+class TrailingNearRepeatTests(unittest.TestCase):
+    def test_identical_signatures_also_count_as_near_repeats(self):
+        blocks = [("shell", "cmd B"), ("shell", "cmd B"), ("shell", "cmd B")]
+        count, sig = loop_guard.trailing_near_repeat(blocks)
+        self.assertEqual(count, 3)
+        self.assertEqual(sig, ("shell", "cmd B"))
+
+    def test_single_varying_token_still_counts_as_a_near_repeat(self):
+        # Some coding-agent CLIs have been observed embedding a different
+        # throwaway word inside the command text on every repeat (not just
+        # the free-text label already stripped from the signature) as a way
+        # to dodge exact-match detection. trailing_repeat() would see 4
+        # distinct signatures and never fire; trailing_near_repeat() must
+        # still catch this.
+        blocks = [
+            ("shell", "git diff -- Foo.java | python3 -c \"print('hexagon')\""),
+            ("shell", "git diff -- Foo.java | python3 -c \"print('octagon')\""),
+            ("shell", "git diff -- Foo.java | python3 -c \"print('sphere')\""),
+            ("shell", "git diff -- Foo.java | python3 -c \"print('cube')\""),
+        ]
+        exact_count, _ = loop_guard.trailing_repeat(blocks)
+        self.assertEqual(exact_count, 1, "exact match must NOT see these as repeats")
+        near_count, sig = loop_guard.trailing_near_repeat(blocks)
+        self.assertEqual(near_count, 4)
+        self.assertEqual(sig[0], "shell")
+
+    def test_different_token_count_breaks_the_near_repeat_run(self):
+        blocks = [
+            ("shell", "git diff -- Foo.java | wc -l"),
+            ("shell", "git diff -- Foo.java | wc -l"),
+            ("shell", "git diff -- Foo.java --stat | wc -l"),  # extra token
+        ]
+        count, sig = loop_guard.trailing_near_repeat(blocks)
+        self.assertEqual(count, 1)
+        self.assertEqual(sig, ("shell", "git diff -- Foo.java --stat | wc -l"))
+
+    def test_too_many_differing_tokens_breaks_the_run(self):
+        # Legitimate exploration: reading several genuinely different files
+        # with a templated command should NOT be treated as one giant repeat
+        # once more than the small allowed token-diff budget is exceeded.
+        blocks = [
+            ("shell", "cat a.java | grep foo | head -20"),
+            ("shell", "cat b.java | grep bar | head -50"),  # 3 tokens differ
+        ]
+        count, sig = loop_guard.trailing_near_repeat(blocks, max_diff_tokens=2)
+        self.assertEqual(count, 1)
+
+    def test_a_genuinely_different_tool_type_breaks_the_run(self):
+        blocks = [
+            ("shell", "git diff -- Foo.java | python3 -c \"print('hexagon')\""),
+            ("grep", "git diff -- Foo.java | python3 -c \"print('octagon')\""),
+        ]
+        count, sig = loop_guard.trailing_near_repeat(blocks)
+        self.assertEqual(count, 1)
+
+    def test_empty_signature_returns_zero(self):
+        count, sig = loop_guard.trailing_near_repeat([("unknown", "")])
+        self.assertEqual(count, 0)
+        self.assertIsNone(sig)
+
+    def test_no_blocks_returns_zero(self):
+        count, sig = loop_guard.trailing_near_repeat([])
+        self.assertEqual(count, 0)
+        self.assertIsNone(sig)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
The existing loop-guard only detects byte-identical repeated tool calls at the tail of a transcript (`trailing_repeat()`). A real CI run showed a coding-agent CLI evading this: on every repeat it embedded a fresh throwaway word directly inside an otherwise-identical shell command (not just the already-excluded free-text bullet label), producing a technically-unique signature every time (hexagon, octagon, sphere, cube, ... ~2990 times) — the guard never fired and the job ran until the CI job's 8h hard timeout killed it.

## Fix
- Added `trailing_near_repeat()`: flags a trailing run of calls sharing the same `tool_type` and token count, differing from the newest call in only a small number of tokens (`max(3, 15%)`).
- Wired into `main()` alongside the existing exact-match check, gated by a new `--near-threshold` (default 15, env `COPILOT_LOOP_GUARD_NEAR_THRESHOLD`) — deliberately higher than `--threshold` since fuzzy matching is more false-positive-prone on legitimate repetitive-looking exploration.
- Added `scripts/tests/test_loop_guard.py` with generic/synthetic test coverage (no project-specific content).

## Testing
- `python3 scripts/tests/test_loop_guard.py` — 17/17 pass
- `bash scripts/providers/tests/test_copilot_loop_guard.sh` — integration test still passes
