### PR TITLE
fix(setup): restore the closing brace of _cache_cursor_session

### DIFF
--- a/setup/cache.sh
+++ b/setup/cache.sh
@@ -110,9 +110,11 @@ _cache_kimi_session() {
 _cache_cursor_session() {
   # shellcheck source=/dev/null
   source "${SCRIPT_DIR}/cursor-session.sh" env
+}
 
 _cache_fa_session() {
-  source "${SCRIPT_DIR}/fa-session.sh" env}
+  source "${SCRIPT_DIR}/fa-session.sh" env
+}
 
 _cache_gradle() {
   # Gradle wrapper distribution (~/.gradle/wrapper) and dependency cache (~/.gradle/caches).


### PR DESCRIPTION
PR #352 inserted `_cache_fa_session` immediately after the cursor-session source line and swallowed the closing `}` of `_cache_cursor_session` — it ended up glued to the `fa-session` `env` line. Every `cache.sh keys …` invocation now dies with *unexpected end of file* (found by the dmtools-dart machine e2e on issue #21).