### PR TITLE
fix(timer): resolve ticketKey from contextId in GitHub-issue flows

### DIFF
--- a/js/timerAutoCommitAndSave.js
+++ b/js/timerAutoCommitAndSave.js
@@ -38,6 +38,13 @@ function resolveCustomParams(params) {
 function getTicketKey(params) {
     if (params.ticket && params.ticket.key) return params.ticket.key;
     if (params.ticketKey) return params.ticketKey;
+    // GitHub-issue flow: the ticket key travels as contextId
+    // (--metadata '{"contextId":"gh-21"}' → params.jobParams.metadata / jobParams).
+    var jobParams = params.jobParams || {};
+    if (jobParams.contextId) return jobParams.contextId;
+    if (jobParams.metadata && jobParams.metadata.contextId) return jobParams.metadata.contextId;
+    if (params.metadata && params.metadata.contextId) return params.metadata.contextId;
+    if (params.contextId) return params.contextId;
     return null;
 }
 


### PR DESCRIPTION
**Observed:** dmtools-dart machine-kit rework runs log `⏱️ timer: no ticketKey available, skipping` — the auto-commit-and-push timer never fires for issue-triggered runs.

**Root cause:** `getTicketKey()` only checks `params.ticket.key` and `params.ticketKey` (Jira ticket hydration). The GitHub-issue flow passes the ticket key as `--metadata '{"contextId":"gh-21"}'`, which lands in `params.jobParams.contextId` — right next to the `getContextId()` the same action already uses.

**Fix:** fall back to contextId in every shape: `jobParams.contextId` → `jobParams.metadata.contextId` → `metadata.contextId` → `contextId`. Jira-style runs (ticket hydration) are unaffected — the original checks stay first.