### PR TITLE
fix(fa): pass FA_LOG_FILE to fa --log-file — the live CI trace was empty

### DIFF
--- a/scripts/providers/fa.sh
+++ b/scripts/providers/fa.sh
@@ -67,6 +67,14 @@ run_fa() {
   if [ -n "${FA_SESSION_NAME:-}" ] && [ -n "${FA_SESSION_ROOT:-}" ]; then
     cmd+=(--session "${FA_SESSION_NAME}" --session-root "${FA_SESSION_ROOT}")
   fi
+  # Tee fa's full transcript (assistant text + tool calls, untruncated)
+  # to FA_LOG_FILE when the caller provides it — the AI Teammate workflow
+  # tails this file into the run log as [fa]-prefixed lines for live
+  # observability (flutter_agent_harness#91, fa >= v0.1.335). Without
+  # this flag the file stays empty and the agent is a blind spot in CI.
+  if [ -n "${FA_LOG_FILE:-}" ]; then
+    cmd+=(--log-file "${FA_LOG_FILE}")
+  fi
   cmd+=(${pass_args[@]+"${pass_args[@]}"} -p "$PROMPT")
 
   echo "Working directory: $(pwd)"


### PR DESCRIPTION
The AI Teammate workflow exports FA_LOG_FILE and tails it into the run
log as [fa] lines, but run_fa never passed --log-file to fa, so the file
stayed empty and fa's own work (model dialogue, harness tool calls) was
invisible in CI runs (dmtools echoes fa's stdout only as a final escaped
JSON blob). Forward the flag whenever FA_LOG_FILE is set (fa >= v0.1.335,
flutter_agent_harness#91).
