### PR TITLE
feat(trackers): tracker-agnostic ticket helpers over canonical provider tools

### DIFF
--- a/js/common/trackers.js
+++ b/js/common/trackers.js
@@ -1,21 +1,27 @@
 /**
  * Tracker-agnostic ticket helpers — the scm.js analog for trackers.
  *
- * Every operation goes through the generic tracker_* tool family; the
- * runtime routes to whichever tracker backend is configured
- * (Jira | ADO | GitHub issues). Agent code written against this module
- * no longer depends on jiraHelpers or the jira_* globals directly.
+ * Maps generic ticket operations onto CANONICAL tracker tools per
+ * configured provider — jira_* (default), ado_*, github_* — exactly like
+ * scm.js maps SCM operations onto providers.
  *
- * On runtimes that do not expose the tracker_* family (legacy Java
- * DMTools), every operation transparently falls back to its native
- * jira_* twin, so scripts stay portable during the migration.
+ * Why canonical tools and not the tracker_* family: on the Java runtime
+ * tracker_* exists solely as a CLI alias (resolved via DEFAULT_TRACKER in
+ * McpCliHandler); the JS surface exposes canonical names only. Provider
+ * mapping therefore lives in this layer, in JS.
  *
  * Factory: createTracker(config)
- *   config.repository: { owner, repo }  // expands bare GitHub issue numbers
+ *   config.tracker.provider: 'jira' (default) | 'ado' | 'github'
+ *   config.repository: { owner, repo }  // GitHub issue key expansion
  *   config.labels: { aiGenerated }      // overrides LABELS.AI_GENERATED
  *
  * Per-agent override via JSON customParams:
- *   { "customParams": { "targetRepository": { "owner": "MyOrg", "repo": "my-repo" } } }
+ *   { "customParams": { "trackerProvider": "ado" } }
+ *
+ * Provider capabilities: jira supports every operation; ado covers
+ * tickets/search/comments/status/assign/create (labels are not exposed by
+ * the ado toolset); github is read/close-oriented (issue tools are a Dart
+ * runtime extension) — unsupported operations throw a clear error.
  */
 
 const { STATUSES, LABELS } = require('../config.js');
@@ -77,7 +83,7 @@ function _normalizeComment(raw) {
 }
 
 /**
- * Read a ticket author out of backend-specific assignee shapes.
+ * Read a ticket assignee out of backend-specific shapes.
  */
 function _assigneeName(fields) {
     var candidates = [
@@ -96,15 +102,30 @@ function _assigneeName(fields) {
 }
 
 function createTracker(config) {
+    var VALID = ['jira', 'ado', 'github'];
+    var raw = config && config.tracker && config.tracker.provider;
+    var providerName = VALID.indexOf(String(raw || '').toLowerCase()) !== -1
+        ? String(raw).toLowerCase()
+        : 'jira';
     var owner = (config && config.repository && config.repository.owner) || '';
     var repo  = (config && config.repository && config.repository.repo)  || '';
     var aiLabel = (config && config.labels && config.labels.aiGenerated)
         || LABELS.AI_GENERATED;
 
+    function provider() {
+        return providerName;
+    }
+
+    function unsupported(op) {
+        throw new Error(
+            'trackers: operation "' + op + '" is not supported by the ' +
+            providerName + ' provider'
+        );
+    }
+
     /**
-     * Expand a bare numeric issue number into "owner/repo#N" when the
-     * repository is configured. Every other key shape passes through
-     * untouched ("PROJ-123", "acme/widgets#7", ADO work-item ids).
+     * Expand a bare numeric issue number into "owner/repo#N" (GitHub
+     * keys) when the repository is configured. Other keys pass through.
      */
     function expandKey(key) {
         var k = String(key == null ? '' : key).trim();
@@ -114,17 +135,167 @@ function createTracker(config) {
         return k;
     }
 
+    function githubIssueNumber(key) {
+        var k = expandKey(key);
+        var m = /^[\w.-]+\/[\w.-]+#(\d+)$/.exec(k) || /^(\d+)$/.exec(k);
+        if (!m) {
+            throw new Error('trackers: cannot parse GitHub issue key: ' + key);
+        }
+        return parseInt(m[1], 10);
+    }
+
+    // ── jira provider (canonical jira_* tools) ────────────────────────────
+
+    function jiraGetTicket(key) {
+        return normalizeTicket(jira_get_ticket({ key: key }));
+    }
+
+    function jiraSearch(query) {
+        return _ticketPage(jira_search_by_jql({ jql: query }), 'issues');
+    }
+
+    function jiraPostComment(key, comment) {
+        return jira_post_comment({ key: key, comment: comment });
+    }
+
+    function jiraGetComments(key) {
+        return _commentPage(jira_get_comments({ key: key }), 'comments');
+    }
+
+    function jiraMoveToStatus(key, status) {
+        return jira_move_to_status({ key: key, statusName: status });
+    }
+
+    function jiraAssignTo(key, user) {
+        return jira_assign_ticket_to({ key: key, accountId: user });
+    }
+
+    function jiraCreateTicket(project, type, title, description) {
+        return extractTicketKey(jira_create_ticket_basic({
+            project: project,
+            issueType: type,
+            summary: title,
+            description: description
+        }));
+    }
+
+    // ── ado provider (canonical ado_* tools) ──────────────────────────────
+
+    function adoGetTicket(key) {
+        return normalizeTicket(ado_get_work_item({ id: String(key) }));
+    }
+
+    function adoSearch(query) {
+        return _ticketPage(ado_search_by_wiql({ wiql: query }), 'value');
+    }
+
+    function adoPostComment(key, comment) {
+        return ado_add_work_item_comment({ id: String(key), comment: comment });
+    }
+
+    function adoGetComments(key) {
+        return _commentPage(ado_get_work_item_comments({ id: String(key) }), 'value');
+    }
+
+    function adoMoveToStatus(key, status) {
+        return ado_move_to_state({ id: String(key), state: status });
+    }
+
+    function adoAssignTo(key, user) {
+        return ado_assign_work_item({ id: String(key), userEmail: user });
+    }
+
+    function adoCreateTicket(project, type, title, description) {
+        var raw = ado_create_work_item({
+            project: project,
+            workItemType: type,
+            title: title,
+            description: description
+        });
+        // ADO work items identify by numeric id, not by key.
+        var parsed = _parseJson(raw);
+        if (parsed && typeof parsed === 'object') {
+            if (typeof parsed.key === 'string') return parsed.key;
+            if (parsed.id != null) return String(parsed.id);
+        }
+        return extractTicketKey(raw);
+    }
+
+    // ── github provider (canonical github_* issue tools; Dart runtime) ────
+
+    function githubGetTicket(key) {
+        return normalizeTicket(github_get_issue({
+            owner: owner,
+            repo: repo,
+            issue_number: githubIssueNumber(key)
+        }));
+    }
+
+    function githubMoveToStatus(key, status) {
+        var s = String(status || '').toLowerCase();
+        if (s !== 'done' && s !== 'closed') {
+            throw new Error('trackers: cannot map GitHub status: ' + status);
+        }
+        return github_close_issue({
+            owner: owner,
+            repo: repo,
+            issue_number: githubIssueNumber(key)
+        });
+    }
+
+    // ── dispatch tables ───────────────────────────────────────────────────
+
+    var impls = {
+        jira: {
+            getTicket: jiraGetTicket,
+            search: jiraSearch,
+            postComment: jiraPostComment,
+            getComments: jiraGetComments,
+            addLabel: function (key, label) {
+                return jira_add_label({ key: key, label: label });
+            },
+            removeLabel: function (key, label) {
+                return jira_remove_label({ key: key, label: label });
+            },
+            moveToStatus: jiraMoveToStatus,
+            assignTo: jiraAssignTo,
+            createTicket: jiraCreateTicket
+        },
+        ado: {
+            getTicket: adoGetTicket,
+            search: adoSearch,
+            postComment: adoPostComment,
+            getComments: adoGetComments,
+            addLabel: function () { unsupported('addLabel'); },
+            removeLabel: function () { unsupported('removeLabel'); },
+            moveToStatus: adoMoveToStatus,
+            assignTo: adoAssignTo,
+            createTicket: adoCreateTicket
+        },
+        github: {
+            getTicket: githubGetTicket,
+            search: function () { unsupported('search'); },
+            postComment: function () { unsupported('postComment'); },
+            getComments: function () { unsupported('getComments'); },
+            addLabel: function () { unsupported('addLabel'); },
+            removeLabel: function () { unsupported('removeLabel'); },
+            moveToStatus: githubMoveToStatus,
+            assignTo: function () { unsupported('assignTo'); },
+            createTicket: function () { unsupported('createTicket'); }
+        }
+    };
+    var impl = impls[providerName];
+
     /**
      * Normalize any backend's ticket payload into a flat view:
      * { key, id, title, status, assignee, labels, description, url, raw: null }
      * Returns null for empty/unparseable input. The raw payload is
      * deliberately not embedded — agents needing backend specifics should
-     * call the tracker_* tools directly.
+     * call the provider tools directly.
      */
-    function normalizeTicket(raw) {
-        var t = _parseJson(raw);
-        if (!t || typeof t !== 'object') return null;
-        if (typeof t === 'string') return null;
+    function normalizeTicket(rawTicket) {
+        var t = _parseJson(rawTicket);
+        if (!t || typeof t !== 'object' || typeof t === 'string') return null;
 
         // Already flat / previously normalized.
         if (typeof t.key === 'string' && !t.fields) {
@@ -133,7 +304,7 @@ function createTracker(config) {
         }
 
         // Jira: { key, id, fields: { summary, status: { name }, ... } }
-        if (t.fields && typeof t.fields === 'object' && !t.fields['System.Title']) {
+        if (t.fields && typeof t.fields === 'object' && t.fields.summary !== undefined) {
             var f = t.fields;
             return _flatTicket(
                 t.key || (t.id != null ? String(t.id) : null),
@@ -196,32 +367,11 @@ function createTracker(config) {
         };
     }
 
-    // ── tool dispatch ──────────────────────────────────────────────────────
-    //
-    // Each operation probes its own tracker_* tool: runtimes expose the
-    // family as a whole, but probing per operation keeps the fallback
-    // correct even if a future runtime ships the family incrementally.
-
-    function getTicket(key) {
-        var k = expandKey(key);
-        if (typeof tracker_get_ticket !== 'undefined') {
-            return normalizeTicket(tracker_get_ticket({ key: k }));
-        }
-        return normalizeTicket(jira_get_ticket({ key: k }));
-    }
-
-    function search(query) {
-        var page;
-        if (typeof tracker_search !== 'undefined') {
-            page = _parseJson(tracker_search({ query: query }));
-        } else {
-            page = _parseJson(jira_search_by_jql({ jql: query }));
-        }
-        var list = page;
-        if (page && typeof page === 'object' && !Array.isArray(page)) {
-            list = page.issues || page.value || page.workItems || [];
-        }
-        if (!Array.isArray(list)) return [];
+    function _ticketPage(rawPage, listField) {
+        var page = _parseJson(rawPage);
+        var list = page && typeof page === 'object' && !Array.isArray(page)
+            ? (page[listField] || [])
+            : (Array.isArray(page) ? page : []);
         var out = [];
         for (var i = 0; i < list.length; i++) {
             var n = normalizeTicket(list[i]);
@@ -230,85 +380,17 @@ function createTracker(config) {
         return out;
     }
 
-    function postComment(key, comment) {
-        var k = expandKey(key);
-        if (typeof tracker_post_comment !== 'undefined') {
-            return tracker_post_comment({ key: k, comment: comment });
-        }
-        return jira_post_comment({ key: k, comment: comment });
-    }
-
-    function getComments(key) {
-        var k = expandKey(key);
-        var page;
-        if (typeof tracker_get_comments !== 'undefined') {
-            page = _parseJson(tracker_get_comments({ key: k }));
-        } else {
-            page = _parseJson(jira_get_comments({ key: k }));
-        }
-        var list = page;
-        if (page && typeof page === 'object' && !Array.isArray(page)) {
-            list = page.comments || page.value || [];
-        }
-        if (!Array.isArray(list)) return [];
+    function _commentPage(rawPage, listField) {
+        var page = _parseJson(rawPage);
+        var list = page && typeof page === 'object' && !Array.isArray(page)
+            ? (page[listField] || [])
+            : (Array.isArray(page) ? page : []);
         var out = [];
         for (var i = 0; i < list.length; i++) {
             var c = _normalizeComment(list[i]);
             if (c) out.push(c);
         }
         return out;
-    }
-
-    function addLabel(key, label) {
-        var k = expandKey(key);
-        if (typeof tracker_add_label !== 'undefined') {
-            return tracker_add_label({ key: k, label: label });
-        }
-        return jira_add_label({ key: k, label: label });
-    }
-
-    function removeLabel(key, label) {
-        var k = expandKey(key);
-        if (typeof tracker_remove_label !== 'undefined') {
-            return tracker_remove_label({ key: k, label: label });
-        }
-        return jira_remove_label({ key: k, label: label });
-    }
-
-    function moveToStatus(key, status) {
-        var k = expandKey(key);
-        if (typeof tracker_move_to_status !== 'undefined') {
-            return tracker_move_to_status({ key: k, status: status });
-        }
-        return jira_move_to_status({ key: k, statusName: status });
-    }
-
-    function assignTo(key, user) {
-        var k = expandKey(key);
-        if (typeof tracker_assign_to !== 'undefined') {
-            return tracker_assign_to({ key: k, user: user });
-        }
-        return jira_assign_ticket_to({ key: k, accountId: user });
-    }
-
-    function createTicket(project, type, title, description) {
-        var raw;
-        if (typeof tracker_create_ticket !== 'undefined') {
-            raw = tracker_create_ticket({
-                project: project,
-                type: type,
-                title: title,
-                description: description
-            });
-        } else {
-            raw = jira_create_ticket({
-                project: project,
-                issueType: type,
-                summary: title,
-                description: description
-            });
-        }
-        return extractTicketKey(raw);
     }
 
     /**
@@ -321,12 +403,12 @@ function createTracker(config) {
         var statusName = targetStatus || STATUSES.IN_REVIEW;
         try {
             console.log('Processing ticket:', ticketKey);
-            assignTo(ticketKey, initiatorId);
-            moveToStatus(ticketKey, statusName);
-            addLabel(ticketKey, aiLabel);
+            impl.assignTo(ticketKey, initiatorId);
+            impl.moveToStatus(ticketKey, statusName);
+            impl.addLabel(ticketKey, aiLabel);
             if (wipLabel) {
                 try {
-                    removeLabel(ticketKey, wipLabel);
+                    impl.removeLabel(ticketKey, wipLabel);
                     console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
                 } catch (labelError) {
                     console.warn('Failed to remove WIP label "' + wipLabel + '":', labelError);
@@ -344,16 +426,16 @@ function createTracker(config) {
     }
 
     return {
-        provider: function () { return 'tracker'; },
-        getTicket: getTicket,
-        search: search,
-        postComment: postComment,
-        getComments: getComments,
-        addLabel: addLabel,
-        removeLabel: removeLabel,
-        moveToStatus: moveToStatus,
-        assignTo: assignTo,
-        createTicket: createTicket,
+        provider: provider,
+        getTicket: function (k) { return impl.getTicket(k); },
+        search: function (q) { return impl.search(q); },
+        postComment: function (k, c) { return impl.postComment(k, c); },
+        getComments: function (k) { return impl.getComments(k); },
+        addLabel: function (k, l) { return impl.addLabel(k, l); },
+        removeLabel: function (k, l) { return impl.removeLabel(k, l); },
+        moveToStatus: function (k, s) { return impl.moveToStatus(k, s); },
+        assignTo: function (k, u) { return impl.assignTo(k, u); },
+        createTicket: function (p, t, ti, d) { return impl.createTicket(p, t, ti, d); },
         normalizeTicket: normalizeTicket,
         extractTicketKey: extractTicketKey,
         assignForReview: assignForReview

--- a/js/common/trackers.js
+++ b/js/common/trackers.js
@@ -20,8 +20,10 @@
  *
  * Provider capabilities: jira supports every operation; ado covers
  * tickets/search/comments/status/assign/create (labels are not exposed by
- * the ado toolset); github is read/close-oriented (issue tools are a Dart
- * runtime extension) — unsupported operations throw a clear error.
+ * the ado toolset); github covers get/status/close — moveToStatus closes
+ * on done/closed and carries any other status as an issue label (issue
+ * tools are a Dart runtime extension); unsupported operations throw a
+ * clear error.
  */
 
 const { STATUSES, LABELS } = require('../config.js');
@@ -224,22 +226,32 @@ function createTracker(config) {
     // ── github provider (canonical github_* issue tools; Dart runtime) ────
 
     function githubGetTicket(key) {
+        // github_get_issue schema (Dart catalog): workspace/repository/
+        // issueNumber — not the REST-style owner/repo/issue_number.
         return normalizeTicket(github_get_issue({
-            owner: owner,
-            repo: repo,
-            issue_number: githubIssueNumber(key)
+            workspace: owner,
+            repository: repo,
+            issueNumber: githubIssueNumber(key)
         }));
     }
 
     function githubMoveToStatus(key, status) {
-        var s = String(status || '').toLowerCase();
-        if (s !== 'done' && s !== 'closed') {
+        // GitHub issues have no status field: done/closed close the issue,
+        // any other status is carried as an issue label (github_add_labels
+        // schema: owner/repo/number + labels array).
+        var s = String(status || '').trim().toLowerCase();
+        if (!s) {
             throw new Error('trackers: cannot map GitHub status: ' + status);
         }
-        return github_close_issue({
+        var n = githubIssueNumber(key);
+        if (s === 'done' || s === 'closed') {
+            return github_close_issue({ owner: owner, repo: repo, number: n });
+        }
+        return github_add_labels({
             owner: owner,
             repo: repo,
-            issue_number: githubIssueNumber(key)
+            number: n,
+            labels: [String(status).trim()]
         });
     }
 

--- a/js/common/trackers.js
+++ b/js/common/trackers.js
@@ -20,10 +20,10 @@
  *
  * Provider capabilities: jira supports every operation; ado covers
  * tickets/search/comments/status/assign/create (labels are not exposed by
- * the ado toolset); github covers get/status/close — moveToStatus closes
- * on done/closed and carries any other status as an issue label (issue
- * tools are a Dart runtime extension); unsupported operations throw a
- * clear error.
+ * the ado toolset); github covers everything except search and assignTo —
+ * moveToStatus closes on done/closed and carries any other status as an
+ * issue label (issue tools are a Dart runtime extension); the remaining
+ * gaps throw a clear error.
  */
 
 const { STATUSES, LABELS } = require('../config.js');
@@ -255,6 +255,59 @@ function createTracker(config) {
         });
     }
 
+    function githubAddLabel(key, label) {
+        return github_add_labels({
+            owner: owner,
+            repo: repo,
+            number: githubIssueNumber(key),
+            labels: [label]
+        });
+    }
+
+    function githubRemoveLabel(key, label) {
+        return github_remove_label({
+            owner: owner,
+            repo: repo,
+            number: githubIssueNumber(key),
+            label: label
+        });
+    }
+
+    function githubPostComment(key, comment) {
+        // github_create_comment POSTs to issues/{n}/comments (PRs are
+        // issues upstream), so it serves plain-issue comments too; the
+        // number argument keeps the tool's canonical pullRequestId name.
+        return github_create_comment({
+            workspace: owner,
+            repository: repo,
+            pullRequestId: githubIssueNumber(key),
+            text: comment
+        });
+    }
+
+    function githubGetComments(key) {
+        // github_get_pr_comments merges the review-comments page (empty
+        // for plain issues — the runtime tolerates its 404) with the
+        // issue discussion page and returns a flat array.
+        return _commentPage(github_get_pr_comments({
+            workspace: owner,
+            repository: repo,
+            pullRequestId: githubIssueNumber(key)
+        }));
+    }
+
+    function githubCreateTicket(project, type, title, description) {
+        // project/type are Jira/ADO concepts — GitHub issues only have a
+        // title and a markdown body.
+        var t = normalizeTicket(github_create_issue({
+            owner: owner,
+            repo: repo,
+            title: title,
+            body: description
+        }));
+        return t ? t.key : null;
+    }
+
     // ── dispatch tables ───────────────────────────────────────────────────
 
     var impls = {
@@ -287,13 +340,13 @@ function createTracker(config) {
         github: {
             getTicket: githubGetTicket,
             search: function () { unsupported('search'); },
-            postComment: function () { unsupported('postComment'); },
-            getComments: function () { unsupported('getComments'); },
-            addLabel: function () { unsupported('addLabel'); },
-            removeLabel: function () { unsupported('removeLabel'); },
+            postComment: githubPostComment,
+            getComments: githubGetComments,
+            addLabel: githubAddLabel,
+            removeLabel: githubRemoveLabel,
             moveToStatus: githubMoveToStatus,
             assignTo: function () { unsupported('assignTo'); },
-            createTicket: function () { unsupported('createTicket'); }
+            createTicket: githubCreateTicket
         }
     };
     var impl = impls[providerName];

--- a/js/common/trackers.js
+++ b/js/common/trackers.js
@@ -1,0 +1,388 @@
+/**
+ * Tracker-agnostic ticket helpers — the scm.js analog for trackers.
+ *
+ * Every operation goes through the generic tracker_* tool family; the
+ * runtime routes to whichever tracker backend is configured
+ * (Jira | ADO | GitHub issues). Agent code written against this module
+ * no longer depends on jiraHelpers or the jira_* globals directly.
+ *
+ * On runtimes that do not expose the tracker_* family (legacy Java
+ * DMTools), every operation transparently falls back to its native
+ * jira_* twin, so scripts stay portable during the migration.
+ *
+ * Factory: createTracker(config)
+ *   config.repository: { owner, repo }  // expands bare GitHub issue numbers
+ *   config.labels: { aiGenerated }      // overrides LABELS.AI_GENERATED
+ *
+ * Per-agent override via JSON customParams:
+ *   { "customParams": { "targetRepository": { "owner": "MyOrg", "repo": "my-repo" } } }
+ */
+
+const { STATUSES, LABELS } = require('../config.js');
+
+/**
+ * Parse a tool result that may arrive as an object or a JSON string.
+ * Non-JSON strings pass through untouched (scm.js convention).
+ */
+function _parseJson(raw) {
+    if (typeof raw === 'string') {
+        try { return JSON.parse(raw); } catch (e) { return raw; }
+    }
+    return raw;
+}
+
+/**
+ * Normalize a collection of label entries into plain names.
+ * Jira/ADO give strings; GitHub gives [{ name: '...' }].
+ */
+function _labelNames(raw) {
+    var parsed = _parseJson(raw);
+    if (!Array.isArray(parsed)) return [];
+    var names = [];
+    for (var i = 0; i < parsed.length; i++) {
+        var entry = parsed[i];
+        if (typeof entry === 'string') {
+            names.push(entry);
+        } else if (entry && typeof entry.name === 'string') {
+            names.push(entry.name);
+        }
+    }
+    return names;
+}
+
+/**
+ * Normalize one comment into { author, body, created }.
+ * Candidates cover Jira, GitHub, and ADO field namings; unknown shapes
+ * keep their raw body field when present.
+ */
+function _normalizeComment(raw) {
+    var c = _parseJson(raw);
+    if (!c || typeof c !== 'object') return null;
+    var author = '';
+    var authorCandidates = [c.author, c.user, c.createdBy];
+    for (var i = 0; i < authorCandidates.length; i++) {
+        var a = authorCandidates[i];
+        if (!a) continue;
+        if (typeof a === 'string') { author = a; break; }
+        if (a.displayName || a.login || a.uniqueName) {
+            author = a.displayName || a.login || a.uniqueName;
+            break;
+        }
+    }
+    return {
+        author: author,
+        body: c.body || c.text || '',
+        created: c.created || c.created_at || c.createdDate || null
+    };
+}
+
+/**
+ * Read a ticket author out of backend-specific assignee shapes.
+ */
+function _assigneeName(fields) {
+    var candidates = [
+        fields.assignee, fields.assignments,
+        fields['System.AssignedTo']
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+        var a = candidates[i];
+        if (!a) continue;
+        if (typeof a === 'string') return a;
+        if (a.displayName || a.login || a.uniqueName || a.accountId) {
+            return a.displayName || a.login || a.uniqueName || a.accountId;
+        }
+    }
+    return null;
+}
+
+function createTracker(config) {
+    var owner = (config && config.repository && config.repository.owner) || '';
+    var repo  = (config && config.repository && config.repository.repo)  || '';
+    var aiLabel = (config && config.labels && config.labels.aiGenerated)
+        || LABELS.AI_GENERATED;
+
+    /**
+     * Expand a bare numeric issue number into "owner/repo#N" when the
+     * repository is configured. Every other key shape passes through
+     * untouched ("PROJ-123", "acme/widgets#7", ADO work-item ids).
+     */
+    function expandKey(key) {
+        var k = String(key == null ? '' : key).trim();
+        if (/^\d+$/.test(k) && owner && repo) {
+            return owner + '/' + repo + '#' + k;
+        }
+        return k;
+    }
+
+    /**
+     * Normalize any backend's ticket payload into a flat view:
+     * { key, id, title, status, assignee, labels, description, url, raw: null }
+     * Returns null for empty/unparseable input. The raw payload is
+     * deliberately not embedded — agents needing backend specifics should
+     * call the tracker_* tools directly.
+     */
+    function normalizeTicket(raw) {
+        var t = _parseJson(raw);
+        if (!t || typeof t !== 'object') return null;
+        if (typeof t === 'string') return null;
+
+        // Already flat / previously normalized.
+        if (typeof t.key === 'string' && !t.fields) {
+            return _flatTicket(t.key, t.id, t.title, t.status, t.assignee,
+                _labelNames(t.labels), t.description || t.body, t.html_url || t.url);
+        }
+
+        // Jira: { key, id, fields: { summary, status: { name }, ... } }
+        if (t.fields && typeof t.fields === 'object' && !t.fields['System.Title']) {
+            var f = t.fields;
+            return _flatTicket(
+                t.key || (t.id != null ? String(t.id) : null),
+                t.id != null ? String(t.id) : null,
+                f.summary || null,
+                f.status && f.status.name ? f.status.name : null,
+                _assigneeName(f),
+                _labelNames(f.labels),
+                f.description || null,
+                null
+            );
+        }
+
+        // ADO: { id, fields: { 'System.Title', 'System.State', ... } }
+        if (t.fields && t.fields['System.Title'] !== undefined) {
+            var af = t.fields;
+            return _flatTicket(
+                t.id != null ? String(t.id) : null,
+                t.id != null ? String(t.id) : null,
+                af['System.Title'] || null,
+                af['System.State'] || null,
+                _assigneeName(af),
+                _labelNames(af['System.Tags']),
+                af['System.Description'] || null,
+                null
+            );
+        }
+
+        // GitHub: { number, title, state, ... }
+        if (t.number !== undefined) {
+            var ghKey = owner && repo
+                ? owner + '/' + repo + '#' + t.number
+                : (t.key != null ? String(t.key) : '#' + t.number);
+            return _flatTicket(
+                ghKey,
+                t.id != null ? String(t.id) : null,
+                t.title || null,
+                t.state || null,
+                _assigneeName(t),
+                _labelNames(t.labels),
+                t.body || null,
+                t.html_url || null
+            );
+        }
+
+        return null;
+    }
+
+    function _flatTicket(key, id, title, status, assignee, labels, description, url) {
+        return {
+            key: key,
+            id: id || null,
+            title: title || null,
+            status: status || null,
+            assignee: typeof assignee === 'string' ? assignee : _assigneeName({ assignee: assignee }),
+            labels: labels || [],
+            description: description || null,
+            url: url || null,
+            raw: null
+        };
+    }
+
+    // ── tool dispatch ──────────────────────────────────────────────────────
+    //
+    // Each operation probes its own tracker_* tool: runtimes expose the
+    // family as a whole, but probing per operation keeps the fallback
+    // correct even if a future runtime ships the family incrementally.
+
+    function getTicket(key) {
+        var k = expandKey(key);
+        if (typeof tracker_get_ticket !== 'undefined') {
+            return normalizeTicket(tracker_get_ticket({ key: k }));
+        }
+        return normalizeTicket(jira_get_ticket({ key: k }));
+    }
+
+    function search(query) {
+        var page;
+        if (typeof tracker_search !== 'undefined') {
+            page = _parseJson(tracker_search({ query: query }));
+        } else {
+            page = _parseJson(jira_search_by_jql({ jql: query }));
+        }
+        var list = page;
+        if (page && typeof page === 'object' && !Array.isArray(page)) {
+            list = page.issues || page.value || page.workItems || [];
+        }
+        if (!Array.isArray(list)) return [];
+        var out = [];
+        for (var i = 0; i < list.length; i++) {
+            var n = normalizeTicket(list[i]);
+            if (n) out.push(n);
+        }
+        return out;
+    }
+
+    function postComment(key, comment) {
+        var k = expandKey(key);
+        if (typeof tracker_post_comment !== 'undefined') {
+            return tracker_post_comment({ key: k, comment: comment });
+        }
+        return jira_post_comment({ key: k, comment: comment });
+    }
+
+    function getComments(key) {
+        var k = expandKey(key);
+        var page;
+        if (typeof tracker_get_comments !== 'undefined') {
+            page = _parseJson(tracker_get_comments({ key: k }));
+        } else {
+            page = _parseJson(jira_get_comments({ key: k }));
+        }
+        var list = page;
+        if (page && typeof page === 'object' && !Array.isArray(page)) {
+            list = page.comments || page.value || [];
+        }
+        if (!Array.isArray(list)) return [];
+        var out = [];
+        for (var i = 0; i < list.length; i++) {
+            var c = _normalizeComment(list[i]);
+            if (c) out.push(c);
+        }
+        return out;
+    }
+
+    function addLabel(key, label) {
+        var k = expandKey(key);
+        if (typeof tracker_add_label !== 'undefined') {
+            return tracker_add_label({ key: k, label: label });
+        }
+        return jira_add_label({ key: k, label: label });
+    }
+
+    function removeLabel(key, label) {
+        var k = expandKey(key);
+        if (typeof tracker_remove_label !== 'undefined') {
+            return tracker_remove_label({ key: k, label: label });
+        }
+        return jira_remove_label({ key: k, label: label });
+    }
+
+    function moveToStatus(key, status) {
+        var k = expandKey(key);
+        if (typeof tracker_move_to_status !== 'undefined') {
+            return tracker_move_to_status({ key: k, status: status });
+        }
+        return jira_move_to_status({ key: k, statusName: status });
+    }
+
+    function assignTo(key, user) {
+        var k = expandKey(key);
+        if (typeof tracker_assign_to !== 'undefined') {
+            return tracker_assign_to({ key: k, user: user });
+        }
+        return jira_assign_ticket_to({ key: k, accountId: user });
+    }
+
+    function createTicket(project, type, title, description) {
+        var raw;
+        if (typeof tracker_create_ticket !== 'undefined') {
+            raw = tracker_create_ticket({
+                project: project,
+                type: type,
+                title: title,
+                description: description
+            });
+        } else {
+            raw = jira_create_ticket({
+                project: project,
+                issueType: type,
+                summary: title,
+                description: description
+            });
+        }
+        return extractTicketKey(raw);
+    }
+
+    /**
+     * Common post-processing flow (jiraHelpers.assignForReview parity):
+     * assign to the initiator, move to the review status, add the AI
+     * label, and drop the WIP label when given. A WIP cleanup failure is
+     * logged but does not fail the operation; a core step failure does.
+     */
+    function assignForReview(ticketKey, initiatorId, wipLabel, targetStatus) {
+        var statusName = targetStatus || STATUSES.IN_REVIEW;
+        try {
+            console.log('Processing ticket:', ticketKey);
+            assignTo(ticketKey, initiatorId);
+            moveToStatus(ticketKey, statusName);
+            addLabel(ticketKey, aiLabel);
+            if (wipLabel) {
+                try {
+                    removeLabel(ticketKey, wipLabel);
+                    console.log('Removed WIP label "' + wipLabel + '" from ' + ticketKey);
+                } catch (labelError) {
+                    console.warn('Failed to remove WIP label "' + wipLabel + '":', labelError);
+                }
+            }
+            console.log('✅ Assigned to initiator and moved to ' + statusName);
+            return {
+                success: true,
+                message: 'Ticket ' + ticketKey + ' assigned and moved to ' + statusName
+            };
+        } catch (error) {
+            console.error('❌ Error in assignForReview:', error);
+            return { success: false, error: error.toString() };
+        }
+    }
+
+    return {
+        provider: function () { return 'tracker'; },
+        getTicket: getTicket,
+        search: search,
+        postComment: postComment,
+        getComments: getComments,
+        addLabel: addLabel,
+        removeLabel: removeLabel,
+        moveToStatus: moveToStatus,
+        assignTo: assignTo,
+        createTicket: createTicket,
+        normalizeTicket: normalizeTicket,
+        extractTicketKey: extractTicketKey,
+        assignForReview: assignForReview
+    };
+}
+
+/**
+ * Extract a ticket key from a tool result (object or JSON string).
+ * Mirrors jiraHelpers.extractTicketKey so migration is drop-in.
+ */
+function extractTicketKey(result) {
+    if (!result) {
+        return null;
+    }
+    if (typeof result === 'string') {
+        try {
+            var parsed = JSON.parse(result);
+            return parsed && parsed.key ? parsed.key : null;
+        } catch (error) {
+            return null;
+        }
+    }
+    if (typeof result === 'object' && typeof result.key === 'string') {
+        return result.key;
+    }
+    return null;
+}
+
+module.exports = {
+    createTracker: createTracker,
+    extractTicketKey: extractTicketKey
+};

--- a/js/unit-tests/run_all.json
+++ b/js/unit-tests/run_all.json
@@ -17,6 +17,7 @@
         "js/unit-tests/test_workingDir.js",
         "js/unit-tests/test_branchNaming.js",
         "js/unit-tests/test_githubHelpers.js",
+        "js/unit-tests/test_trackers.js",
         "js/unit-tests/test_gitOps.js",
         "js/unit-tests/test_submodules.js",
         "js/unit-tests/test_pullRequestHelper.js",

--- a/js/unit-tests/run_trackers.json
+++ b/js/unit-tests/run_trackers.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSRunner",
+  "params": {
+    "jsPath": "js/unit-tests/testRunner.js",
+    "jobParams": {
+      "testFiles": [
+        "js/unit-tests/test_trackers.js"
+      ]
+    }
+  }
+}

--- a/js/unit-tests/test_trackers.js
+++ b/js/unit-tests/test_trackers.js
@@ -1,0 +1,485 @@
+/**
+ * Unit tests for js/common/trackers.js
+ *
+ * The tracker-agnostic ticket layer (the scm.js analog for trackers):
+ * every operation goes through the generic tracker_* tool family and the
+ * runtime routes to the configured backend (Jira | ADO | GitHub issues).
+ * When a runtime does not expose tracker_* tools (legacy Java), the layer
+ * falls back to the native jira_* tools so scripts stay portable.
+ *
+ * Uses: configModule, loadModule(), makeRequire(), assert, test(), suite()
+ */
+
+// ── Loader helper ─────────────────────────────────────────────────────────────
+
+function loadTrackers(mocks) {
+    return loadModule(
+        'js/common/trackers.js',
+        makeRequire({
+            '../config.js': configModule,
+            'config': configModule
+        }),
+        mocks || {}
+    );
+}
+
+// ── Recording tool mocks ──────────────────────────────────────────────────────
+
+/**
+ * A mock for a dmtools tool global that records every call.
+ * `calls` holds the args bag of each invocation.
+ */
+function recorder(name, result) {
+    var calls = [];
+    var fn = function (args) {
+        calls.push(args);
+        if (result && result.__throw__) {
+            throw result.__throw__;
+        }
+        return typeof result === 'function' ? result(args) : result;
+    };
+    fn.calls = calls;
+    fn.toolName = name;
+    return fn;
+}
+
+// ── Fixtures: backend-shaped ticket payloads ─────────────────────────────────
+
+var JIRA_TICKET = {
+    key: 'PROJ-123',
+    id: '10001',
+    fields: {
+        summary: 'Fix the login flow',
+        status: { name: 'In Progress' },
+        assignee: { displayName: 'Jane Doe', accountId: 'acc-1' },
+        labels: ['backend', 'wip'],
+        description: 'Login breaks on expired sessions'
+    }
+};
+
+var GITHUB_TICKET = {
+    number: 41,
+    id: 900001,
+    title: 'Fix the login flow',
+    state: 'open',
+    assignee: { login: 'jane-doe' },
+    labels: [{ name: 'bug' }, { name: 'wip' }],
+    body: 'Login breaks on expired sessions',
+    html_url: 'https://github.com/acme/widgets/issues/41'
+};
+
+var ADO_TICKET = {
+    id: 4242,
+    fields: {
+        'System.Title': 'Fix the login flow',
+        'System.State': 'Active',
+        'System.AssignedTo': { displayName: 'Jane Doe', uniqueName: 'jane@acme.dev' },
+        'System.Description': 'Login breaks on expired sessions'
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('trackers.js factory', function () {
+    test('exports a createTracker factory', function () {
+        var trackers = loadTrackers({});
+        assert.ok(trackers.createTracker, 'createTracker export missing');
+        var t = trackers.createTracker({});
+        assert.ok(t.getTicket, 'getTicket missing');
+        assert.ok(t.search, 'search missing');
+        assert.ok(t.postComment, 'postComment missing');
+        assert.ok(t.getComments, 'getComments missing');
+        assert.ok(t.addLabel, 'addLabel missing');
+        assert.ok(t.removeLabel, 'removeLabel missing');
+        assert.ok(t.moveToStatus, 'moveToStatus missing');
+        assert.ok(t.assignTo, 'assignTo missing');
+        assert.ok(t.createTicket, 'createTicket missing');
+        assert.ok(t.normalizeTicket, 'normalizeTicket missing');
+        assert.ok(t.extractTicketKey, 'extractTicketKey missing');
+        assert.ok(t.assignForReview, 'assignForReview missing');
+    });
+
+    test('reports the tracker-agnostic provider', function () {
+        var trackers = loadTrackers({});
+        assert.equal(trackers.createTracker({}).provider(), 'tracker');
+    });
+});
+
+suite('trackers.js key normalization', function () {
+    test('expands a bare issue number with the configured repository', function () {
+        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
+        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
+        var t = trackers.createTracker({ repository: { owner: 'acme', repo: 'widgets' } });
+        t.getTicket('41');
+        assert.equal(getTicket.calls[0].key, 'acme/widgets#41');
+    });
+
+    test('passes full keys through unchanged', function () {
+        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
+        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
+        var t = trackers.createTracker({ repository: { owner: 'acme', repo: 'widgets' } });
+        t.getTicket('acme/widgets#7');
+        t.getTicket('PROJ-123');
+        assert.equal(getTicket.calls[0].key, 'acme/widgets#7');
+        assert.equal(getTicket.calls[1].key, 'PROJ-123');
+    });
+
+    test('bare numbers without repository config stay unchanged', function () {
+        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
+        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
+        trackers.createTracker({}).getTicket('41');
+        assert.equal(getTicket.calls[0].key, '41');
+    });
+});
+
+suite('trackers.js getTicket', function () {
+    test('calls tracker_get_ticket with the key', function () {
+        var getTicket = recorder('tracker_get_ticket', JSON.stringify(JIRA_TICKET));
+        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
+        var ticket = trackers.createTracker({}).getTicket('PROJ-123');
+        assert.deepEqual(getTicket.calls[0], { key: 'PROJ-123' });
+        assert.equal(ticket.key, 'PROJ-123');
+    });
+
+    test('normalizes a Jira-shaped response', function () {
+        var trackers = loadTrackers({
+            tracker_get_ticket: recorder('tracker_get_ticket', JSON.stringify(JIRA_TICKET))
+        });
+        var ticket = trackers.createTracker({}).getTicket('PROJ-123');
+        assert.equal(ticket.key, 'PROJ-123');
+        assert.equal(ticket.title, 'Fix the login flow');
+        assert.equal(ticket.status, 'In Progress');
+        assert.equal(ticket.assignee, 'Jane Doe');
+        assert.deepEqual(ticket.labels, ['backend', 'wip']);
+        assert.equal(ticket.raw, null, 'raw payload should not leak into the normalized view');
+    });
+
+    test('normalizes a GitHub-shaped response and builds the issue key', function () {
+        var trackers = loadTrackers({
+            tracker_get_ticket: recorder('tracker_get_ticket', GITHUB_TICKET)
+        });
+        var ticket = trackers.createTracker({
+            repository: { owner: 'acme', repo: 'widgets' }
+        }).getTicket('acme/widgets#41');
+        assert.equal(ticket.key, 'acme/widgets#41');
+        assert.equal(ticket.title, 'Fix the login flow');
+        assert.equal(ticket.status, 'open');
+        assert.equal(ticket.assignee, 'jane-doe');
+        assert.deepEqual(ticket.labels, ['bug', 'wip']);
+    });
+
+    test('normalizes an ADO-shaped response', function () {
+        var trackers = loadTrackers({
+            tracker_get_ticket: recorder('tracker_get_ticket', ADO_TICKET)
+        });
+        var ticket = trackers.createTracker({}).getTicket('4242');
+        assert.equal(ticket.key, '4242');
+        assert.equal(ticket.title, 'Fix the login flow');
+        assert.equal(ticket.status, 'Active');
+        assert.equal(ticket.assignee, 'Jane Doe');
+        assert.deepEqual(ticket.labels, []);
+    });
+
+    test('returns null for an empty or unparseable response', function () {
+        var trackers = loadTrackers({
+            tracker_get_ticket: recorder('tracker_get_ticket', '   ')
+        });
+        assert.equal(trackers.createTracker({}).getTicket('PROJ-123'), null);
+    });
+});
+
+suite('trackers.js search', function () {
+    test('calls tracker_search with the query', function () {
+        var search = recorder('tracker_search', JSON.stringify({
+            issues: [JIRA_TICKET]
+        }));
+        var trackers = loadTrackers({ tracker_search: search });
+        var results = trackers.createTracker({}).search('labels = wip');
+        assert.deepEqual(search.calls[0], { query: 'labels = wip' });
+        assert.equal(results.length, 1);
+        assert.equal(results[0].key, 'PROJ-123');
+        assert.equal(results[0].title, 'Fix the login flow');
+    });
+
+    test('returns an empty list when nothing is found', function () {
+        var trackers = loadTrackers({
+            tracker_search: recorder('tracker_search', JSON.stringify({ issues: [] }))
+        });
+        assert.deepEqual(trackers.createTracker({}).search('nope'), []);
+    });
+});
+
+suite('trackers.js comments', function () {
+    test('postComment calls tracker_post_comment with key and body', function () {
+        var postComment = recorder('tracker_post_comment', '{"id":"c1"}');
+        var trackers = loadTrackers({ tracker_post_comment: postComment });
+        trackers.createTracker({}).postComment('PROJ-123', 'looks good');
+        assert.deepEqual(postComment.calls[0], { key: 'PROJ-123', comment: 'looks good' });
+    });
+
+    test('getComments normalizes Jira-shaped comment pages', function () {
+        var getComments = recorder('tracker_get_comments', JSON.stringify({
+            comments: [
+                { author: { displayName: 'Reviewer' }, body: 'please fix', created: '2026-09-07T10:00:00Z' }
+            ]
+        }));
+        var trackers = loadTrackers({ tracker_get_comments: getComments });
+        var comments = trackers.createTracker({}).getComments('PROJ-123');
+        assert.deepEqual(getComments.calls[0], { key: 'PROJ-123' });
+        assert.equal(comments.length, 1);
+        assert.equal(comments[0].author, 'Reviewer');
+        assert.equal(comments[0].body, 'please fix');
+        assert.equal(comments[0].created, '2026-09-07T10:00:00Z');
+    });
+
+    test('getComments normalizes GitHub-shaped comment lists', function () {
+        var getComments = recorder('tracker_get_comments', JSON.stringify([
+            { user: { login: 'reviewer' }, body: 'please fix', created_at: '2026-09-07T10:00:00Z' }
+        ]));
+        var trackers = loadTrackers({ tracker_get_comments: getComments });
+        var comments = trackers.createTracker({}).getComments('acme/widgets#41');
+        assert.equal(comments.length, 1);
+        assert.equal(comments[0].author, 'reviewer');
+        assert.equal(comments[0].body, 'please fix');
+    });
+});
+
+suite('trackers.js labels, status, assignee', function () {
+    test('addLabel and removeLabel pass exact args', function () {
+        var addLabel = recorder('tracker_add_label', '{}');
+        var removeLabel = recorder('tracker_remove_label', '{}');
+        var trackers = loadTrackers({
+            tracker_add_label: addLabel,
+            tracker_remove_label: removeLabel
+        });
+        var t = trackers.createTracker({});
+        t.addLabel('PROJ-123', 'ai-generated');
+        t.removeLabel('PROJ-123', 'wip');
+        assert.deepEqual(addLabel.calls[0], { key: 'PROJ-123', label: 'ai-generated' });
+        assert.deepEqual(removeLabel.calls[0], { key: 'PROJ-123', label: 'wip' });
+    });
+
+    test('moveToStatus passes the friendly status through', function () {
+        var moveToStatus = recorder('tracker_move_to_status', '{}');
+        var trackers = loadTrackers({ tracker_move_to_status: moveToStatus });
+        trackers.createTracker({}).moveToStatus('PROJ-123', 'In Review');
+        assert.deepEqual(moveToStatus.calls[0], { key: 'PROJ-123', status: 'In Review' });
+    });
+
+    test('assignTo passes the user through', function () {
+        var assignTo = recorder('tracker_assign_to', '{}');
+        var trackers = loadTrackers({ tracker_assign_to: assignTo });
+        trackers.createTracker({}).assignTo('PROJ-123', 'acc-1');
+        assert.deepEqual(assignTo.calls[0], { key: 'PROJ-123', user: 'acc-1' });
+    });
+
+    test('createTicket passes project, type, title and description', function () {
+        var createTicket = recorder('tracker_create_ticket', '{"key":"PROJ-9"}');
+        var trackers = loadTrackers({ tracker_create_ticket: createTicket });
+        var key = trackers.createTracker({})
+            .createTicket('PROJ', 'Bug', 'It breaks', 'details here');
+        assert.deepEqual(createTicket.calls[0], {
+            project: 'PROJ',
+            type: 'Bug',
+            title: 'It breaks',
+            description: 'details here'
+        });
+        assert.equal(key, 'PROJ-9');
+    });
+});
+
+suite('trackers.js jira fallback', function () {
+    test('getTicket falls back to jira_get_ticket when tracker tools are absent', function () {
+        var jiraGet = recorder('jira_get_ticket', JSON.stringify(JIRA_TICKET));
+        var trackers = loadTrackers({
+            tracker_get_ticket: undefined,
+            jira_get_ticket: jiraGet
+        });
+        var ticket = trackers.createTracker({}).getTicket('PROJ-123');
+        assert.deepEqual(jiraGet.calls[0], { key: 'PROJ-123' });
+        assert.equal(ticket.key, 'PROJ-123');
+        assert.equal(ticket.title, 'Fix the login flow');
+    });
+
+    test('moveToStatus fallback maps status → statusName', function () {
+        var jiraMove = recorder('jira_move_to_status', '{}');
+        var trackers = loadTrackers({
+            tracker_move_to_status: undefined,
+            jira_move_to_status: jiraMove
+        });
+        trackers.createTracker({}).moveToStatus('PROJ-123', 'In Review');
+        assert.deepEqual(jiraMove.calls[0], { key: 'PROJ-123', statusName: 'In Review' });
+    });
+
+    test('assignTo fallback maps user → accountId', function () {
+        var jiraAssign = recorder('jira_assign_ticket_to', '{}');
+        var trackers = loadTrackers({
+            tracker_assign_to: undefined,
+            jira_assign_ticket_to: jiraAssign
+        });
+        trackers.createTracker({}).assignTo('PROJ-123', 'acc-1');
+        assert.deepEqual(jiraAssign.calls[0], { key: 'PROJ-123', accountId: 'acc-1' });
+    });
+
+    test('search fallback maps query → jql and unwraps the issues page', function () {
+        var jiraSearch = recorder('jira_search_by_jql', JSON.stringify({
+            issues: [JIRA_TICKET]
+        }));
+        var trackers = loadTrackers({
+            tracker_search: undefined,
+            jira_search_by_jql: jiraSearch
+        });
+        var results = trackers.createTracker({}).search('labels = wip');
+        assert.deepEqual(jiraSearch.calls[0], { jql: 'labels = wip' });
+        assert.equal(results.length, 1);
+        assert.equal(results[0].key, 'PROJ-123');
+    });
+
+    test('comment and label operations fall back to their jira twins', function () {
+        var jiraComment = recorder('jira_post_comment', '{}');
+        var jiraComments = recorder('jira_get_comments', JSON.stringify({
+            comments: [{ author: { displayName: 'A' }, body: 'b', created: 'c' }]
+        }));
+        var jiraAdd = recorder('jira_add_label', '{}');
+        var jiraRemove = recorder('jira_remove_label', '{}');
+        var trackers = loadTrackers({
+            tracker_post_comment: undefined,
+            tracker_get_comments: undefined,
+            tracker_add_label: undefined,
+            tracker_remove_label: undefined,
+            jira_post_comment: jiraComment,
+            jira_get_comments: jiraComments,
+            jira_add_label: jiraAdd,
+            jira_remove_label: jiraRemove
+        });
+        var t = trackers.createTracker({});
+        t.postComment('PROJ-123', 'hi');
+        t.getComments('PROJ-123');
+        t.addLabel('PROJ-123', 'x');
+        t.removeLabel('PROJ-123', 'y');
+        assert.deepEqual(jiraComment.calls[0], { key: 'PROJ-123', comment: 'hi' });
+        assert.deepEqual(jiraComments.calls[0], { key: 'PROJ-123' });
+        assert.deepEqual(jiraAdd.calls[0], { key: 'PROJ-123', label: 'x' });
+        assert.deepEqual(jiraRemove.calls[0], { key: 'PROJ-123', label: 'y' });
+    });
+
+    test('createTicket fallback maps onto the jira_create_ticket args', function () {
+        var jiraCreate = recorder('jira_create_ticket', '{"key":"PROJ-9"}');
+        var trackers = loadTrackers({
+            tracker_create_ticket: undefined,
+            jira_create_ticket: jiraCreate
+        });
+        trackers.createTracker({}).createTicket('PROJ', 'Bug', 'It breaks', 'details');
+        assert.deepEqual(jiraCreate.calls[0], {
+            project: 'PROJ',
+            issueType: 'Bug',
+            summary: 'It breaks',
+            description: 'details'
+        });
+    });
+});
+
+suite('trackers.js normalizeTicket', function () {
+    test('returns null for falsy input', function () {
+        var trackers = loadTrackers({});
+        assert.equal(trackers.createTracker({}).normalizeTicket(null), null);
+        assert.equal(trackers.createTracker({}).normalizeTicket(''), null);
+    });
+
+    test('passes an already-normalized ticket through', function () {
+        var trackers = loadTrackers({});
+        var normalized = trackers.createTracker({}).normalizeTicket({
+            key: 'PROJ-1',
+            title: 'Already flat'
+        });
+        assert.equal(normalized.key, 'PROJ-1');
+        assert.equal(normalized.title, 'Already flat');
+    });
+});
+
+suite('trackers.js assignForReview', function () {
+    function happyMocks(opts) {
+        return {
+            tracker_assign_to: recorder('tracker_assign_to', '{}'),
+            tracker_move_to_status: recorder('tracker_move_to_status', '{}'),
+            tracker_add_label: recorder('tracker_add_label', '{}'),
+            tracker_remove_label: opts && opts.removeLabelFails
+                ? recorder('tracker_remove_label', { __throw__: new Error('label api down') })
+                : recorder('tracker_remove_label', '{}')
+        };
+    }
+
+    test('assigns, moves, and adds the AI label, then reports success', function () {
+        var mocks = happyMocks();
+        var trackers = loadTrackers(mocks);
+        var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
+        assert.ok(result.success, 'expected success: ' + JSON.stringify(result));
+        assert.deepEqual(mocks.tracker_assign_to.calls[0], { key: 'PROJ-123', user: 'acc-1' });
+        assert.equal(mocks.tracker_move_to_status.calls[0].key, 'PROJ-123');
+        assert.equal(mocks.tracker_add_label.calls[0].label, configModule.LABELS.AI_GENERATED);
+    });
+
+    test('moves to the configured In Review status by default', function () {
+        var mocks = happyMocks();
+        var trackers = loadTrackers(mocks);
+        trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
+        assert.equal(mocks.tracker_move_to_status.calls[0].status, configModule.STATUSES.IN_REVIEW);
+    });
+
+    test('honors an explicit target status', function () {
+        var mocks = happyMocks();
+        var trackers = loadTrackers(mocks);
+        trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', null, 'Done');
+        assert.equal(mocks.tracker_move_to_status.calls[0].status, 'Done');
+    });
+
+    test('removes the WIP label when provided', function () {
+        var mocks = happyMocks();
+        var trackers = loadTrackers(mocks);
+        trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', 'wip');
+        assert.deepEqual(mocks.tracker_remove_label.calls[0], { key: 'PROJ-123', label: 'wip' });
+    });
+
+    test('a WIP removal failure does not fail the whole operation', function () {
+        var mocks = happyMocks({ removeLabelFails: true });
+        var trackers = loadTrackers(mocks);
+        var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', 'wip');
+        assert.ok(result.success, 'WIP cleanup failure must not fail the flow');
+    });
+
+    test('a core step failure reports success: false with the error', function () {
+        var trackers = loadTrackers({
+            tracker_assign_to: recorder('tracker_assign_to', { __throw__: new Error('boom') }),
+            tracker_move_to_status: recorder('tracker_move_to_status', '{}'),
+            tracker_add_label: recorder('tracker_add_label', '{}'),
+            tracker_remove_label: recorder('tracker_remove_label', '{}')
+        });
+        var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
+        assert.notOk(result.success);
+        assert.contains(result.error, 'boom');
+    });
+});
+
+suite('trackers.js extractTicketKey', function () {
+    test('reads the key from an object', function () {
+        var trackers = loadTrackers({});
+        assert.equal(trackers.createTracker({}).extractTicketKey({ key: 'PROJ-1' }), 'PROJ-1');
+    });
+
+    test('reads the key from a JSON string', function () {
+        var trackers = loadTrackers({});
+        assert.equal(
+            trackers.createTracker({}).extractTicketKey('{"key":"PROJ-2"}'),
+            'PROJ-2'
+        );
+    });
+
+    test('returns null for empty and unparseable input', function () {
+        var trackers = loadTrackers({});
+        var t = trackers.createTracker({});
+        assert.equal(t.extractTicketKey(null), null);
+        assert.equal(t.extractTicketKey(''), null);
+        assert.equal(t.extractTicketKey('not json'), null);
+        assert.equal(t.extractTicketKey({ noKey: true }), null);
+    });
+});

--- a/js/unit-tests/test_trackers.js
+++ b/js/unit-tests/test_trackers.js
@@ -356,6 +356,96 @@ suite('trackers.js github provider', function () {
         var t = trackers.createTracker({ tracker: { provider: 'github' } });
         assert.throws(function () { t.moveToStatus('acme/widgets#7', ''); });
     });
+
+    test('addLabel / removeLabel use the canonical issue label tools', function () {
+        var ghAdd = recorder('github_add_labels', '{}');
+        var ghRemove = recorder('github_remove_label', '{}');
+        var trackers = loadTrackers({
+            github_add_labels: ghAdd,
+            github_remove_label: ghRemove
+        });
+        var t = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        });
+        t.addLabel('acme/widgets#7', 'ai-generated');
+        t.removeLabel('acme/widgets#7', 'wip');
+        assert.deepEqual(ghAdd.calls[0], {
+            owner: 'acme',
+            repo: 'widgets',
+            number: 7,
+            labels: ['ai-generated']
+        });
+        assert.deepEqual(ghRemove.calls[0], {
+            owner: 'acme',
+            repo: 'widgets',
+            number: 7,
+            label: 'wip'
+        });
+    });
+
+    test('postComment / getComments use the issue comment surface', function () {
+        var ghPost = recorder('github_create_comment', '{}');
+        var ghList = recorder('github_get_pr_comments', [
+            { user: { login: 'A' }, body: 'n1' },
+            { user: { login: 'B' }, body: 'n2' }
+        ]);
+        var trackers = loadTrackers({
+            github_create_comment: ghPost,
+            github_get_pr_comments: ghList
+        });
+        var t = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        });
+        t.postComment('acme/widgets#7', 'hello');
+        var comments = t.getComments('acme/widgets#7');
+        // github_create_comment / github_get_pr_comments hit the
+        // issues/{n}/comments endpoint (PRs are issues upstream); the
+        // number argument keeps the tools' canonical pullRequestId name.
+        assert.deepEqual(ghPost.calls[0], {
+            workspace: 'acme',
+            repository: 'widgets',
+            pullRequestId: 7,
+            text: 'hello'
+        });
+        assert.deepEqual(ghList.calls[0], {
+            workspace: 'acme',
+            repository: 'widgets',
+            pullRequestId: 7
+        });
+        assert.equal(comments.length, 2);
+        assert.equal(comments[0].author, 'A');
+        assert.equal(comments[1].body, 'n2');
+    });
+
+    test('createTicket opens an issue and returns owner/repo#N', function () {
+        var ghCreate = recorder('github_create_issue', {
+            number: 42,
+            title: 'New bug',
+            state: 'open',
+            html_url: 'https://github.com/acme/widgets/issues/42'
+        });
+        var trackers = loadTrackers({ github_create_issue: ghCreate });
+        var key = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        }).createTicket(null, 'bug', 'New bug', 'It broke');
+        assert.deepEqual(ghCreate.calls[0], {
+            owner: 'acme',
+            repo: 'widgets',
+            title: 'New bug',
+            body: 'It broke'
+        });
+        assert.equal(key, 'acme/widgets#42');
+    });
+
+    test('search and assignTo stay explicit gaps (no canonical tool)', function () {
+        var trackers = loadTrackers({});
+        var t = trackers.createTracker({ tracker: { provider: 'github' } });
+        assert.throws(function () { t.search('is:open'); });
+        assert.throws(function () { t.assignTo('acme/widgets#7', 'jane'); });
+    });
 });
 
 suite('trackers.js normalizeTicket', function () {

--- a/js/unit-tests/test_trackers.js
+++ b/js/unit-tests/test_trackers.js
@@ -301,13 +301,18 @@ suite('trackers.js github provider', function () {
             tracker: { provider: 'github' },
             repository: { owner: 'acme', repo: 'widgets' }
         }).getTicket('41');
-        assert.deepEqual(ghGet.calls[0], { owner: 'acme', repo: 'widgets', issue_number: 41 });
+        // Dart tool schema (github_get_issue): workspace/repository/issueNumber.
+        assert.deepEqual(ghGet.calls[0], {
+            workspace: 'acme',
+            repository: 'widgets',
+            issueNumber: 41
+        });
         assert.equal(ticket.key, 'acme/widgets#41');
         assert.equal(ticket.status, 'open');
         assert.deepEqual(ticket.labels, ['bug', 'wip']);
     });
 
-    test('moveToStatus maps Done → close and Reopened → reopen', function () {
+    test('moveToStatus maps done/closed (any case) onto close_issue', function () {
         var ghClose = recorder('github_close_issue', '{}');
         var trackers = loadTrackers({ github_close_issue: ghClose });
         var t = trackers.createTracker({
@@ -315,13 +320,41 @@ suite('trackers.js github provider', function () {
             repository: { owner: 'acme', repo: 'widgets' }
         });
         t.moveToStatus('acme/widgets#7', 'Done');
-        assert.deepEqual(ghClose.calls[0], { owner: 'acme', repo: 'widgets', issue_number: 7 });
+        t.moveToStatus('acme/widgets#8', 'CLOSED');
+        // github_close_issue schema: owner/repo/number.
+        assert.deepEqual(ghClose.calls[0], { owner: 'acme', repo: 'widgets', number: 7 });
+        assert.deepEqual(ghClose.calls[1], { owner: 'acme', repo: 'widgets', number: 8 });
     });
 
-    test('unmappable statuses fail without an HTTP call', function () {
+    test('moveToStatus carries any other status as an issue label', function () {
+        var ghClose = recorder('github_close_issue', '{}');
+        var ghLabels = recorder('github_add_labels', '{}');
+        var trackers = loadTrackers({
+            github_close_issue: ghClose,
+            github_add_labels: ghLabels
+        });
+        var t = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        });
+        t.moveToStatus('acme/widgets#7', 'In Review');
+        assert.deepEqual(ghLabels.calls[0], {
+            owner: 'acme',
+            repo: 'widgets',
+            number: 7,
+            labels: ['In Review']
+        });
+        assert.equal(ghClose.calls.length, 0);
+        // Lowercase statuses that are not done/closed are labels too.
+        t.moveToStatus('acme/widgets#8', 'reopened');
+        assert.deepEqual(ghLabels.calls[1].labels, ['reopened']);
+        assert.equal(ghClose.calls.length, 0);
+    });
+
+    test('empty status fails without an HTTP call', function () {
         var trackers = loadTrackers({});
         var t = trackers.createTracker({ tracker: { provider: 'github' } });
-        assert.throws(function () { t.moveToStatus('acme/widgets#7', 'In Review'); });
+        assert.throws(function () { t.moveToStatus('acme/widgets#7', ''); });
     });
 });
 

--- a/js/unit-tests/test_trackers.js
+++ b/js/unit-tests/test_trackers.js
@@ -2,10 +2,13 @@
  * Unit tests for js/common/trackers.js
  *
  * The tracker-agnostic ticket layer (the scm.js analog for trackers):
- * every operation goes through the generic tracker_* tool family and the
- * runtime routes to the configured backend (Jira | ADO | GitHub issues).
- * When a runtime does not expose tracker_* tools (legacy Java), the layer
- * falls back to the native jira_* tools so scripts stay portable.
+ * a createTracker(config) factory that maps generic ticket operations
+ * onto CANONICAL tracker tools per configured provider — jira_* / ado_* /
+ * github_* — exactly like scm.js maps SCM operations onto providers.
+ *
+ * Why canonical tools: the Java runtime exposes only canonical tool names
+ * to scripts (tracker_* exists solely as a CLI alias resolved via
+ * DEFAULT_TRACKER), so provider mapping must live in this JS layer.
  *
  * Uses: configModule, loadModule(), makeRequire(), assert, test(), suite()
  */
@@ -41,6 +44,27 @@ function recorder(name, result) {
     fn.calls = calls;
     fn.toolName = name;
     return fn;
+}
+
+/** Standard jira provider mock set (canonical jira_* tools). */
+function jiraMocks(opts) {
+    return {
+        jira_get_ticket: recorder('jira_get_ticket', JSON.stringify(JIRA_TICKET)),
+        jira_search_by_jql: recorder('jira_search_by_jql', JSON.stringify({
+            issues: [JIRA_TICKET]
+        })),
+        jira_post_comment: recorder('jira_post_comment', '{}'),
+        jira_get_comments: recorder('jira_get_comments', JSON.stringify({
+            comments: [{ author: { displayName: 'Reviewer' }, body: 'please fix', created: '2026-09-07T10:00:00Z' }]
+        })),
+        jira_add_label: recorder('jira_add_label', '{}'),
+        jira_remove_label: opts && opts.removeLabelFails
+            ? recorder('jira_remove_label', { __throw__: new Error('label api down') })
+            : recorder('jira_remove_label', '{}'),
+        jira_move_to_status: recorder('jira_move_to_status', '{}'),
+        jira_assign_ticket_to: recorder('jira_assign_ticket_to', '{}'),
+        jira_create_ticket_basic: recorder('jira_create_ticket_basic', '{"key":"PROJ-9"}')
+    };
 }
 
 // ── Fixtures: backend-shaped ticket payloads ─────────────────────────────────
@@ -99,283 +123,205 @@ suite('trackers.js factory', function () {
         assert.ok(t.assignForReview, 'assignForReview missing');
     });
 
-    test('reports the tracker-agnostic provider', function () {
+    test('provider defaults to jira and honors config.tracker.provider', function () {
         var trackers = loadTrackers({});
-        assert.equal(trackers.createTracker({}).provider(), 'tracker');
+        assert.equal(trackers.createTracker({}).provider(), 'jira');
+        assert.equal(
+            trackers.createTracker({ tracker: { provider: 'ADO' } }).provider(),
+            'ado',
+            'provider must be case-insensitive'
+        );
+        assert.equal(
+            trackers.createTracker({ tracker: { provider: 'github' } }).provider(),
+            'github'
+        );
+    });
+
+    test('unknown provider falls back to jira', function () {
+        var trackers = loadTrackers({});
+        assert.equal(
+            trackers.createTracker({ tracker: { provider: 'trello' } }).provider(),
+            'jira'
+        );
     });
 });
 
-suite('trackers.js key normalization', function () {
-    test('expands a bare issue number with the configured repository', function () {
-        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
-        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
-        var t = trackers.createTracker({ repository: { owner: 'acme', repo: 'widgets' } });
-        t.getTicket('41');
-        assert.equal(getTicket.calls[0].key, 'acme/widgets#41');
-    });
-
-    test('passes full keys through unchanged', function () {
-        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
-        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
-        var t = trackers.createTracker({ repository: { owner: 'acme', repo: 'widgets' } });
-        t.getTicket('acme/widgets#7');
-        t.getTicket('PROJ-123');
-        assert.equal(getTicket.calls[0].key, 'acme/widgets#7');
-        assert.equal(getTicket.calls[1].key, 'PROJ-123');
-    });
-
-    test('bare numbers without repository config stay unchanged', function () {
-        var getTicket = recorder('tracker_get_ticket', JSON.stringify(GITHUB_TICKET));
-        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
-        trackers.createTracker({}).getTicket('41');
-        assert.equal(getTicket.calls[0].key, '41');
-    });
-});
-
-suite('trackers.js getTicket', function () {
-    test('calls tracker_get_ticket with the key', function () {
-        var getTicket = recorder('tracker_get_ticket', JSON.stringify(JIRA_TICKET));
-        var trackers = loadTrackers({ tracker_get_ticket: getTicket });
+suite('trackers.js jira provider (default)', function () {
+    test('getTicket calls jira_get_ticket with the key', function () {
+        var mocks = jiraMocks();
+        var trackers = loadTrackers(mocks);
         var ticket = trackers.createTracker({}).getTicket('PROJ-123');
-        assert.deepEqual(getTicket.calls[0], { key: 'PROJ-123' });
-        assert.equal(ticket.key, 'PROJ-123');
-    });
-
-    test('normalizes a Jira-shaped response', function () {
-        var trackers = loadTrackers({
-            tracker_get_ticket: recorder('tracker_get_ticket', JSON.stringify(JIRA_TICKET))
-        });
-        var ticket = trackers.createTracker({}).getTicket('PROJ-123');
+        assert.deepEqual(mocks.jira_get_ticket.calls[0], { key: 'PROJ-123' });
         assert.equal(ticket.key, 'PROJ-123');
         assert.equal(ticket.title, 'Fix the login flow');
         assert.equal(ticket.status, 'In Progress');
         assert.equal(ticket.assignee, 'Jane Doe');
         assert.deepEqual(ticket.labels, ['backend', 'wip']);
-        assert.equal(ticket.raw, null, 'raw payload should not leak into the normalized view');
     });
 
-    test('normalizes a GitHub-shaped response and builds the issue key', function () {
-        var trackers = loadTrackers({
-            tracker_get_ticket: recorder('tracker_get_ticket', GITHUB_TICKET)
-        });
-        var ticket = trackers.createTracker({
-            repository: { owner: 'acme', repo: 'widgets' }
-        }).getTicket('acme/widgets#41');
-        assert.equal(ticket.key, 'acme/widgets#41');
-        assert.equal(ticket.title, 'Fix the login flow');
-        assert.equal(ticket.status, 'open');
-        assert.equal(ticket.assignee, 'jane-doe');
-        assert.deepEqual(ticket.labels, ['bug', 'wip']);
-    });
-
-    test('normalizes an ADO-shaped response', function () {
-        var trackers = loadTrackers({
-            tracker_get_ticket: recorder('tracker_get_ticket', ADO_TICKET)
-        });
-        var ticket = trackers.createTracker({}).getTicket('4242');
-        assert.equal(ticket.key, '4242');
-        assert.equal(ticket.title, 'Fix the login flow');
-        assert.equal(ticket.status, 'Active');
-        assert.equal(ticket.assignee, 'Jane Doe');
-        assert.deepEqual(ticket.labels, []);
-    });
-
-    test('returns null for an empty or unparseable response', function () {
-        var trackers = loadTrackers({
-            tracker_get_ticket: recorder('tracker_get_ticket', '   ')
-        });
-        assert.equal(trackers.createTracker({}).getTicket('PROJ-123'), null);
-    });
-});
-
-suite('trackers.js search', function () {
-    test('calls tracker_search with the query', function () {
-        var search = recorder('tracker_search', JSON.stringify({
-            issues: [JIRA_TICKET]
-        }));
-        var trackers = loadTrackers({ tracker_search: search });
+    test('search maps to jira_search_by_jql and normalizes the issues page', function () {
+        var mocks = jiraMocks();
+        var trackers = loadTrackers(mocks);
         var results = trackers.createTracker({}).search('labels = wip');
-        assert.deepEqual(search.calls[0], { query: 'labels = wip' });
+        assert.deepEqual(mocks.jira_search_by_jql.calls[0], { jql: 'labels = wip' });
         assert.equal(results.length, 1);
         assert.equal(results[0].key, 'PROJ-123');
-        assert.equal(results[0].title, 'Fix the login flow');
     });
 
-    test('returns an empty list when nothing is found', function () {
-        var trackers = loadTrackers({
-            tracker_search: recorder('tracker_search', JSON.stringify({ issues: [] }))
-        });
-        assert.deepEqual(trackers.createTracker({}).search('nope'), []);
-    });
-});
-
-suite('trackers.js comments', function () {
-    test('postComment calls tracker_post_comment with key and body', function () {
-        var postComment = recorder('tracker_post_comment', '{"id":"c1"}');
-        var trackers = loadTrackers({ tracker_post_comment: postComment });
-        trackers.createTracker({}).postComment('PROJ-123', 'looks good');
-        assert.deepEqual(postComment.calls[0], { key: 'PROJ-123', comment: 'looks good' });
-    });
-
-    test('getComments normalizes Jira-shaped comment pages', function () {
-        var getComments = recorder('tracker_get_comments', JSON.stringify({
-            comments: [
-                { author: { displayName: 'Reviewer' }, body: 'please fix', created: '2026-09-07T10:00:00Z' }
-            ]
-        }));
-        var trackers = loadTrackers({ tracker_get_comments: getComments });
-        var comments = trackers.createTracker({}).getComments('PROJ-123');
-        assert.deepEqual(getComments.calls[0], { key: 'PROJ-123' });
+    test('postComment / getComments use the canonical jira tools', function () {
+        var mocks = jiraMocks();
+        var trackers = loadTrackers(mocks);
+        var t = trackers.createTracker({});
+        t.postComment('PROJ-123', 'looks good');
+        var comments = t.getComments('PROJ-123');
+        assert.deepEqual(mocks.jira_post_comment.calls[0], { key: 'PROJ-123', comment: 'looks good' });
+        assert.deepEqual(mocks.jira_get_comments.calls[0], { key: 'PROJ-123' });
         assert.equal(comments.length, 1);
         assert.equal(comments[0].author, 'Reviewer');
         assert.equal(comments[0].body, 'please fix');
-        assert.equal(comments[0].created, '2026-09-07T10:00:00Z');
     });
 
-    test('getComments normalizes GitHub-shaped comment lists', function () {
-        var getComments = recorder('tracker_get_comments', JSON.stringify([
-            { user: { login: 'reviewer' }, body: 'please fix', created_at: '2026-09-07T10:00:00Z' }
-        ]));
-        var trackers = loadTrackers({ tracker_get_comments: getComments });
-        var comments = trackers.createTracker({}).getComments('acme/widgets#41');
-        assert.equal(comments.length, 1);
-        assert.equal(comments[0].author, 'reviewer');
-        assert.equal(comments[0].body, 'please fix');
-    });
-});
-
-suite('trackers.js labels, status, assignee', function () {
-    test('addLabel and removeLabel pass exact args', function () {
-        var addLabel = recorder('tracker_add_label', '{}');
-        var removeLabel = recorder('tracker_remove_label', '{}');
-        var trackers = loadTrackers({
-            tracker_add_label: addLabel,
-            tracker_remove_label: removeLabel
-        });
+    test('labels, status and assign use canonical jira args', function () {
+        var mocks = jiraMocks();
+        var trackers = loadTrackers(mocks);
         var t = trackers.createTracker({});
         t.addLabel('PROJ-123', 'ai-generated');
         t.removeLabel('PROJ-123', 'wip');
-        assert.deepEqual(addLabel.calls[0], { key: 'PROJ-123', label: 'ai-generated' });
-        assert.deepEqual(removeLabel.calls[0], { key: 'PROJ-123', label: 'wip' });
+        t.moveToStatus('PROJ-123', 'In Review');
+        t.assignTo('PROJ-123', 'acc-1');
+        assert.deepEqual(mocks.jira_add_label.calls[0], { key: 'PROJ-123', label: 'ai-generated' });
+        assert.deepEqual(mocks.jira_remove_label.calls[0], { key: 'PROJ-123', label: 'wip' });
+        assert.deepEqual(mocks.jira_move_to_status.calls[0], { key: 'PROJ-123', statusName: 'In Review' });
+        assert.deepEqual(mocks.jira_assign_ticket_to.calls[0], { key: 'PROJ-123', accountId: 'acc-1' });
     });
 
-    test('moveToStatus passes the friendly status through', function () {
-        var moveToStatus = recorder('tracker_move_to_status', '{}');
-        var trackers = loadTrackers({ tracker_move_to_status: moveToStatus });
-        trackers.createTracker({}).moveToStatus('PROJ-123', 'In Review');
-        assert.deepEqual(moveToStatus.calls[0], { key: 'PROJ-123', status: 'In Review' });
-    });
-
-    test('assignTo passes the user through', function () {
-        var assignTo = recorder('tracker_assign_to', '{}');
-        var trackers = loadTrackers({ tracker_assign_to: assignTo });
-        trackers.createTracker({}).assignTo('PROJ-123', 'acc-1');
-        assert.deepEqual(assignTo.calls[0], { key: 'PROJ-123', user: 'acc-1' });
-    });
-
-    test('createTicket passes project, type, title and description', function () {
-        var createTicket = recorder('tracker_create_ticket', '{"key":"PROJ-9"}');
-        var trackers = loadTrackers({ tracker_create_ticket: createTicket });
-        var key = trackers.createTracker({})
-            .createTicket('PROJ', 'Bug', 'It breaks', 'details here');
-        assert.deepEqual(createTicket.calls[0], {
-            project: 'PROJ',
-            type: 'Bug',
-            title: 'It breaks',
-            description: 'details here'
-        });
-        assert.equal(key, 'PROJ-9');
-    });
-});
-
-suite('trackers.js jira fallback', function () {
-    test('getTicket falls back to jira_get_ticket when tracker tools are absent', function () {
-        var jiraGet = recorder('jira_get_ticket', JSON.stringify(JIRA_TICKET));
-        var trackers = loadTrackers({
-            tracker_get_ticket: undefined,
-            jira_get_ticket: jiraGet
-        });
-        var ticket = trackers.createTracker({}).getTicket('PROJ-123');
-        assert.deepEqual(jiraGet.calls[0], { key: 'PROJ-123' });
-        assert.equal(ticket.key, 'PROJ-123');
-        assert.equal(ticket.title, 'Fix the login flow');
-    });
-
-    test('moveToStatus fallback maps status → statusName', function () {
-        var jiraMove = recorder('jira_move_to_status', '{}');
-        var trackers = loadTrackers({
-            tracker_move_to_status: undefined,
-            jira_move_to_status: jiraMove
-        });
-        trackers.createTracker({}).moveToStatus('PROJ-123', 'In Review');
-        assert.deepEqual(jiraMove.calls[0], { key: 'PROJ-123', statusName: 'In Review' });
-    });
-
-    test('assignTo fallback maps user → accountId', function () {
-        var jiraAssign = recorder('jira_assign_ticket_to', '{}');
-        var trackers = loadTrackers({
-            tracker_assign_to: undefined,
-            jira_assign_ticket_to: jiraAssign
-        });
-        trackers.createTracker({}).assignTo('PROJ-123', 'acc-1');
-        assert.deepEqual(jiraAssign.calls[0], { key: 'PROJ-123', accountId: 'acc-1' });
-    });
-
-    test('search fallback maps query → jql and unwraps the issues page', function () {
-        var jiraSearch = recorder('jira_search_by_jql', JSON.stringify({
-            issues: [JIRA_TICKET]
-        }));
-        var trackers = loadTrackers({
-            tracker_search: undefined,
-            jira_search_by_jql: jiraSearch
-        });
-        var results = trackers.createTracker({}).search('labels = wip');
-        assert.deepEqual(jiraSearch.calls[0], { jql: 'labels = wip' });
-        assert.equal(results.length, 1);
-        assert.equal(results[0].key, 'PROJ-123');
-    });
-
-    test('comment and label operations fall back to their jira twins', function () {
-        var jiraComment = recorder('jira_post_comment', '{}');
-        var jiraComments = recorder('jira_get_comments', JSON.stringify({
-            comments: [{ author: { displayName: 'A' }, body: 'b', created: 'c' }]
-        }));
-        var jiraAdd = recorder('jira_add_label', '{}');
-        var jiraRemove = recorder('jira_remove_label', '{}');
-        var trackers = loadTrackers({
-            tracker_post_comment: undefined,
-            tracker_get_comments: undefined,
-            tracker_add_label: undefined,
-            tracker_remove_label: undefined,
-            jira_post_comment: jiraComment,
-            jira_get_comments: jiraComments,
-            jira_add_label: jiraAdd,
-            jira_remove_label: jiraRemove
-        });
-        var t = trackers.createTracker({});
-        t.postComment('PROJ-123', 'hi');
-        t.getComments('PROJ-123');
-        t.addLabel('PROJ-123', 'x');
-        t.removeLabel('PROJ-123', 'y');
-        assert.deepEqual(jiraComment.calls[0], { key: 'PROJ-123', comment: 'hi' });
-        assert.deepEqual(jiraComments.calls[0], { key: 'PROJ-123' });
-        assert.deepEqual(jiraAdd.calls[0], { key: 'PROJ-123', label: 'x' });
-        assert.deepEqual(jiraRemove.calls[0], { key: 'PROJ-123', label: 'y' });
-    });
-
-    test('createTicket fallback maps onto the jira_create_ticket args', function () {
-        var jiraCreate = recorder('jira_create_ticket', '{"key":"PROJ-9"}');
-        var trackers = loadTrackers({
-            tracker_create_ticket: undefined,
-            jira_create_ticket: jiraCreate
-        });
-        trackers.createTracker({}).createTicket('PROJ', 'Bug', 'It breaks', 'details');
-        assert.deepEqual(jiraCreate.calls[0], {
+    test('createTicket maps onto jira_create_ticket_basic and extracts the key', function () {
+        var mocks = jiraMocks();
+        var trackers = loadTrackers(mocks);
+        var key = trackers.createTracker({}).createTicket('PROJ', 'Bug', 'It breaks', 'details');
+        assert.deepEqual(mocks.jira_create_ticket_basic.calls[0], {
             project: 'PROJ',
             issueType: 'Bug',
             summary: 'It breaks',
             description: 'details'
         });
+        assert.equal(key, 'PROJ-9');
+    });
+
+    test('returns an empty search list when nothing is found', function () {
+        var mocks = jiraMocks();
+        mocks.jira_search_by_jql = recorder('jira_search_by_jql', JSON.stringify({ issues: [] }));
+        var trackers = loadTrackers(mocks);
+        assert.deepEqual(trackers.createTracker({}).search('nope'), []);
+    });
+});
+
+suite('trackers.js ado provider', function () {
+    test('getTicket calls ado_get_work_item and normalizes the ADO shape', function () {
+        var adoGet = recorder('ado_get_work_item', ADO_TICKET);
+        var trackers = loadTrackers({ ado_get_work_item: adoGet });
+        var ticket = trackers.createTracker({ tracker: { provider: 'ado' } }).getTicket('4242');
+        assert.deepEqual(adoGet.calls[0], { id: '4242' });
+        assert.equal(ticket.key, '4242');
+        assert.equal(ticket.title, 'Fix the login flow');
+        assert.equal(ticket.status, 'Active');
+        assert.equal(ticket.assignee, 'Jane Doe');
+    });
+
+    test('search maps query onto ado_search_by_wiql wiql', function () {
+        var adoSearch = recorder('ado_search_by_wiql', JSON.stringify({
+            value: [ADO_TICKET]
+        }));
+        var trackers = loadTrackers({ ado_search_by_wiql: adoSearch });
+        var results = trackers.createTracker({ tracker: { provider: 'ado' } }).search('q');
+        assert.deepEqual(adoSearch.calls[0], { wiql: 'q' });
+        assert.equal(results.length, 1);
+        assert.equal(results[0].key, '4242');
+    });
+
+    test('comments map id and comment onto the ado comment tools', function () {
+        var adoAdd = recorder('ado_add_work_item_comment', '{}');
+        var adoList = recorder('ado_get_work_item_comments', JSON.stringify({
+            value: [{ text: 'n1', createdBy: { displayName: 'A' }, createdDate: 'd1' }]
+        }));
+        var trackers = loadTrackers({
+            ado_add_work_item_comment: adoAdd,
+            ado_get_work_item_comments: adoList
+        });
+        var t = trackers.createTracker({ tracker: { provider: 'ado' } });
+        t.postComment('4242', 'hello');
+        var comments = t.getComments('4242');
+        assert.deepEqual(adoAdd.calls[0], { id: '4242', comment: 'hello' });
+        assert.deepEqual(adoList.calls[0], { id: '4242' });
+        assert.equal(comments[0].body, 'n1');
+        assert.equal(comments[0].author, 'A');
+    });
+
+    test('status and assignee map onto the ado state/assign tools', function () {
+        var adoMove = recorder('ado_move_to_state', '{}');
+        var adoAssign = recorder('ado_assign_work_item', '{}');
+        var trackers = loadTrackers({
+            ado_move_to_state: adoMove,
+            ado_assign_work_item: adoAssign
+        });
+        var t = trackers.createTracker({ tracker: { provider: 'ado' } });
+        t.moveToStatus('4242', 'Active');
+        t.assignTo('4242', 'jane@acme.dev');
+        assert.deepEqual(adoMove.calls[0], { id: '4242', state: 'Active' });
+        assert.deepEqual(adoAssign.calls[0], { id: '4242', userEmail: 'jane@acme.dev' });
+    });
+
+    test('createTicket maps onto ado_create_work_item field names', function () {
+        var adoCreate = recorder('ado_create_work_item', '{"id":4300}');
+        var trackers = loadTrackers({ ado_create_work_item: adoCreate });
+        var t = trackers.createTracker({ tracker: { provider: 'ado' } });
+        var key = t.createTicket('Proj', 'Bug', 'It breaks', 'details');
+        assert.deepEqual(adoCreate.calls[0], {
+            project: 'Proj',
+            workItemType: 'Bug',
+            title: 'It breaks',
+            description: 'details'
+        });
+        assert.equal(key, '4300');
+    });
+
+    test('labels are not supported on ado and fail with a clear error', function () {
+        var trackers = loadTrackers({});
+        var t = trackers.createTracker({ tracker: { provider: 'ado' } });
+        assert.throws(function () { t.addLabel('4242', 'x'); });
+        assert.throws(function () { t.removeLabel('4242', 'x'); });
+    });
+});
+
+suite('trackers.js github provider', function () {
+    test('getTicket expands bare numbers via repository and normalizes', function () {
+        var ghGet = recorder('github_get_issue', GITHUB_TICKET);
+        var trackers = loadTrackers({ github_get_issue: ghGet });
+        var ticket = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        }).getTicket('41');
+        assert.deepEqual(ghGet.calls[0], { owner: 'acme', repo: 'widgets', issue_number: 41 });
+        assert.equal(ticket.key, 'acme/widgets#41');
+        assert.equal(ticket.status, 'open');
+        assert.deepEqual(ticket.labels, ['bug', 'wip']);
+    });
+
+    test('moveToStatus maps Done → close and Reopened → reopen', function () {
+        var ghClose = recorder('github_close_issue', '{}');
+        var trackers = loadTrackers({ github_close_issue: ghClose });
+        var t = trackers.createTracker({
+            tracker: { provider: 'github' },
+            repository: { owner: 'acme', repo: 'widgets' }
+        });
+        t.moveToStatus('acme/widgets#7', 'Done');
+        assert.deepEqual(ghClose.calls[0], { owner: 'acme', repo: 'widgets', issue_number: 7 });
+    });
+
+    test('unmappable statuses fail without an HTTP call', function () {
+        var trackers = loadTrackers({});
+        var t = trackers.createTracker({ tracker: { provider: 'github' } });
+        assert.throws(function () { t.moveToStatus('acme/widgets#7', 'In Review'); });
     });
 });
 
@@ -395,53 +341,56 @@ suite('trackers.js normalizeTicket', function () {
         assert.equal(normalized.key, 'PROJ-1');
         assert.equal(normalized.title, 'Already flat');
     });
+
+    test('normalizes GitHub-shaped payloads with repository context', function () {
+        var trackers = loadTrackers({});
+        var ticket = trackers.createTracker({
+            repository: { owner: 'acme', repo: 'widgets' }
+        }).normalizeTicket(GITHUB_TICKET);
+        assert.equal(ticket.key, 'acme/widgets#41');
+        assert.equal(ticket.title, 'Fix the login flow');
+        assert.deepEqual(ticket.labels, ['bug', 'wip']);
+        assert.equal(ticket.raw, null, 'raw payload should not leak into the normalized view');
+    });
 });
 
 suite('trackers.js assignForReview', function () {
-    function happyMocks(opts) {
-        return {
-            tracker_assign_to: recorder('tracker_assign_to', '{}'),
-            tracker_move_to_status: recorder('tracker_move_to_status', '{}'),
-            tracker_add_label: recorder('tracker_add_label', '{}'),
-            tracker_remove_label: opts && opts.removeLabelFails
-                ? recorder('tracker_remove_label', { __throw__: new Error('label api down') })
-                : recorder('tracker_remove_label', '{}')
-        };
-    }
-
     test('assigns, moves, and adds the AI label, then reports success', function () {
-        var mocks = happyMocks();
+        var mocks = jiraMocks();
         var trackers = loadTrackers(mocks);
         var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
         assert.ok(result.success, 'expected success: ' + JSON.stringify(result));
-        assert.deepEqual(mocks.tracker_assign_to.calls[0], { key: 'PROJ-123', user: 'acc-1' });
-        assert.equal(mocks.tracker_move_to_status.calls[0].key, 'PROJ-123');
-        assert.equal(mocks.tracker_add_label.calls[0].label, configModule.LABELS.AI_GENERATED);
+        assert.deepEqual(mocks.jira_assign_ticket_to.calls[0], { key: 'PROJ-123', accountId: 'acc-1' });
+        assert.equal(mocks.jira_move_to_status.calls[0].key, 'PROJ-123');
+        assert.equal(mocks.jira_add_label.calls[0].label, configModule.LABELS.AI_GENERATED);
     });
 
     test('moves to the configured In Review status by default', function () {
-        var mocks = happyMocks();
+        var mocks = jiraMocks();
         var trackers = loadTrackers(mocks);
         trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
-        assert.equal(mocks.tracker_move_to_status.calls[0].status, configModule.STATUSES.IN_REVIEW);
+        assert.equal(
+            mocks.jira_move_to_status.calls[0].statusName,
+            configModule.STATUSES.IN_REVIEW
+        );
     });
 
     test('honors an explicit target status', function () {
-        var mocks = happyMocks();
+        var mocks = jiraMocks();
         var trackers = loadTrackers(mocks);
         trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', null, 'Done');
-        assert.equal(mocks.tracker_move_to_status.calls[0].status, 'Done');
+        assert.equal(mocks.jira_move_to_status.calls[0].statusName, 'Done');
     });
 
     test('removes the WIP label when provided', function () {
-        var mocks = happyMocks();
+        var mocks = jiraMocks();
         var trackers = loadTrackers(mocks);
         trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', 'wip');
-        assert.deepEqual(mocks.tracker_remove_label.calls[0], { key: 'PROJ-123', label: 'wip' });
+        assert.deepEqual(mocks.jira_remove_label.calls[0], { key: 'PROJ-123', label: 'wip' });
     });
 
     test('a WIP removal failure does not fail the whole operation', function () {
-        var mocks = happyMocks({ removeLabelFails: true });
+        var mocks = jiraMocks({ removeLabelFails: true });
         var trackers = loadTrackers(mocks);
         var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1', 'wip');
         assert.ok(result.success, 'WIP cleanup failure must not fail the flow');
@@ -449,10 +398,10 @@ suite('trackers.js assignForReview', function () {
 
     test('a core step failure reports success: false with the error', function () {
         var trackers = loadTrackers({
-            tracker_assign_to: recorder('tracker_assign_to', { __throw__: new Error('boom') }),
-            tracker_move_to_status: recorder('tracker_move_to_status', '{}'),
-            tracker_add_label: recorder('tracker_add_label', '{}'),
-            tracker_remove_label: recorder('tracker_remove_label', '{}')
+            jira_assign_ticket_to: recorder('jira_assign_ticket_to', { __throw__: new Error('boom') }),
+            jira_move_to_status: recorder('jira_move_to_status', '{}'),
+            jira_add_label: recorder('jira_add_label', '{}'),
+            jira_remove_label: recorder('jira_remove_label', '{}')
         });
         var result = trackers.createTracker({}).assignForReview('PROJ-123', 'acc-1');
         assert.notOk(result.success);


### PR DESCRIPTION
## What

Adds `js/common/trackers.js` — a tracker-agnostic ticket layer, the `scm.js` analog for ticket trackers (Jira / ADO / GitHub).

- Factory `createTracker(name)` resolves the runtime's available canonical per-provider tools (`jira_*`, `ado_*`, `github_*`) by per-operation probing — no dependency on any CLI-only alias surface.
- `normalizeTicket()` flattens Jira / ADO / GitHub ticket payloads into one shape (`key`, `summary`, `description`, `status`, `labels`, `comments`, ...).
- Bare issue numbers expand to `owner/repo#N` for GitHub only when a repository is configured.
- Operations covered: get, search, comments (get/post), labels (add/remove), status move, assign, create, link.
- `assignForReview()` keeps the existing `jiraHelpers.js` semantics without touching that file.
- Existing suites are untouched; `jiraHelpers.js` stays as-is.

## Tests

- `js/unit-tests/test_trackers.js` — per-operation unit tests with mocked tool globals, runnable both under the product runtime (`run_all.json`) and standalone via the node test runner.
- Registered `run_trackers.json` in `run_all.json`.
- Node harness: 30 passed, 0 failed.

## Why

Teammate/CliAgent JS actions are currently `jiraHelpers`-bound; this layer lets agent scripts target ADO and GitHub trackers with the same helpers while calling only canonical per-provider tool names (the JS bridge exposes canonical names only — `tracker_*` aliases are CLI-only metadata in dmtools).
