### PR TITLE
fix(rework): guard syncBaseBranchIfConfigured against undefined customParams

### DIFF
--- a/js/preCliReworkSetup.js
+++ b/js/preCliReworkSetup.js
@@ -37,7 +37,7 @@ var baseBranchMarker = require('./common/baseBranchMarker.js');
  * @param {Object} config        - resolved project config (config.git.baseBranch, workingDir)
  */
 function syncBaseBranchIfConfigured(baseBranch, customParams, config) {
-    if (!customParams.branchSyncFnPath || !baseBranch || baseBranch === config.git.baseBranch) {
+    if (!customParams || !customParams.branchSyncFnPath || !baseBranch || baseBranch === config.git.baseBranch) {
         return;
     }
     var branchSyncFn = configLoader.loadHookFn(customParams.branchSyncFnPath, 'branchSyncFnPath');


### PR DESCRIPTION
**Root cause (observed in production):** rework runs triggered from GitHub issues (dmtools-dart machine-kit, issue gh-21, Actions run `34298662840`) crashed in `preCliReworkSetup.js`:

```
❌ Error in preCliReworkSetup: TypeError: cannot read property 'branchSyncFnPath' of undefined
```

**Chain of failure:**
1. `syncBaseBranchIfConfigured()` dereferenced `customParams.branchSyncFnPath` without a null check — its own docstring says it must *no-op* when the hook isn't configured.
2. The crash aborted `preCliReworkSetup.action()` **before** it wrote `input/<ticket>/pr_info.md`.
3. `pushReworkChanges.js` (postJSAction) then correctly refused to commit/push — it verifies the expected PR branch from that file — so the rework agent had to push manually without verified branch context.

**Fix:** one-line null guard, matching the contract that `preCliDevelopmentSetup.js` already honors via `customParams = customParams || {}`.

```diff
-if (!customParams.branchSyncFnPath || !baseBranch || baseBranch === config.git.baseBranch) {
+if (!customParams || !customParams.branchSyncFnPath || !baseBranch || baseBranch === config.git.baseBranch) {
```

**Impact:** configs without `customParams` (the normal case — two-branch sync hooks are rare) now take the documented no-op path instead of crashing the entire rework setup.