### PR TITLE
feat(fa): FA_LOG_FILE env tees the full session trace via fa --log-file

### DIFF
--- a/scripts/providers/fa.sh
+++ b/scripts/providers/fa.sh
@@ -67,6 +67,15 @@ run_fa() {
   if [ -n "${FA_SESSION_NAME:-}" ] && [ -n "${FA_SESSION_ROOT:-}" ]; then
     cmd+=(--session "${FA_SESSION_NAME}" --session-root "${FA_SESSION_ROOT}")
   fi
+  # FA_LOG_FILE (optional): tee fa's full stdout trace (assistant text, tool
+  # calls) to this file — untruncated, unlike the terminal-width trajectory
+  # rows. CI tails/uploads it; requires fa >= v0.1.335 (--log-file).
+  # Callers can still pass --log-file explicitly via PASS_ARGS.
+  if [ -n "${FA_LOG_FILE:-}" ] \
+    && ! printf '%s\n' ${pass_args[@]+"${pass_args[@]}"} | grep -qx -- '--log-file'; then
+    mkdir -p "$(dirname "${FA_LOG_FILE}")"
+    cmd+=(--log-file "${FA_LOG_FILE}")
+  fi
   cmd+=(${pass_args[@]+"${pass_args[@]}"} -p "$PROMPT")
 
   echo "Working directory: $(pwd)"


### PR DESCRIPTION
Pairs with flutter_agent_harness#91 (`--log-file`, released in fa v0.1.335).

**Why:** dmtools captures run-agent.sh stdout and echoes it only at completion as one escaped JSON blob (the Actions UI truncates such lines → the run looks empty), and the `fa trajectory tail` live view truncates rows at terminal width. Neither shows full assistant messages.

**What:** `run_fa()` adds `--log-file $FA_LOG_FILE` when the env var is set (dir auto-created; an explicit `--log-file` in PASS_ARGS wins). CI then tails the file into the step log and uploads it as an artifact.