### PR TITLE
fix(developTicketAndCreatePR): fail explicitly on fatal AI CLI/environment errors

### DIFF
--- a/js/developTicketAndCreatePR.js
+++ b/js/developTicketAndCreatePR.js
@@ -467,6 +467,47 @@ function postErrorCommentToJira(ticketKey, stage, errorMessage) {
     }
 }
 
+/**
+ * Detects CLI/environment failures that a retry can never fix — e.g. the configured
+ * AI_AGENT_PROVIDER binary (cursor-agent, kimi, claude, ...) is missing from the
+ * runner's PATH, or AI_AGENT_PROVIDER names an unknown provider. run-agent.sh surfaces
+ * these as "Command failed (exit code 127)" (127 = shell "command not found"), unlike
+ * transient failures (rate limits, timeouts = exit code 124) that a resume/retry can
+ * plausibly resolve. Silently resetting the ticket for retry on this class of error
+ * just loops forever, since the missing tool never appears on its own.
+ */
+function isFatalCliEnvironmentError(responseText) {
+    var text = String(responseText || '');
+    return /exit code 127\)/.test(text) ||
+        /not found in PATH/i.test(text) ||
+        /Error: unknown provider/i.test(text);
+}
+
+function postFatalCliEnvironmentErrorToJira(ticketKey, errorMessage) {
+    try {
+        jira_post_comment({
+            key: ticketKey,
+            comment: 'h3. ❌ AI CLI Environment Failure\n\n' +
+                'The configured AI CLI tool could not run on the runner (e.g. missing binary or misconfigured provider):\n\n{code}' + errorMessage + '{code}\n\n' +
+                'This is an infrastructure/setup problem, not a normal work-item issue — retrying will fail the same way until the runner environment is fixed. The job has been failed explicitly instead of silently looping on retry.'
+        });
+    } catch (e) {
+        console.error('Failed to post fatal CLI environment error comment:', e);
+    }
+}
+
+/**
+ * Posts the fatal-error comment and throws a marked Error so it propagates out of
+ * action() uncaught (see the outer catch below) instead of being swallowed into the
+ * usual "reset for retry" recovery path.
+ */
+function throwFatalCliEnvironmentError(ticketKey, errorMessage) {
+    postFatalCliEnvironmentErrorToJira(ticketKey, errorMessage);
+    var err = new Error('Fatal CLI/environment failure: ' + errorMessage);
+    err.fatalCliEnvironment = true;
+    throw err;
+}
+
 function labelsToRemove(customParams, metadata) {
     var labels = [];
     if (customParams && customParams.removeLabel) labels.push(customParams.removeLabel);
@@ -779,7 +820,12 @@ function action(params) {
                     return { success: true, path: 'no-changes-needed', ticketKey: ticketKey };
                 }
 
-                // Case B: agent was genuinely interrupted — retry.
+                // Case B: agent was genuinely interrupted, OR the CLI/environment itself is
+                // broken (e.g. missing AI CLI binary) — the latter can never self-resolve via retry.
+                if (isFatalCliEnvironmentError(developmentSummary)) {
+                    console.error('CLI/environment failure detected (e.g. AI CLI binary missing from PATH) — failing the job explicitly instead of resetting for retry.');
+                    throwFatalCliEnvironmentError(ticketKey, developmentSummary);
+                }
                 console.log('No git changes detected AND no response.md — CLI agent was interrupted. Resetting ticket for retry.');
                 try {
                     jira_post_comment({
@@ -879,6 +925,12 @@ function action(params) {
             responseContent = null;
         }
         if (!responseContent || !responseContent.trim()) {
+            // Same distinction as above: an unrecoverable CLI/environment failure must fail
+            // the job explicitly rather than reset for an endless retry loop.
+            if (isFatalCliEnvironmentError(developmentSummary)) {
+                console.error('CLI/environment failure detected (e.g. AI CLI binary missing from PATH) — failing the job explicitly instead of resetting for retry.');
+                throwFatalCliEnvironmentError(ticketKey, developmentSummary);
+            }
             // Agent was interrupted after committing partial work (e.g. outputs/rca.md) but
             // before writing response.md. Reset ticket for retry rather than posting an error.
             console.log('outputs/response.md missing after commit — CLI agent was interrupted mid-way. Resetting for retry.');
@@ -1027,6 +1079,13 @@ function action(params) {
 
     } catch (error) {
         console.error('❌ Error in development workflow:', error);
+
+        if (error && error.fatalCliEnvironment) {
+            // Retrying can never fix a broken CLI/tooling setup (missing binary, bad
+            // provider config, ...) — let the exception propagate so the job fails
+            // loudly and visibly instead of silently looping via resume/reset-for-retry.
+            throw error;
+        }
 
         // Try to reset ticket for retry instead of leaving it stuck In Development.
         try {

--- a/js/unit-tests/test_developTicketAndCreatePR.js
+++ b/js/unit-tests/test_developTicketAndCreatePR.js
@@ -31,6 +31,55 @@ function loadDevelopTicketAndCreatePR(mocks, feedbackLoopOverrides) {
     );
 }
 
+// Loads developTicketAndCreatePR.js with the REAL common/pullRequest.js and
+// common/submodules.js helpers (instead of the bare stubs above) so tests can
+// drive performGitOperations() all the way to its "No changes were made" path,
+// which the bare stubs can't reach (they lack readStagedDiffStat/buildOriginFetchCommand).
+function loadDevelopTicketAndCreatePRWithRealGitHelpers(mocks) {
+    var realPrHelper = loadModule('js/common/pullRequest.js', makeRequire({}), {});
+    return loadModule(
+        'js/developTicketAndCreatePR.js',
+        makeRequire({
+            './common/jiraHelpers.js': { extractTicketKey: function(key) { return key; } },
+            './common/pullRequest.js': realPrHelper,
+            './common/submodules.js': { pushManagedSubmodules: function() {} },
+            './common/feedbackLoop.js': {
+                runQualityGates: function() { return { success: true }; },
+                runPolicyGates: function() { return { success: true }; },
+                runPostPublishGates: function() { return { success: true }; },
+                resumeAgent: function() { return { attempted: false }; }
+            },
+            './common/autoStart.js': { triggerSmIfIdle: function() {} },
+            './common/outputFiles.js': { readOutputFile: function() { return null; } },
+            './cacheToReleases.js': {},
+            './configLoader.js': configLoaderModule,
+            './config.js': configModule,
+            './common/tokenUsageComment.js': { postTokenUsageComments: function() {} }
+        }),
+        Object.assign({
+            cli_execute_command: function() { return ''; },
+            jira_post_comment: function() {},
+            jira_move_to_status: function() {},
+            jira_remove_label: function() {}
+        }, mocks || {})
+    );
+}
+
+// Common git-command mock shared by the two tests below: simulates a ticket
+// branch with no staged/committed/pushed changes at all — i.e. the CLI agent
+// never actually ran (which is exactly what happens when the AI CLI binary is
+// missing from the runner, exit code 127).
+function noChangesGitCommandMock(ticketKey, branchName) {
+    return function(args) {
+        var command = args.command;
+        if (command.indexOf('gh pr list --head ' + branchName) === 0) return '';
+        if (command === 'git branch --show-current') return branchName;
+        if (command === 'git diff --cached --stat') return '';
+        if (command.indexOf('git rev-list --count') === 0) return '0';
+        return '';
+    };
+}
+
 suite('developTicketAndCreatePR > failure recovery', function() {
 
     test('resets ticket and removes retry-blocking labels when git configuration fails', function() {
@@ -118,6 +167,63 @@ suite('developTicketAndCreatePR > failure recovery', function() {
         assert.deepEqual(movedTo, ['Ready For Development']);
         assert.equal(comments.length, 1);
         assert.contains(comments[0].comment, 'Development Workflow Error');
+    });
+
+    test('fails the job explicitly (throws) instead of resetting for retry when the AI CLI binary is missing from the runner (exit code 127)', function() {
+        var movedTo = [];
+        var removedLabels = [];
+        var comments = [];
+        // Mirrors the real dmtools "response" text observed when run-agent.sh can't
+        // find the configured provider's CLI binary (e.g. cursor-agent not installed).
+        var fatalResponse = 'CLI command executed but did not produce output file:\n' +
+            'CLI Command: ./agents/scripts/run-agent.sh "prompt"\n' +
+            "Error: Failed to execute CLI command './agents/scripts/run-agent.sh \"prompt\"': " +
+            'Command failed (exit code 127): ./agents/scripts/run-agent.sh "prompt"\n' +
+            'Output:\nAI Agent Provider: cursor\nError: cursor-agent not found in PATH\n';
+
+        var mod = loadDevelopTicketAndCreatePRWithRealGitHelpers({
+            cli_execute_command: noChangesGitCommandMock('TS-3', 'ai/TS-3'),
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_move_to_status: function(args) { movedTo.push(args.statusName); },
+            jira_remove_label: function(args) { removedLabels.push(args.label); }
+        });
+
+        assert.throws(function() {
+            mod.action({
+                ticket: { key: 'TS-3', fields: { summary: 'Broken CLI', description: '', labels: [] } },
+                metadata: { contextId: 'story_development' },
+                customParams: {},
+                response: fatalResponse
+            });
+        }, 'expected action() to throw so the CI job fails explicitly instead of silently continuing');
+
+        assert.equal(movedTo.length, 0, 'ticket must not be silently reset to Ready For Development');
+        assert.equal(removedLabels.length, 0, 'retry-blocking labels must not be removed on a fatal environment error');
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'AI CLI Environment Failure');
+    });
+
+    test('still resets ticket for retry (does not throw) on an ordinary interrupted response with no fatal environment signature', function() {
+        var movedTo = [];
+        var comments = [];
+        var mod = loadDevelopTicketAndCreatePRWithRealGitHelpers({
+            cli_execute_command: noChangesGitCommandMock('TS-4', 'ai/TS-4'),
+            jira_post_comment: function(args) { comments.push(args); },
+            jira_move_to_status: function(args) { movedTo.push(args.statusName); }
+        });
+
+        var result = mod.action({
+            ticket: { key: 'TS-4', fields: { summary: 'Rate limited', description: '', labels: [] } },
+            metadata: { contextId: 'story_development' },
+            customParams: {},
+            response: 'Agent hit a rate limit and stopped mid-analysis.'
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.path, 'interrupted');
+        assert.deepEqual(movedTo, ['Ready For Development']);
+        assert.equal(comments.length, 1);
+        assert.contains(comments[0].comment, 'Development Interrupted');
     });
 
 });


### PR DESCRIPTION
## Problem
When the configured AI CLI fails to run at all on the runner (e.g. the
`AI_AGENT_PROVIDER` binary such as `cursor-agent` is missing from `PATH`, or
`AI_AGENT_PROVIDER` names an unknown provider), `run-agent.sh` surfaces this
as an exit-127 \"command not found\" failure. `developTicketAndCreatePR.js`
treated this the same as a normal interrupted/rate-limited run and silently
reset the ticket to *Ready For Development* for retry. Because the missing
binary/bad config never resolves on its own, the job just looped forever
instead of failing loudly.

## Fix
- Add `isFatalCliEnvironmentError()` to detect this unrecoverable class of
  error from the CLI response text (exit code 127, "not found in PATH",
  "unknown provider"), as distinct from transient failures (rate limits,
  timeouts) that a resume/retry can plausibly fix.
- Add `throwFatalCliEnvironmentError()` which posts a distinct "AI CLI
  Environment Failure" Jira comment and throws, so the error propagates out
  of `action()` uncaught and fails the CI job explicitly instead of being
  swallowed by the generic reset-for-retry recovery path.
- Wire the check into both places that previously reset-for-retry on empty/
  missing `response.md`, and re-throw in the outer `catch` when the error is
  marked `fatalCliEnvironment` (bypassing the usual "reset ticket" recovery).

## Tests
Added two unit tests to `test_developTicketAndCreatePR.js`:
- Asserts `action()` throws (and does **not** reset the ticket status or
  remove retry-blocking labels) when given a response matching the exit-127
  signature.
- Asserts an ordinary interrupted response with no fatal signature still
  takes the existing reset-for-retry path unchanged.

Verified with `node --check` on both files (dmtools/GraalJS runtime isn't
available in this environment to run the full unit-test suite locally).