### PR TITLE
fix(pr_review): prefer RIGHT side when a same-numbered line is both removed and added

### DIFF
--- a/js/postPRReviewComments.js
+++ b/js/postPRReviewComments.js
@@ -320,6 +320,12 @@ function parseDiffLineInfo(diffText, filePath, targetLine) {
     var oldLine = null;
     var newLine = null;
     var lines = String(diffText).split(/\r?\n/);
+    // Deferred LEFT match: a removed line ('-') at the target line number.
+    // We don't return immediately on a LEFT match because a same-numbered
+    // added line ('+') can appear later in the same replace block (the
+    // common "-old\n+new" single-line replacement pattern) and RIGHT should
+    // win — the finding is about the current/new code, not the removed one.
+    var pendingLeftMatch = null;
 
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
@@ -329,6 +335,7 @@ function parseDiffLineInfo(diffText, filePath, targetLine) {
             oldFile = null;
             oldLine = null;
             newLine = null;
+            pendingLeftMatch = null;
             continue;
         }
 
@@ -363,7 +370,9 @@ function parseDiffLineInfo(diffText, filePath, targetLine) {
             if (newLine === lineNumber) return { present: true, side: 'RIGHT' };
             newLine++;
         } else if (line.indexOf('-') === 0) {
-            if (oldLine === lineNumber) return { present: true, side: 'LEFT' };
+            if (oldLine === lineNumber && !pendingLeftMatch) {
+                pendingLeftMatch = { present: true, side: 'LEFT' };
+            }
             oldLine++;
         } else if (line.indexOf(' ') === 0) {
             // Context lines exist on both sides; prefer RIGHT (new version).
@@ -379,6 +388,7 @@ function parseDiffLineInfo(diffText, filePath, targetLine) {
         }
     }
 
+    if (pendingLeftMatch) return pendingLeftMatch;
     return { present: false, side: null };
 }
 

--- a/js/unit-tests/test_postPRReviewComments.js
+++ b/js/unit-tests/test_postPRReviewComments.js
@@ -649,5 +649,53 @@ suite('postPRReviewComments', function() {
             assert.equal(result.success, true, 'action must still succeed when the scm provider lacks submitReview');
         });
     });
+
+    suite('parseDiffLineInfo', function() {
+        test('prefers RIGHT over LEFT for a single-line replacement at the same line number', function() {
+            var mod = loadPostPRReviewComments();
+
+            // Classic single-line replacement: old and new content share the
+            // same line number (5) inside the hunk. A finding about the
+            // current code must anchor on RIGHT (the new line), not LEFT
+            // (the removed line), even though the '-' line is encountered
+            // first while scanning the diff.
+            var diffText =
+                'diff --git a/foo.js b/foo.js\n' +
+                'index e96d9d1..988d518 100644\n' +
+                '--- a/foo.js\n' +
+                '+++ b/foo.js\n' +
+                '@@ -2,7 +2,7 @@ function greet() {\n' +
+                ' \tconst a = 1;\n' +
+                ' \tconst b = 2;\n' +
+                ' \tconst label = "before";\n' +
+                '-\tconst greeting = "helo";\n' +
+                '+\tconst greeting = "hello";\n' +
+                ' \n' +
+                ' \treturn greeting;\n';
+
+            var info = mod.parseDiffLineInfo(diffText, 'foo.js', 5);
+
+            assert.equal(info.present, true);
+            assert.equal(info.side, 'RIGHT', 'a same-numbered replacement must resolve to RIGHT, not LEFT');
+        });
+
+        test('still resolves LEFT for a pure removal (no matching + at the same line)', function() {
+            var mod = loadPostPRReviewComments();
+
+            var diffText =
+                'diff --git a/foo.js b/foo.js\n' +
+                'index e96d9d1..988d518 100644\n' +
+                '--- a/foo.js\n' +
+                '+++ b/foo.js\n' +
+                '@@ -2,2 +2,1 @@ function greet() {\n' +
+                ' \tconst a = 1;\n' +
+                '-\tconst unused = 2;\n';
+
+            var info = mod.parseDiffLineInfo(diffText, 'foo.js', 3);
+
+            assert.equal(info.present, true);
+            assert.equal(info.side, 'LEFT', 'a pure removal with no matching added line must still resolve to LEFT');
+        });
+    });
 });
 


### PR DESCRIPTION
## Problem

`parseDiffLineInfo()` in `js/postPRReviewComments.js` returns `side: LEFT` for the very common single-line replacement diff pattern:

```diff
-MENU_API_MANAGEMENT_NL = "Api beheer";
+MENU_API_MANAGEMENT_NL = "API beheer";
```

Both the removed and added line share the same line number inside the hunk (e.g. line 36). The parser walks the diff top-to-bottom and returns as soon as it matches the `-` line, never reaching the `+` line at the same target line number.

Downstream, `postInlineComment()` requests `side: RIGHT` (the finding is about the new/current code), gets back `LEFT` from the parser, treats it as a mismatch, and silently falls back to a plain PR comment instead of creating a GitHub review thread — even though the line is present in the diff and the finding is valid.

Observed in production: `pr_review` correctly identified the sole changed line, asked for an inline review comment with `side: RIGHT`, and all 3 findings on that line fell back to plain issue comments with the `📍 file:line` prefix instead of becoming review threads.

## Fix

Defer the LEFT match until the whole hunk/file has been scanned. If a same-numbered `+` line is found later in the same hunk, RIGHT wins (matching the existing behavior for context lines, which already prefer RIGHT). A pure removal with no matching added line at the same number still resolves to LEFT as before.

## Tests

Added two regression tests to `js/unit-tests/test_postPRReviewComments.js`:
- single-line replacement → resolves to RIGHT
- pure removal (no matching + at the same line) → still resolves to LEFT

No other behavior changes.